### PR TITLE
chore: transfer ownership to GRC Engineering Club

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,8 @@
 {
   "name": "grc-engineering-suite",
   "owner": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club",
+    "url": "https://grcengclub.com"
   },
   "metadata": {
     "description": "GRC Engineering Plugin Suite - Tools for auditors, internal teams, TPRM, and framework-specific compliance",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes follow the format from [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Changed
+
+**Ownership transfer to GRC Engineering Club**
+- Repository transferred from `ethanolivertroy/claude-grc-engineering` to [`GRCEngClub/claude-grc-engineering`](https://github.com/GRCEngClub/claude-grc-engineering). The toolkit is now the official open-source project of the [GRC Engineering Club](https://grcengclub.com).
+- `LICENSE` copyright updated to "GRC Engineering Club contributors" (MIT terms unchanged). Third-party attributions (SCF CC BY-ND 4.0, CIS Controls CC BY-SA 4.0) preserved.
+- All 30 `plugin.json` files: `author` and `repository` fields now reflect Club ownership.
+- `.claude-plugin/marketplace.json`: `owner` updated to the Club (homepage: grcengclub.com).
+- `package.json`: `author`, `repository`, `homepage`, `bugs`, and license URLs migrated.
+- `schemas/finding.schema.json`: `$id` updated to the Club-owned URL. Schema contract unchanged — still v1.0.0, no behavioral break.
+- Documentation and helper scripts: install commands and issue-tracker URLs point at the Club repo.
+- External tool references (e.g., `ethanolivertroy/oscal-cli`, `ethanolivertroy/frdocx-to-froscal-ssp`, `ethanolivertroy/compliance-trestle-skills`, `hackIDLE/*`) remain unchanged. These are independent upstream projects the toolkit wraps; their attribution stays accurate.
+- Founding author: Ethan Troy (`@ethanolivertroy`). Co-leads of the Club's leadership team: AJ Yawn (`@ajy0127`) and Ethan Troy. See forthcoming `GOVERNANCE.md` and `MAINTAINERS.md`.
+
+**Migration note for existing users**: If your `/plugin marketplace add` points at the old `ethanolivertroy/claude-grc-engineering` URL, re-add the marketplace using `GRCEngClub/claude-grc-engineering`. GitHub auto-redirects the old URL, but updating avoids future ambiguity.
+
 ### Added
 
 **Foundations**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ templates:
 ### Local Testing
 ```bash
 # Clone and run with local plugins
-git clone https://github.com/ethanolivertroy/claude-grc-engineering.git
+git clone https://github.com/GRCEngClub/claude-grc-engineering.git
 claude --plugin-dir ./claude-grc-engineering
 ```
 
@@ -140,11 +140,11 @@ export ANTHROPIC_VERTEX_PROJECT_ID=your-project-id
 Users install plugins via:
 ```bash
 # Add marketplace (one-time)
-/plugin marketplace add ethanolivertroy/claude-grc-engineering
+/plugin marketplace add GRCEngClub/claude-grc-engineering
 
 # Install specific plugins
-/plugin install grc-engineer@ethanolivertroy-plugins
-/plugin install soc2@ethanolivertroy-plugins
+/plugin install grc-engineer@grc-engineering-suite
+/plugin install soc2@grc-engineering-suite
 ```
 
 ## Plugin Namespaces

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Ethan Troy
+Copyright (c) 2025-2026 GRC Engineering Club contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ A few opinionated design choices worth naming up front, since they're most of wh
 
 ```bash
 # In Claude Code
-/plugin marketplace add ethanolivertroy/claude-grc-engineering
-/plugin install grc-engineer@ethanolivertroy-plugins
+/plugin marketplace add GRCEngClub/claude-grc-engineering
+/plugin install grc-engineer@grc-engineering-suite
 ```
 
 For a first run with no cloud credentials, use your GitHub account as the data source:
 
 ```bash
-/plugin install github-inspector@ethanolivertroy-plugins
-/plugin install soc2@ethanolivertroy-plugins
+/plugin install github-inspector@grc-engineering-suite
+/plugin install soc2@grc-engineering-suite
 /github-inspector:setup
 /github-inspector:collect --scope=@me
 /grc-engineer:gap-assessment SOC2 --sources=github-inspector

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,7 +53,7 @@ mkdir -p plugins/connectors/<tool>/{commands,skills/<tool>-expert,scripts,tests/
   "description": "Connector for <tool>. Emits GRC findings against SCF + SOC 2/NIST/ISO/…",
   "author": "you <you@example.com>",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "<tool>"]
 }
 ```
@@ -163,4 +163,4 @@ Reviewers will look for:
 
 ## Questions?
 
-Open a discussion at https://github.com/ethanolivertroy/claude-grc-engineering/discussions. "How would I add a connector for X?" is a welcome question.
+Open a discussion at https://github.com/GRCEngClub/claude-grc-engineering/discussions. "How would I add a connector for X?" is a welcome question.

--- a/docs/ENTERPRISE-DEPLOYMENT.md
+++ b/docs/ENTERPRISE-DEPLOYMENT.md
@@ -284,7 +284,7 @@ export ANTHROPIC_MODEL='us.anthropic.claude-sonnet-4-20250514'
 2. Configure authentication
 3. Install the GRC Engineering plugins:
    ```bash
-   /plugin marketplace add ethanolivertroy/claude-grc-engineering
-   /plugin install grc-engineer@ethanolivertroy-plugins
+   /plugin marketplace add GRCEngClub/claude-grc-engineering
+   /plugin install grc-engineer@grc-engineering-suite
    ```
 4. Start using GRC commands with enterprise-grade security!

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,7 +13,7 @@ From zero to your first gap assessment in about 10 minutes. This walkthrough use
 
 ```bash
 # Inside Claude Code
-/plugin marketplace add ethanolivertroy/claude-grc-engineering
+/plugin marketplace add GRCEngClub/claude-grc-engineering
 ```
 
 ## 2. Install the core plugins
@@ -21,9 +21,9 @@ From zero to your first gap assessment in about 10 minutes. This walkthrough use
 You need the engineering hub, one connector, and at least one framework plugin.
 
 ```bash
-/plugin install grc-engineer@ethanolivertroy-plugins
-/plugin install github-inspector@ethanolivertroy-plugins
-/plugin install soc2@ethanolivertroy-plugins
+/plugin install grc-engineer@grc-engineering-suite
+/plugin install github-inspector@grc-engineering-suite
+/plugin install soc2@grc-engineering-suite
 ```
 
 Confirm with:
@@ -127,7 +127,7 @@ Cached findings are reused; only the crosswalk join re-runs.
 
 **Add AWS to the picture**:
 ```bash
-/plugin install aws-inspector@ethanolivertroy-plugins
+/plugin install aws-inspector@grc-engineering-suite
 /aws-inspector:setup
 /aws-inspector:collect --profile=default --region=us-east-1
 /grc-engineer:gap-assessment SOC2,FedRAMP-Moderate --sources=github-inspector,aws-inspector

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
   ],
   "license": "(MIT AND CC-BY-SA-4.0)",
   "licenses": [
-    { "type": "MIT", "url": "https://github.com/ethanolivertroy/claude-grc-engineering/blob/main/LICENSE" },
-    { "type": "CC-BY-SA-4.0", "url": "https://github.com/ethanolivertroy/claude-grc-engineering/blob/main/plugins/frameworks/cis-controls/LICENSE-CIS.md" }
+    { "type": "MIT", "url": "https://github.com/GRCEngClub/claude-grc-engineering/blob/main/LICENSE" },
+    { "type": "CC-BY-SA-4.0", "url": "https://github.com/GRCEngClub/claude-grc-engineering/blob/main/plugins/frameworks/cis-controls/LICENSE-CIS.md" }
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ethanolivertroy/claude-grc-engineering.git"
+    "url": "git+https://github.com/GRCEngClub/claude-grc-engineering.git"
   },
-  "homepage": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "homepage": "https://github.com/GRCEngClub/claude-grc-engineering",
   "bugs": {
-    "url": "https://github.com/ethanolivertroy/claude-grc-engineering/issues"
+    "url": "https://github.com/GRCEngClub/claude-grc-engineering/issues"
   },
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "dependencies": {
     "dotenv": "^16.4.5",
     "js-yaml": "^4.1.1",

--- a/plugins/connectors/aws-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/aws-inspector/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "aws-inspector",
   "version": "0.1.0",
   "description": "GRC connector for AWS: evaluates IAM, S3, CloudTrail, EBS, and RDS for compliance misconfigurations. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "aws", "scf", "soc2", "fedramp", "connector"]
 }

--- a/plugins/connectors/gcp-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/gcp-inspector/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "gcp-inspector",
   "version": "0.1.0",
   "description": "GRC connector for Google Cloud: evaluates IAM, Cloud Storage, audit logs, KMS rotation, and Compute for compliance misconfigurations. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "gcp", "google-cloud", "scf", "fedramp", "connector"]
 }

--- a/plugins/connectors/github-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/github-inspector/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "github-inspector",
   "version": "0.1.0",
   "description": "GRC connector for GitHub: evaluates repo protections, branch policies, Actions, secret scanning, Dependabot, and deploy keys. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "github", "scf", "soc2", "connector"]
 }

--- a/plugins/connectors/github-inspector/commands/setup.md
+++ b/plugins/connectors/github-inspector/commands/setup.md
@@ -44,7 +44,7 @@ None. Reads from the environment:
 ```
 github-inspector:setup ✓
   gh version:       2.59.0
-  authenticated as: ethanolivertroy
+  authenticated as: octocat
   config written:   ~/.config/claude-grc/connectors/github-inspector.yaml
 
 Next: /github-inspector:collect --scope=@me

--- a/plugins/connectors/github-inspector/commands/status.md
+++ b/plugins/connectors/github-inspector/commands/status.md
@@ -19,7 +19,7 @@ bash plugins/connectors/github-inspector/scripts/status.sh
 github-inspector
   status:         ready
   gh:             /usr/local/bin/gh v2.59.0
-  auth:           valid (ethanolivertroy, scopes: repo,read:org)
+  auth:           valid (octocat, scopes: repo,read:org)
   config:         ~/.config/claude-grc/connectors/github-inspector.yaml
   scope:          @me
   last run:       2 hours ago (run_id 20260413-a1b2c3d4)

--- a/plugins/connectors/okta-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/okta-inspector/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "okta-inspector",
   "version": "0.1.0",
   "description": "GRC connector for Okta: evaluates authentication policies, MFA enrollment, password policy, session management, and admin/privileged accounts. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "okta", "identity", "iam", "scf", "fedramp", "connector"]
 }

--- a/plugins/fedramp-ssp/.claude-plugin/plugin.json
+++ b/plugins/fedramp-ssp/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "fedramp-ssp",
   "version": "0.1.0",
   "description": "Convert FedRAMP Rev 5 Moderate SSP DOCX templates to validated OSCAL 1.2.0 JSON. Wraps ethanolivertroy/frdocx-to-froscal-ssp — ready for oscal-cli, Compliance Trestle, eMASS, and FedRAMP 20X workflows.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["fedramp", "oscal", "ssp", "docx", "compliance-as-code"]
 }

--- a/plugins/fedramp-ssp/scripts/convert.sh
+++ b/plugins/fedramp-ssp/scripts/convert.sh
@@ -68,7 +68,7 @@ frdocx_to_froscal.py, convert.py, src/main.py, or a __main__.py.
 Fix:
   - Inspect $TOOL_DIR/README.md for the current invocation.
   - Run the pipeline manually once; the plugin calls 'python <entrypoint>'.
-  - Or file an issue at ethanolivertroy/claude-grc-engineering.
+  - Or file an issue at GRCEngClub/claude-grc-engineering.
 EOF
   exit 5
 fi

--- a/plugins/frameworks/cis-controls/.claude-plugin/plugin.json
+++ b/plugins/frameworks/cis-controls/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "cis-controls",
   "description": "CIS Controls v8 Plugin - Center for Internet Security baseline with IG1/IG2/IG3 implementation groups and 153 safeguards",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "CC-BY-SA-4.0 AND MIT",
   "license_note": "CIS-derived content (commands, skills) is CC BY-SA 4.0 per the upstream CIS Controls license. Original glue code is MIT. See LICENSE-CIS.md."
 }

