### PR TITLE
feat(connectors): add production scoping for AWS and GitHub inspectors

### DIFF
--- a/plugins/connectors/aws-inspector/commands/collect.md
+++ b/plugins/connectors/aws-inspector/commands/collect.md
@@ -18,6 +18,8 @@ node plugins/connectors/aws-inspector/scripts/collect.js [options]
 - `--regions=<csv>` — regions to scan (default: the config's `default_region`; IAM + S3 + CloudTrail have global/multi-region considerations)
 - `--services=<csv>` — subset of `iam,s3,cloudtrail,ebs` (default: all)
 - `--profile=<name>` — override the configured AWS profile
+- `--scope-file=<path>` — path to scope YAML file for production filtering (default: `config/scope.yaml` in plugin dir)
+- `--tag-filter=<csv>` — inline tag filters as `key=value` pairs, e.g. `--tag-filter=env=production,team=platform`
 - `--output=<fmt>` — `silent` | `summary` (default) | `json`
 - `--refresh` — ignore cache; re-query AWS
 - `--quiet` — no stderr progress
@@ -85,7 +87,8 @@ Minimum IAM policy for a read-only scan:
       "Action": [
         "iam:GetAccountPasswordPolicy", "iam:GetAccountSummary",
         "iam:ListUsers", "iam:ListAccessKeys", "iam:GetLoginProfile", "iam:GetUser", "iam:ListMFADevices", "iam:ListUserPolicies", "iam:ListAttachedUserPolicies",
-        "s3:ListAllMyBuckets", "s3:GetBucketEncryption", "s3:GetBucketPublicAccessBlock", "s3:GetBucketVersioning", "s3:GetBucketLogging", "s3:GetBucketLocation",
+        "s3:ListAllMyBuckets", "s3:GetBucketEncryption", "s3:GetBucketPublicAccessBlock", "s3:GetBucketVersioning", "s3:GetBucketLogging", "s3:GetBucketLocation", "s3:GetBucketTagging",
+        "sts:GetCallerIdentity",
         "cloudtrail:DescribeTrails", "cloudtrail:GetTrailStatus", "cloudtrail:GetEventSelectors",
         "ec2:GetEbsEncryptionByDefault"
       ],
@@ -111,7 +114,58 @@ The AWS-managed `SecurityAudit` policy is a superset that also works.
 
 # Alternate profile
 /aws-inspector:collect --profile=audit-role
+
+# Production only (tag filter)
+/aws-inspector:collect --tag-filter=env=production
+
+# Production only (scope file)
+/aws-inspector:collect --scope-file=config/scope.yaml
 ```
+
+## Production scoping
+
+To scan only production resources, create or edit `config/scope.yaml` in the plugin directory:
+
+```yaml
+# Multi-account: scan dedicated production AWS accounts
+profiles:
+  - prod-us
+  - prod-eu
+
+# Tag filtering: only scan S3 buckets tagged env=production
+tag_key: "env"
+tag_value: "production"
+
+# Restrict to production regions
+regions:
+  - us-east-1
+  - eu-west-1
+
+# Bucket name patterns (glob)
+bucket_patterns:
+  - prod-*
+  - company-prod-*
+
+# Exclude test buckets
+bucket_exclude:
+  - prod-test-*
+```
+
+```bash
+# Use the default scope file
+/aws-inspector:collect --scope-file=config/scope.yaml
+
+# Or use inline tag filters without a scope file
+/aws-inspector:collect --tag-filter=env=production
+
+# Combine with other flags
+/aws-inspector:collect --scope-file=config/scope.yaml --services=s3 --output=json
+```
+
+**Notes:**
+- Tag filtering applies to S3 buckets only. IAM, EBS, and CloudTrail checks are account-level.
+- Multi-profile mode resolves each profile's account ID via `sts:GetCallerIdentity`.
+- When no scope file is active and no `--tag-filter` is passed, all resources are scanned (unchanged default).
 
 ## CI/CD usage
 

--- a/plugins/connectors/aws-inspector/config/scope.yaml
+++ b/plugins/connectors/aws-inspector/config/scope.yaml
@@ -1,0 +1,46 @@
+# aws-inspector scope configuration
+#
+# Scope audits to production resources only. Use --scope-file to activate
+# this file, or set defaults.scope_file in your connector config.
+#
+# When no scope file is used, the connector scans all resources in the
+# configured account (unchanged default behavior).
+
+# profiles: AWS CLI profile names to scan across multiple accounts.
+# Each profile should be configured via `aws configure --profile <name>`.
+# If empty, uses the single profile from --profile or connector config.
+profiles: []
+# profiles:
+#   - prod-us
+#   - prod-eu
+
+# Tag-based filtering for S3 buckets (AND logic).
+# Buckets missing the specified tag(s) are skipped.
+# IAM, EBS, and CloudTrail checks are account-level and not tag-filterable.
+#
+# Option A: single tag key/value
+# tag_key: "env"
+# tag_value: "production"
+#
+# Option B: multiple tag filters (all must match)
+# tag_filters:
+#   - env=production
+#   - team=platform
+
+# Region override (replaces --regions and config defaults)
+regions: []
+# regions:
+#   - us-east-1
+#   - eu-west-1
+
+# S3 bucket name patterns (glob). Only matching buckets are scanned.
+bucket_patterns: []
+# bucket_patterns:
+#   - prod-*
+#   - company-prod-*
+
+# S3 bucket name exclusions (glob). Matching buckets are skipped.
+bucket_exclude: []
+# bucket_exclude:
+#   - prod-test-*
+#   - prod-sandbox-*

--- a/plugins/connectors/aws-inspector/scripts/collect.js
+++ b/plugins/connectors/aws-inspector/scripts/collect.js
@@ -10,6 +10,7 @@
  *   node collect.js [--regions=us-east-1,us-west-2]
  *                   [--services=iam,s3,cloudtrail,ebs]
  *                   [--profile=<name>] [--output=summary|silent|json]
+ *                   [--scope-file=<path>] [--tag-filter=env=production]
  *                   [--quiet]
  */
 
@@ -27,6 +28,8 @@ const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), 
 const CONFIG_FILE = path.join(CONFIG_DIR, 'connectors', 'aws-inspector.yaml');
 const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'aws-inspector');
 const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
+const PLUGIN_DIR = path.resolve(new URL('.', import.meta.url).pathname, '..');
+const DEFAULT_SCOPE_FILE = path.join(PLUGIN_DIR, 'config', 'scope.yaml');
 const SOURCE = 'aws-inspector';
 const SOURCE_VERSION = '0.1.0';
 
@@ -41,58 +44,92 @@ async function main(argv) {
   catch { fail(EXIT.NOT_CONFIGURED, `config missing (${CONFIG_FILE}). Run /aws-inspector:setup first.`); }
 
   const profile = args.profile || config.profile || process.env.AWS_PROFILE || '';
-  const regions = args.regions?.length ? args.regions : (config.defaults?.regions || [config.default_region || 'us-east-1']);
+  let regions = args.regions?.length ? args.regions : (config.defaults?.regions || [config.default_region || 'us-east-1']);
   const services = args.services?.length ? args.services : (config.defaults?.services || ['iam', 's3', 'cloudtrail', 'ebs']);
-  const accountId = config.account_id;
-  if (!accountId) fail(EXIT.NOT_CONFIGURED, 'account_id missing from config. Re-run /aws-inspector:setup.');
 
-  const env = { ...process.env };
-  if (profile) env.AWS_PROFILE = profile;
+  // Load scope file for production filtering
+  let scope = null;
+  const scopePath = args.scopeFile || config.defaults?.scope_file || '';
+  if (scopePath) {
+    try {
+      scope = parseYaml(await fs.readFile(scopePath, 'utf8'));
+      log(`scope: loaded from ${scopePath}`);
+    } catch { fail(EXIT.USAGE, `Scope file not found: ${scopePath}`); }
+  } else if (await fileExists(DEFAULT_SCOPE_FILE)) {
+    try {
+      const parsed = parseYaml(await fs.readFile(DEFAULT_SCOPE_FILE, 'utf8'));
+      // Only activate scope if the file has meaningful content (non-empty lists or tag filters)
+      const hasContent = (Array.isArray(parsed.profiles) && parsed.profiles.length)
+        || (Array.isArray(parsed.tag_filters) && parsed.tag_filters.length)
+        || parsed.tag_key
+        || (Array.isArray(parsed.bucket_patterns) && parsed.bucket_patterns.length)
+        || (Array.isArray(parsed.regions) && parsed.regions.length);
+      if (hasContent) { scope = parsed; log(`scope: loaded from ${DEFAULT_SCOPE_FILE}`); }
+    } catch { /* default scope file missing or unreadable — no scoping */ }
+  }
+
+  // Merge CLI --tag-filter into scope
+  if (args.tagFilters?.length) {
+    if (!scope) scope = {};
+    scope.tag_filters = [...(scope.tag_filters || []), ...args.tagFilters];
+  }
+
+  // Override regions from scope if present
+  if (scope && Array.isArray(scope.regions) && scope.regions.length) {
+    regions = scope.regions;
+  }
+
+  // Determine profiles to scan
+  const profiles = (scope && Array.isArray(scope.profiles) && scope.profiles.length)
+    ? scope.profiles
+    : [profile];
+  const isMultiProfile = profiles.length > 1 || (scope?.profiles?.length > 0);
+
+  // For single-profile mode, require account_id from config
+  if (!isMultiProfile) {
+    const accountId = config.account_id;
+    if (!accountId) fail(EXIT.NOT_CONFIGURED, 'account_id missing from config. Re-run /aws-inspector:setup.');
+  }
 
   await fs.mkdir(CACHE_DIR, { recursive: true });
   const runId = makeRunId();
   const startedAt = Date.now();
-  log(`regions=${regions.join(',')} services=${services.join(',')} profile=${profile || '<default>'}`);
 
-  const findings = [];
-  const errors = [];
+  const allFindings = [];
+  const allErrors = [];
 
-  const ctx = { env, regions, runId, accountId };
+  for (const prof of profiles) {
+    const profEnv = { ...process.env };
+    if (prof) profEnv.AWS_PROFILE = prof;
 
-  // IAM is global; run once.
-  if (services.includes('iam')) {
-    try { findings.push(...await collectIAM(ctx, log)); }
-    catch (err) { errors.push({ service: 'iam', error: err.message }); log(`iam failed: ${err.message}`); }
-  }
-
-  // EBS default encryption is per-region.
-  if (services.includes('ebs')) {
-    for (const region of regions) {
-      try { findings.push(...await collectEBS(ctx, region, log)); }
-      catch (err) { errors.push({ service: 'ebs', region, error: err.message }); log(`ebs ${region} failed: ${err.message}`); }
+    // Resolve account ID for this profile
+    let accountId;
+    if (isMultiProfile || !config.account_id) {
+      try {
+        const { stdout } = await aws(profEnv, ['sts', 'get-caller-identity', '--output', 'json']);
+        accountId = JSON.parse(stdout).Account;
+      } catch (err) {
+        allErrors.push({ profile: prof, error: `Auth failed: ${err.message}` });
+        log(`profile=${prof || '<default>'} auth failed, skipping`);
+        continue;
+      }
+    } else {
+      accountId = config.account_id;
     }
-  }
 
-  // S3 list is global but operations are regional. Enumerate buckets once; probe bucket properties with us-east-1.
-  if (services.includes('s3')) {
-    try { findings.push(...await collectS3(ctx, log)); }
-    catch (err) { errors.push({ service: 's3', error: err.message }); log(`s3 failed: ${err.message}`); }
-  }
+    log(`profile=${prof || '<default>'} account=${accountId} regions=${regions.join(',')} services=${services.join(',')}`);
 
-  // CloudTrail: enumerate per region, multi-region trails appear once per home region.
-  if (services.includes('cloudtrail')) {
-    for (const region of regions) {
-      try { findings.push(...await collectCloudTrail(ctx, region, log)); }
-      catch (err) { errors.push({ service: 'cloudtrail', region, error: err.message }); log(`cloudtrail ${region} failed: ${err.message}`); }
-    }
+    const { findings, errors } = await scanAccount({ env: profEnv, accountId, regions, services, scope, runId, log });
+    allFindings.push(...findings);
+    allErrors.push(...errors);
   }
 
   const cachePath = path.join(CACHE_DIR, `${runId}.json`);
-  await fs.writeFile(cachePath, JSON.stringify(findings, null, 2));
+  await fs.writeFile(cachePath, JSON.stringify(allFindings, null, 2));
 
   const counters = { pass: 0, fail: 0, inconclusive: 0, not_applicable: 0, skipped: 0 };
   const sev = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
-  for (const d of findings) for (const e of d.evaluations) {
+  for (const d of allFindings) for (const e of d.evaluations) {
     counters[e.status] = (counters[e.status] || 0) + 1;
     if (e.severity) sev[e.severity] = (sev[e.severity] || 0) + 1;
   }
@@ -102,26 +139,59 @@ async function main(argv) {
     run_id: runId,
     started_at: new Date(startedAt).toISOString(),
     duration_ms: Date.now() - startedAt,
-    account_id: accountId,
+    profiles: profiles.filter(Boolean),
     regions,
     services,
-    resources: findings.length,
-    evaluations: findings.reduce((n, d) => n + d.evaluations.length, 0),
+    scope: scope ? true : false,
+    resources: allFindings.length,
+    evaluations: allFindings.reduce((n, d) => n + d.evaluations.length, 0),
     counters,
     severities: sev,
-    errors: errors.length
+    errors: allErrors.length
   };
   await fs.appendFile(RUNS_LOG, JSON.stringify(manifest) + '\n');
 
-  const summary = `${SOURCE}: ${findings.length} resources, ${manifest.evaluations} evaluations, ${counters.fail || 0} failing (${sev.critical || 0} critical, ${sev.high || 0} high, ${sev.medium || 0} medium).`;
+  const summary = `${SOURCE}: ${allFindings.length} resources, ${manifest.evaluations} evaluations, ${counters.fail || 0} failing (${sev.critical || 0} critical, ${sev.high || 0} high, ${sev.medium || 0} medium).`;
   if (args.output === 'json') {
-    process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, summary: manifest, errors }, null, 2) + '\n');
+    process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, summary: manifest, errors: allErrors }, null, 2) + '\n');
   } else if (args.output !== 'silent') {
     process.stdout.write(summary + '\n');
-    if (errors.length) process.stdout.write(`(${errors.length} partial errors — see JSON output for details)\n`);
+    if (allErrors.length) process.stdout.write(`(${allErrors.length} partial errors — see JSON output for details)\n`);
   }
 
-  process.exit(errors.length ? EXIT.PARTIAL : EXIT.OK);
+  process.exit(allErrors.length ? EXIT.PARTIAL : EXIT.OK);
+}
+
+async function scanAccount({ env, accountId, regions, services, scope, runId, log }) {
+  const findings = [];
+  const errors = [];
+  const ctx = { env, regions, runId, accountId };
+
+  if (services.includes('iam')) {
+    try { findings.push(...await collectIAM(ctx, log)); }
+    catch (err) { errors.push({ service: 'iam', account: accountId, error: err.message }); log(`iam failed: ${err.message}`); }
+  }
+
+  if (services.includes('ebs')) {
+    for (const region of regions) {
+      try { findings.push(...await collectEBS(ctx, region, log)); }
+      catch (err) { errors.push({ service: 'ebs', region, account: accountId, error: err.message }); log(`ebs ${region} failed: ${err.message}`); }
+    }
+  }
+
+  if (services.includes('s3')) {
+    try { findings.push(...await collectS3(ctx, log, scope)); }
+    catch (err) { errors.push({ service: 's3', account: accountId, error: err.message }); log(`s3 failed: ${err.message}`); }
+  }
+
+  if (services.includes('cloudtrail')) {
+    for (const region of regions) {
+      try { findings.push(...await collectCloudTrail(ctx, region, log)); }
+      catch (err) { errors.push({ service: 'cloudtrail', region, account: accountId, error: err.message }); log(`cloudtrail ${region} failed: ${err.message}`); }
+    }
+  }
+
+  return { findings, errors };
 }
 
 // ---------------------------------------------------------------------------
@@ -240,12 +310,38 @@ async function collectEBS(ctx, region, log) {
 // ---------------------------------------------------------------------------
 // S3 — list all buckets, evaluate each
 
-async function collectS3(ctx, log) {
+async function collectS3(ctx, log, scope) {
   const findings = [];
-  const buckets = JSON.parse((await aws(ctx.env, ['s3api', 'list-buckets', '--output', 'json'])).stdout).Buckets || [];
-  log(`s3: ${buckets.length} buckets`);
+  const allBuckets = JSON.parse((await aws(ctx.env, ['s3api', 'list-buckets', '--output', 'json'])).stdout).Buckets || [];
+  log(`s3: ${allBuckets.length} buckets total`);
+
+  // Build tag filters from scope and CLI
+  const tagFilters = buildTagFilters(scope);
+  const hasNameFilter = scope && ((Array.isArray(scope.bucket_patterns) && scope.bucket_patterns.length) || (Array.isArray(scope.bucket_exclude) && scope.bucket_exclude.length));
+
+  // Name-pattern filtering first (free — no API calls)
+  let buckets = allBuckets;
+  if (hasNameFilter) {
+    buckets = buckets.filter(b => matchesBucketScope(b.Name, scope));
+    log(`s3: ${buckets.length}/${allBuckets.length} buckets after name filtering`);
+  }
+
   for (const b of buckets) {
     const name = b.Name;
+
+    // Tag filtering (requires one API call per bucket)
+    if (tagFilters.length) {
+      try {
+        const tags = await getBucketTags(ctx.env, name);
+        if (!matchesTagFilters(tags, tagFilters)) {
+          log(`s3: skipping ${name} (tag filter mismatch)`);
+          continue;
+        }
+      } catch (err) {
+        log(`s3: skipping ${name} (tag check failed: ${err.message})`);
+        continue;
+      }
+    }
     const resource = { type: 'aws_s3_bucket', id: name, arn: `arn:aws:s3:::${name}`, region: null, account_id: ctx.accountId };
     const evaluations = [];
 
@@ -407,6 +503,8 @@ function parseArgs(argv) {
       case 'services': out.services = String(v || '').split(',').map(s => s.trim()).filter(Boolean); break;
       case 'profile':  out.profile = v || ''; break;
       case 'output':   out.output = v || 'summary'; break;
+      case 'scope-file': out.scopeFile = v || ''; break;
+      case 'tag-filter': out.tagFilters = String(v || '').split(',').map(s => s.trim()).filter(Boolean); break;
       case 'refresh':  break; // placeholder; always refreshes for now
       case 'quiet':    out.quiet = true; break;
       default: fail(EXIT.USAGE, `Unknown flag: --${k}`);
@@ -414,6 +512,62 @@ function parseArgs(argv) {
   }
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// Scope filtering helpers
+
+async function fileExists(p) {
+  try { await fs.access(p); return true; } catch { return false; }
+}
+
+async function getBucketTags(env, bucketName) {
+  try {
+    const { stdout } = await aws(env, ['s3api', 'get-bucket-tagging', '--bucket', bucketName, '--output', 'json']);
+    const tagSet = JSON.parse(stdout).TagSet || [];
+    const tags = {};
+    for (const t of tagSet) tags[t.Key] = t.Value;
+    return tags;
+  } catch (err) {
+    if (/NoSuchTagSet/.test(err.message)) return {};
+    throw err;
+  }
+}
+
+function buildTagFilters(scope) {
+  if (!scope) return [];
+  const filters = [];
+  if (scope.tag_key && scope.tag_value) filters.push(`${scope.tag_key}=${scope.tag_value}`);
+  if (Array.isArray(scope.tag_filters)) filters.push(...scope.tag_filters);
+  return filters;
+}
+
+function matchesTagFilters(tags, filters) {
+  for (const f of filters) {
+    const eq = f.indexOf('=');
+    if (eq < 0) continue;
+    const key = f.slice(0, eq);
+    const val = f.slice(eq + 1);
+    if (tags[key] !== val) return false;
+  }
+  return true;
+}
+
+function matchesGlob(name, pattern) {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
+  return new RegExp('^' + escaped + '$').test(name);
+}
+
+function matchesBucketScope(name, scope) {
+  if (!scope) return true;
+  const patterns = Array.isArray(scope.bucket_patterns) ? scope.bucket_patterns : [];
+  const exclude = Array.isArray(scope.bucket_exclude) ? scope.bucket_exclude : [];
+  if (patterns.length && !patterns.some(p => matchesGlob(name, p))) return false;
+  if (exclude.length && exclude.some(p => matchesGlob(name, p))) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// YAML parser
 
 function parseYaml(src) {
   const out = {};

--- a/plugins/connectors/aws-inspector/scripts/setup.sh
+++ b/plugins/connectors/aws-inspector/scripts/setup.sh
@@ -131,5 +131,10 @@ fi
 cat <<'EOF'
 Next:
   /aws-inspector:collect
+  /aws-inspector:collect --tag-filter=env=production
+  /aws-inspector:collect --scope-file=config/scope.yaml
   /grc-engineer:gap-assessment SOC2,FedRAMP-Moderate --sources=aws-inspector
+
+To scope audits to production resources, edit:
+  plugins/connectors/aws-inspector/config/scope.yaml
 EOF

--- a/plugins/connectors/github-inspector/commands/collect.md
+++ b/plugins/connectors/github-inspector/commands/collect.md
@@ -19,6 +19,8 @@ node plugins/connectors/github-inspector/scripts/collect.js [options]
   - `@me` — all repos you own
   - `org:<name>` — all repos in an org you're a member of
   - `repo:<owner>/<name>` — single repo
+  - `repos-file` — scan repos listed in a YAML config file (see below)
+- `--repos-file=<path>` — path to repos YAML file (default: `config/repos.yaml` in the plugin dir)
 - `--refresh` — ignore cache; always re-query GitHub
 - `--output=<fmt>` — `silent` (default for CLI piping) | `summary` (one-line summary) | `json`
 - `--limit=<n>` — cap the number of repos scanned (useful for testing)
@@ -74,6 +76,30 @@ GitHub's REST API gives you 5,000 requests/hour authenticated. The connector bud
 
 # Single repo for testing
 /github-inspector:collect --scope=repo:acme/prod-api
+
+# Curated list from config file
+/github-inspector:collect --scope=repos-file
+
+# Custom repos file path
+/github-inspector:collect --scope=repos-file --repos-file=./my-repos.yaml
+```
+
+## Repos file format
+
+Create a YAML file listing specific repositories to scan:
+
+```yaml
+# config/repos.yaml
+repos:
+  - acme/prod-api
+  - acme/billing-service
+  - acme/infrastructure
+  - other-org/shared-lib
+  - acme/svc-*            # glob pattern: all svc- repos in acme
+
+exclude:
+  - acme/deprecated-app
+  - acme/test-*           # exclude test repos
 ```
 
 ## CI/CD usage

--- a/plugins/connectors/github-inspector/config/repos.yaml
+++ b/plugins/connectors/github-inspector/config/repos.yaml
@@ -1,0 +1,27 @@
+# github-inspector repo scope configuration
+#
+# List specific repositories to scan instead of using --scope=@me or --scope=org:<name>.
+# Use --scope=repos-file to activate this list (or set defaults.scope in your connector config).
+#
+# Each entry is an owner/repo slug:
+#
+# repos:
+#   - acme/prod-api
+#   - acme/billing-service
+#   - acme/infrastructure
+#   - other-org/shared-lib
+#
+# You can also use glob-style patterns (matched against full_name):
+#
+# repos:
+#   - acme/*            # all repos in the acme org
+#   - acme/svc-*        # repos starting with svc- in acme
+#
+# To exclude specific repos from org or pattern matches, add an exclude list:
+#
+# exclude:
+#   - acme/deprecated-app
+#   - acme/test-*
+
+repos: []
+# exclude: []

--- a/plugins/connectors/github-inspector/scripts/collect.js
+++ b/plugins/connectors/github-inspector/scripts/collect.js
@@ -7,8 +7,8 @@
  * controls, and writes a Findings array to the shared cache.
  *
  * Usage:
- *   node collect.js [--scope=@me|org:<name>|repo:<owner/name>]
- *                   [--refresh] [--output=silent|summary|json]
+ *   node collect.js [--scope=@me|org:<name>|repo:<owner/name>|repos-file]
+ *                   [--repos-file=<path>] [--refresh] [--output=silent|summary|json]
  *                   [--limit=<n>] [--concurrency=<n>] [--quiet]
  */
 
@@ -25,6 +25,8 @@ const execFileP = promisify(execFile);
 const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc');
 const CONFIG_FILE = path.join(CONFIG_DIR, 'connectors', 'github-inspector.yaml');
 const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'github-inspector');