--- a/plugins/frameworks/cis-controls/LICENSE-CIS.md
+++ b/plugins/frameworks/cis-controls/LICENSE-CIS.md
@@ -50,4 +50,4 @@ If you're unsure whether a contribution falls under CC BY-SA or MIT, bias toward
 ## Questions?
 
 - CIS Controls licensing: https://www.cisecurity.org/controls/v8
-- This plugin's licensing: open an issue at https://github.com/ethanolivertroy/claude-grc-engineering
+- This plugin's licensing: open an issue at https://github.com/GRCEngClub/claude-grc-engineering

--- a/plugins/frameworks/cmmc/.claude-plugin/plugin.json
+++ b/plugins/frameworks/cmmc/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "CMMC v2.0 Plugin - Cybersecurity Maturity Model Certification for DoD contractors with 5 levels and C3PAO assessment prep",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/csa-ccm/.claude-plugin/plugin.json
+++ b/plugins/frameworks/csa-ccm/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "csa-ccm",
   "description": "CSA CCM Plugin - Cloud Security Alliance Cloud Controls Matrix with 197 controls and CAIQ support",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/dora/.claude-plugin/plugin.json
+++ b/plugins/frameworks/dora/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dora",
   "description": "DORA Plugin - EU Digital Operational Resilience Act for financial entities with ICT risk management (effective January 2025)",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/essential8/.claude-plugin/plugin.json
+++ b/plugins/frameworks/essential8/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "essential8",
   "description": "Essential 8 Plugin - Australian Cyber Security Centre mitigation strategies with 3 maturity levels",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/fedramp-20x/.claude-plugin/plugin.json
+++ b/plugins/frameworks/fedramp-20x/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "FedRAMP 20X Plugin - Modern automated authorization with Key Security Indicators (KSIs), continuous monitoring, and machine-readable policies synced from official FedRAMP docs",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/fedramp-rev5/.claude-plugin/plugin.json
+++ b/plugins/frameworks/fedramp-rev5/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "FedRAMP Rev 5 Plugin - Traditional authorization path with SSP/SAP/SAR/POA&M documentation and NIST 800-53 Rev 5 control mapping",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/gdpr/.claude-plugin/plugin.json
+++ b/plugins/frameworks/gdpr/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "gdpr",
   "description": "GDPR Plugin - EU General Data Protection Regulation with DPIA, data subject rights, and 72-hour breach notification",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/glba/.claude-plugin/plugin.json
+++ b/plugins/frameworks/glba/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "glba",
   "description": "GLBA Plugin - Gramm-Leach-Bliley Act for financial institutions with Safeguards Rule and Privacy Rule compliance",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/hitrust/.claude-plugin/plugin.json