+const PLUGIN_DIR = path.resolve(new URL('.', import.meta.url).pathname, '..');
+const DEFAULT_REPOS_FILE = path.join(PLUGIN_DIR, 'config', 'repos.yaml');
 const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
 const SOURCE = 'github-inspector';
 const SOURCE_VERSION = '0.1.0';
@@ -55,7 +57,7 @@ async function main(argv) {
   // 1. Enumerate repos
   let repos;
   try {
-    repos = await enumerateRepos(scope, { includeArchived, includeForks, limit: args.limit });
+    repos = await enumerateRepos(scope, { includeArchived, includeForks, limit: args.limit, reposFile: args.reposFile });
   } catch (err) {
     if (err.code === 'AUTH_FAILED') fail(EXIT.AUTH, err.message);
     throw err;
@@ -138,17 +140,22 @@ function parseArgs(argv) {
       case 'quiet': out.quiet = true; break;
       case 'include-archived': out.includeArchived = v === undefined || v === 'true'; break;
       case 'include-forks': out.includeForks = v === undefined || v === 'true'; break;
+      case 'repos-file': out.reposFile = v; break;
       default: fail(EXIT.USAGE, `Unknown flag: --${k}`);
     }
   }
   return out;
 }
 
-async function enumerateRepos(scope, { includeArchived, includeForks, limit }) {
+async function enumerateRepos(scope, { includeArchived, includeForks, limit, reposFile }) {
   // scope variants:
-  //   @me        → /user/repos?per_page=100&affiliation=owner
-  //   org:<n>    → /orgs/<n>/repos?per_page=100
-  //   repo:<o/r> → /repos/<o>/<r> (single)
+  //   @me             → /user/repos?per_page=100&affiliation=owner
+  //   org:<n>         → /orgs/<n>/repos?per_page=100
+  //   repo:<o/r>      → /repos/<o>/<r> (single)
+  //   repos-file      → read repos from YAML config file
+  if (scope === 'repos-file') {
+    return enumerateFromFile(reposFile, { includeArchived, includeForks, limit });
+  }
   if (scope.startsWith('repo:')) {
     const slug = scope.slice(5);
     const { stdout } = await gh(['api', `/repos/${slug}`]);
@@ -157,7 +164,7 @@ async function enumerateRepos(scope, { includeArchived, includeForks, limit }) {
   let endpoint;
   if (scope === '@me') endpoint = '/user/repos?affiliation=owner&per_page=100';
   else if (scope.startsWith('org:')) endpoint = `/orgs/${scope.slice(4)}/repos?per_page=100`;
-  else fail(EXIT.USAGE, `Unknown scope format: ${scope}`);
+  else fail(EXIT.USAGE, `Unknown scope format: ${scope}. Valid: @me, org:<name>, repo:<owner/name>, repos-file`);
 
   // Paginate via gh api --paginate
   const { stdout } = await gh(['api', '--paginate', endpoint]);
@@ -168,6 +175,100 @@ async function enumerateRepos(scope, { includeArchived, includeForks, limit }) {
     if (!includeForks && r.fork) return false;
     return true;
   }).slice(0, limit || undefined);
+}
+
+async function enumerateFromFile(reposFilePath, { includeArchived, includeForks, limit }) {
+  const filePath = reposFilePath || DEFAULT_REPOS_FILE;
+  let content;
+  try {
+    content = await fs.readFile(filePath, 'utf8');
+  } catch {
+    fail(EXIT.USAGE, `Repos file not found: ${filePath}. Create it or use a different --scope.`);
+  }
+  const cfg = parseYaml(content);
+
+  // Support both array-style and the flat YAML our parser produces
+  let repoSlugs = cfg.repos;
+  if (!repoSlugs || (Array.isArray(repoSlugs) && repoSlugs.length === 0)) {
+    fail(EXIT.USAGE, `No repos listed in ${filePath}. Add entries under the 'repos:' key.`);
+  }
+  // Our minimal YAML parser returns arrays as objects with numeric keys; normalize
+  if (!Array.isArray(repoSlugs)) {
+    repoSlugs = Object.values(repoSlugs).filter(v => typeof v === 'string');
+  }
+
+  const excludePatterns = normalizeList(cfg.exclude || []);
+
+  // Resolve slugs: plain slugs are fetched directly, glob patterns expand via org listing
+  const plainSlugs = [];
+  const globPatterns = [];
+  for (const slug of repoSlugs) {
+    if (slug.includes('*')) globPatterns.push(slug);
+    else plainSlugs.push(slug);
+  }
+
+  const repos = [];
+
+  // Fetch explicit repos in parallel (bounded)
+  for (const slug of plainSlugs) {
+    try {
+      const { stdout } = await gh(['api', `/repos/${slug}`]);
+      repos.push(JSON.parse(stdout));
+    } catch (err) {
+      process.stderr.write(`[${SOURCE}] warning: could not fetch repo ${slug}: ${err.message.split('\n')[0]}\n`);
+    }
+  }
+
+  // Expand glob patterns by fetching org repos and matching
+  const orgCache = new Map();
+  for (const pattern of globPatterns) {
+    const orgName = pattern.split('/')[0];
+    if (!orgCache.has(orgName)) {
+      try {
+        const { stdout } = await gh(['api', '--paginate', `/orgs/${orgName}/repos?per_page=100`]);
+        orgCache.set(orgName, parseConcatenatedJsonArrays(stdout));
+      } catch {
+        // Fall back to user repos if not an org
+        try {
+          const { stdout } = await gh(['api', '--paginate', `/users/${orgName}/repos?per_page=100`]);
+          orgCache.set(orgName, parseConcatenatedJsonArrays(stdout));
+        } catch (err) {
+          process.stderr.write(`[${SOURCE}] warning: could not list repos for ${orgName}: ${err.message.split('\n')[0]}\n`);
+          orgCache.set(orgName, []);
+        }
+      }
+    }
+    const orgRepos = orgCache.get(orgName);
+    const regex = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$');
+    for (const r of orgRepos) {
+      if (regex.test(r.full_name) && !repos.some(existing => existing.full_name === r.full_name)) {
+        repos.push(r);
+      }
+    }
+  }
+
+  // Apply exclude patterns
+  const filtered = repos.filter(r => {
+    if (!includeArchived && r.archived) return false;
+    if (!includeForks && r.fork) return false;
+    for (const pat of excludePatterns) {
+      if (pat.includes('*')) {
+        const regex = new RegExp('^' + pat.replace(/\*/g, '.*') + '$');
+        if (regex.test(r.full_name)) return false;
+      } else if (r.full_name === pat) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  return filtered.slice(0, limit || undefined);
+}
+
+function normalizeList(val) {
+  if (Array.isArray(val)) return val;
+  if (val && typeof val === 'object') return Object.values(val).filter(v => typeof v === 'string');
+  return [];
 }
 
 function parseConcatenatedJsonArrays(s) {

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,44 @@
+# Security & Feature Gaps
+
+## Critical
+
+- [ ] **Path traversal in `config-loader.js:58`** — `loadConfig(category, name)` passes user-controlled `name` directly to `path.join()` without validation. Other functions in the same file (`loadNISTFamily`, `loadFedRAMPBaseline`, `loadExportControlFramework`) correctly whitelist inputs, but the generic `loadConfig` does not. Add `path.basename()` or whitelist validation.
+- [ ] **Command injection in shell status scripts** — `$LATEST` interpolated unquoted into `node -e` strings. Quote the variable or pipe via stdin:
+  - `plugins/connectors/aws-inspector/scripts/status.sh:68-69`
+  - `plugins/connectors/gcp-inspector/scripts/status.sh:64-65`
+  - `plugins/connectors/okta-inspector/scripts/status.sh:57-58`
+  - `plugins/grc-engineer/scripts/pipeline-status.sh:58-59`
+- [ ] **Unquoted `$ARGUMENTS` in command files** — Shell word-splitting and metacharacter injection possible:
+  - `plugins/grc-engineer/commands/map-control.md:34`
+  - `plugins/grc-engineer/commands/review-pr.md:26`
+
+## High
+
+- [ ] **Regex injection in `risk-transformer.js:197`** — `new RegExp(mitigationKeywords.join('|'))` with unescaped special chars. Escape regex metacharacters before joining.
+
+## Medium
+
+- [ ] **Custom YAML parsers instead of `js-yaml`** — Hand-rolled parsers in all connector `collect.js` files. Replace with `js-yaml` which is already a project dependency.
+- [ ] **Potential ReDoS in `scan-iac.js:186`** — `/resource\s+"([^"]+)"\s+"([^"]+)"\s+{([^}]+)}/gs` — greedy `[^}]+` could cause catastrophic backtracking on large/malformed Terraform files.
+- [ ] **World-readable temp files** — Sensitive data written to `/tmp` without restricted permissions. Use `mktemp` with `0600` mode:
+  - `plugins/connectors/okta-inspector/scripts/setup.sh:61-62` (`/tmp/okta-me.json`, `/tmp/okta-org.json`)
+  - `plugins/connectors/aws-inspector/scripts/setup.sh:55` (`/tmp/aws-setup.err`)
+
+## Low
+
+- [ ] **Info disclosure in error messages** — Env var names leaked in `plugins/connectors/okta-inspector/scripts/collect.js:35-36`. Use a generic message instead of revealing the variable name.
+
+## Removed After Verification
+
+The following items from the original audit were re-evaluated and found to be non-issues:
+
+- ~~Shell chaining in `test-control.js:442`~~ — Command is fully hardcoded (`aws iam generate-credential-report && ...`), not user-controlled. Not exploitable.
+- ~~Quoted `$ARGUMENTS` in `transform-risk.md:17`, `collect-evidence.md:28`, `generate-policy.md:24`~~ — These use proper double-quoting (`"$ARGUMENTS"`), which prevents word-splitting. Not a realistic injection vector.
+- ~~Token passed as function parameter in `review-pr.js:45`~~ — Token is sourced from `process.env.GITHUB_TOKEN`, not from CLI args. Standard pattern; no stack trace exposure risk.
+- ~~Path traversal in `loadNISTFamily`, `loadFedRAMPBaseline`, `loadFedRAMP20xKSI`, `loadExportControlFramework`~~ — All validate input against whitelists before constructing paths. Only the generic `loadConfig` is vulnerable (listed above).
+- ~~Info disclosure in `scf-client.js:393-402`~~ — Error messages show resource-not-found details, which is acceptable operational logging.
+
+## Feature Gaps
+
+- [x] **No multi-repo scoping for github-inspector** — Added `--scope=repos-file` and `config/repos.yaml` to support curated repo lists with glob patterns and exclusions.
+- [x] **No production scoping for aws-inspector** — Added `config/scope.yaml`, `--scope-file`, `--tag-filter` flags, multi-profile support, S3 tag filtering, and bucket name pattern matching.


### PR DESCRIPTION
AWS inspector gains --scope-file and --tag-filter flags to restrict audits
to production resources via dedicated AWS account profiles, S3 bucket tag
filtering, bucket name patterns, and region overrides. GitHub inspector
gains --scope=repos-file to scan a curated list of repositories from a
YAML config with glob pattern and exclusion support.

Also adds todo.md tracking verified security gaps in the codebase.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AWS Inspector: Added `--tag-filter` and `--scope-file` CLI options to filter resources by tags and scope configurations (profiles, regions, bucket patterns).
  * GitHub Inspector: Added `--scope=repos-file` and `--repos-file` options to specify repositories via YAML configuration.

* **Documentation**
  * Updated setup guidance with production scoping examples and scope configuration format details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->