+++ b/plugins/frameworks/hitrust/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "HITRUST CSF Plugin - Healthcare Information Trust Alliance Common Security Framework with i1/r2 assessments and 156 controls",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/irap/.claude-plugin/plugin.json
+++ b/plugins/frameworks/irap/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "Australian IRAP (ISM + Essential Eight) for government cloud",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/ismap/.claude-plugin/plugin.json
+++ b/plugins/frameworks/ismap/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "Japanese ISMAP government cloud security (ISO 27001/27017/27018)",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/iso27001/.claude-plugin/plugin.json
+++ b/plugins/frameworks/iso27001/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "ISO 27001 Plugin - Annex A controls, ISMS implementation guidance, and certification support",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/nist-800-53/.claude-plugin/plugin.json
+++ b/plugins/frameworks/nist-800-53/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "NIST 800-53 Plugin - Control families, baseline selection (Low/Moderate/High), and FedRAMP alignment",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/nydfs/.claude-plugin/plugin.json
+++ b/plugins/frameworks/nydfs/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nydfs",
   "description": "NYDFS 23 NYCRR 500 Plugin - New York Department of Financial Services cybersecurity requirements with annual certification",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/pbmm/.claude-plugin/plugin.json
+++ b/plugins/frameworks/pbmm/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "Canadian PBMM (Protected B Medium Medium) with ITSG-33 controls",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/pci-dss/.claude-plugin/plugin.json
+++ b/plugins/frameworks/pci-dss/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "PCI DSS v4.0.1 Plugin - Payment Card Industry compliance with ROC guidance, SAQ selection, and March 2025 mandatory requirements",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/soc2/.claude-plugin/plugin.json
+++ b/plugins/frameworks/soc2/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "SOC 2 Compliance Plugin - Trust Service Criteria expertise, Type I/II assessment support, and control mapping",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/stateramp/.claude-plugin/plugin.json
+++ b/plugins/frameworks/stateramp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "stateramp",
   "description": "StateRAMP Plugin - State Risk and Authorization Management Program for state and local government cloud services",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/us-export/.claude-plugin/plugin.json
+++ b/plugins/frameworks/us-export/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "US Export Controls Plugin - ITAR and EAR compliance for defense and dual-use technologies",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/grc-auditor/.claude-plugin/plugin.json
+++ b/plugins/grc-auditor/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "GRC Auditor Plugin - Evidence review, control validation, and audit workpaper generation for external auditors and assessors",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/grc-engineer/.claude-plugin/plugin.json
+++ b/plugins/grc-engineer/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "GRC Engineering Plugin - Maps IaC to compliance controls, generates policies, collects evidence, reviews PRs for compliance, and transforms risks to Jira tickets",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/grc-engineer/commands/pipeline-status.md
+++ b/plugins/grc-engineer/commands/pipeline-status.md
@@ -20,7 +20,7 @@ CLAUDE-GRC PIPELINE STATUS (2026-04-13 15:04 UTC)
 
 github-inspector
   status:         ready
-  auth:           valid (ethanolivertroy, scopes: repo,read:org)
+  auth:           valid (octocat, scopes: repo,read:org)
   last run:       3h ago
   cached:         127 resources, 512 evaluations
   rate limit:     4872/5000 remaining

--- a/plugins/grc-engineer/scripts/gap-assessment.js
+++ b/plugins/grc-engineer/scripts/gap-assessment.js
@@ -528,7 +528,7 @@ function toSarif(r) {
     $schema: 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
     version: '2.1.0',
     runs: [{
-      tool: { driver: { name: 'claude-grc-engineering', version: '0.1.0', informationUri: 'https://github.com/ethanolivertroy/claude-grc-engineering' } },
+      tool: { driver: { name: 'claude-grc-engineering', version: '0.1.0', informationUri: 'https://github.com/GRCEngClub/claude-grc-engineering' } },
       invocations: [{ startTimeUtc: r.generated_at, endTimeUtc: r.generated_at }],
       results
     }]

--- a/plugins/grc-internal/.claude-plugin/plugin.json
+++ b/plugins/grc-internal/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "GRC Internal Plugin - Policy management, risk registers, and compliance tracking for internal GRC teams",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/grc-tprm/.claude-plugin/plugin.json
+++ b/plugins/grc-tprm/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "GRC Third-Party Risk Management Plugin - Vendor assessments, questionnaire analysis, and risk scoring",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/oscal/.claude-plugin/plugin.json
+++ b/plugins/oscal/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "oscal",
   "version": "0.1.0",
   "description": "OSCAL (Open Security Controls Assessment Language) toolkit for Claude Code. Wraps ethanolivertroy/oscal-cli for validation and conversion of catalogs, profiles, SSPs, SAPs, SARs, POA&Ms, component definitions, and assessment results.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["oscal", "fedramp", "grc", "compliance", "nist"]
 }

--- a/schemas/finding.schema.json
+++ b/schemas/finding.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/ethanolivertroy/claude-grc-engineering/schemas/finding.schema.json",
+  "$id": "https://github.com/GRCEngClub/claude-grc-engineering/schemas/finding.schema.json",
   "title": "GRC Finding",
   "description": "Canonical output contract for claude-grc-engineering connectors. One document per resource-evaluation batch. See docs/ARCHITECTURE.md for the pipeline model.",
   "type": "object",


### PR DESCRIPTION
## Summary

Mechanical ownership rebrand across 46 files, dedicating the toolkit to the [GRC Engineering Club](https://grcengclub.com) as its official open-source project.

- `LICENSE` copyright → GRC Engineering Club contributors (MIT terms unchanged)
- `package.json`, `schemas/finding.schema.json`, `.claude-plugin/marketplace.json` → Club URLs + owner
- All 30 `plugin.json` files → Club author + `GRCEngClub/claude-grc-engineering` repo URL
- Docs, install commands, helper scripts → Club repo URLs + `grc-engineering-suite` namespace
- Example CLI outputs that showed a personal GitHub handle → `octocat` placeholder
- `CHANGELOG.md` records the transfer and a migration note for users

External dependencies (`ethanolivertroy/oscal-cli`, `ethanolivertroy/frdocx-to-froscal-ssp`, `hackIDLE/*`, etc.) **remain unchanged** — these are independent upstream projects the Club's plugins wrap, not toolkit-internal code.

The Finding schema contract (v1.0.0) is unchanged; no connector break.

## Test plan

- [ ] `grep -rn "Ethan Troy\|ethanolivertroy/claude-grc-engineering\|@ethanolivertroy-plugins" .` returns only the intentional references in `CHANGELOG.md` (historical note).
- [ ] `jq empty` validates every `plugin.json` (JSON still parseable after sed).
- [ ] `/plugin marketplace add GRCEngClub/claude-grc-engineering` followed by `/plugin install grc-engineer@grc-engineering-suite` works end-to-end.
- [ ] `$id` in `schemas/finding.schema.json` resolves to the Club URL.