### PR TITLE
docs: rewrite README and docs in community voice

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,8 @@
 {
   "name": "grc-engineering-suite",
   "owner": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club",
+    "url": "https://grcengclub.com"
   },
   "metadata": {
     "description": "GRC Engineering Plugin Suite - Tools for auditors, internal teams, TPRM, and framework-specific compliance",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes follow the format from [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Changed
+
+**Ownership transfer to GRC Engineering Club**
+- Repository transferred from `ethanolivertroy/claude-grc-engineering` to [`GRCEngClub/claude-grc-engineering`](https://github.com/GRCEngClub/claude-grc-engineering). The toolkit is now the official open-source project of the [GRC Engineering Club](https://grcengclub.com).
+- `LICENSE` copyright updated to "GRC Engineering Club contributors" (MIT terms unchanged). Third-party attributions (SCF CC BY-ND 4.0, CIS Controls CC BY-SA 4.0) preserved.
+- All 30 `plugin.json` files: `author` and `repository` fields now reflect Club ownership.
+- `.claude-plugin/marketplace.json`: `owner` updated to the Club (homepage: grcengclub.com).
+- `package.json`: `author`, `repository`, `homepage`, `bugs`, and license URLs migrated.
+- `schemas/finding.schema.json`: `$id` updated to the Club-owned URL. Schema contract unchanged — still v1.0.0, no behavioral break.
+- Documentation and helper scripts: install commands and issue-tracker URLs point at the Club repo.
+- External tool references (e.g., `ethanolivertroy/oscal-cli`, `ethanolivertroy/frdocx-to-froscal-ssp`, `ethanolivertroy/compliance-trestle-skills`, `hackIDLE/*`) remain unchanged. These are independent upstream projects the toolkit wraps; their attribution stays accurate.
+- Founding author: Ethan Troy (`@ethanolivertroy`). Co-leads of the Club's leadership team: AJ Yawn (`@ajy0127`) and Ethan Troy. See forthcoming `GOVERNANCE.md` and `MAINTAINERS.md`.
+
+**Migration note for existing users**: If your `/plugin marketplace add` points at the old `ethanolivertroy/claude-grc-engineering` URL, re-add the marketplace using `GRCEngClub/claude-grc-engineering`. GitHub auto-redirects the old URL, but updating avoids future ambiguity.
+
 ### Added
 
 **Foundations**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ templates:
 ### Local Testing
 ```bash
 # Clone and run with local plugins
-git clone https://github.com/ethanolivertroy/claude-grc-engineering.git
+git clone https://github.com/GRCEngClub/claude-grc-engineering.git
 claude --plugin-dir ./claude-grc-engineering
 ```
 
@@ -140,11 +140,11 @@ export ANTHROPIC_VERTEX_PROJECT_ID=your-project-id
 Users install plugins via:
 ```bash
 # Add marketplace (one-time)
-/plugin marketplace add ethanolivertroy/claude-grc-engineering
+/plugin marketplace add GRCEngClub/claude-grc-engineering
 
 # Install specific plugins
-/plugin install grc-engineer@ethanolivertroy-plugins
-/plugin install soc2@ethanolivertroy-plugins
+/plugin install grc-engineer@grc-engineering-suite
+/plugin install soc2@grc-engineering-suite
 ```
 
 ## Plugin Namespaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-This is a Claude Code plugin marketplace for Governance, Risk, and Compliance (GRC) professionals. The repository provides 25 specialized plugins organized into:
+This is the official open-source Claude Code plugin marketplace of the [GRC Engineering Club](https://grcengclub.com) for Governance, Risk, and Compliance (GRC) professionals. The repository provides 30 specialized plugins organized into:
 - **4 persona-based plugins** (grc-engineer, grc-auditor, grc-internal, grc-tprm)
-- **21 framework-specific plugins** (soc2, nist-800-53, iso27001, fedramp-rev5, fedramp-20x, pci-dss, cmmc, hitrust, cis-controls, gdpr, csa-ccm, nydfs, dora, stateramp, essential8, glba, us-export, pbmm, ismap, irap, and more)
+- **21 framework-specific plugins** (soc2, nist-800-53, iso27001, fedramp-rev5, fedramp-20x, pci-dss, cmmc, hitrust, cis-controls, gdpr, csa-ccm, nydfs, dora, stateramp, essential8, glba, us-export, pbmm, ismap, irap)
+- **4 Tier-1 connector plugins** (aws-inspector, gcp-inspector, github-inspector, okta-inspector) that emit findings matching `schemas/finding.schema.json`
+- **OSCAL tooling plugins** (oscal, fedramp-ssp) wrapping external upstream projects
 
 Each plugin contains commands (user-facing) and skills (AI agents that implement functionality).
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Ethan Troy
+Copyright (c) 2025-2026 GRC Engineering Club contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ A few opinionated design choices worth naming up front, since they're most of wh
 
 ```bash
 # In Claude Code
-/plugin marketplace add ethanolivertroy/claude-grc-engineering
-/plugin install grc-engineer@ethanolivertroy-plugins
+/plugin marketplace add GRCEngClub/claude-grc-engineering
+/plugin install grc-engineer@grc-engineering-suite
 ```
 
 For a first run with no cloud credentials, use your GitHub account as the data source:
 
 ```bash
-/plugin install github-inspector@ethanolivertroy-plugins
-/plugin install soc2@ethanolivertroy-plugins
+/plugin install github-inspector@grc-engineering-suite
+/plugin install soc2@grc-engineering-suite
 /github-inspector:setup
 /github-inspector:collect --scope=@me
 /grc-engineer:gap-assessment SOC2 --sources=github-inspector

--- a/README.md
+++ b/README.md
@@ -1,28 +1,26 @@
 # claude-grc-engineering
 
-I've worked both sides of FedRAMP: years as a 3PAO assessor, and I build open-source GRC tooling for the teams stuck doing the work by hand. Every team I've assessed ends up re-inventing the same pipeline: pull evidence from AWS, GitHub, GCP, and Okta; map it to SOC 2 or NIST 800-53 or FedRAMP Moderate/High; generate a gap report; fight with OSCAL. I wanted one toolkit that did the whole pipeline end-to-end without bolting me into a vendor platform. This is it.
-
-Install as a [Claude Code](https://docs.claude.com/claude-code) plugin. Run:
+The official open-source GRC toolkit from the [GRC Engineering Club](https://grcengclub.com) — turning checkbox compliance into engineered systems. It ships as a [Claude Code](https://docs.claude.com/claude-code) plugin marketplace: persona plugins for engineers, auditors, internal GRC teams, and TPRM; 20+ framework reference plugins from SOC 2 to FedRAMP to APRA; and thin cloud/SaaS connectors that emit a common Finding contract. Assessors, platform engineers, and GRC teams everywhere end up re-inventing the same pipeline — pull evidence, crosswalk to a framework, generate a gap report, wrestle OSCAL. The Club maintains one toolkit that does the whole pipeline end-to-end without locking anyone into a vendor platform.
 
 ```
-/grc-engineer:gap-assessment SOC2,FedRAMP-Moderate --sources=aws,github
+/grc-engineer:gap-assessment SOC2,FedRAMP-High --sources=aws,github
 ```
 
-You get a prioritized, effort-estimated, remediation-linked gap report backed by 1,468 [Secure Controls Framework](https://securecontrolsframework.com) controls crosswalked to 249 frameworks.
+A prioritized, effort-estimated, remediation-linked gap report backed by 1,468 [Secure Controls Framework](https://securecontrolsframework.com) controls crosswalked to 249 frameworks.
 
-> Not affiliated with Anthropic. Independent open-source project. Claude, Anthropic, and any related marks are property of their respective owners.
+> Not affiliated with Anthropic. Community open-source project. Claude, Anthropic, and any related marks are property of their respective owners.
 
-## What I'm taking a position on
+## Design positions
 
-A few opinionated design choices worth naming up front, since they're most of what makes this different from a Vanta or Drata clone.
+A few opinionated choices worth naming up front, since they're most of what makes this different from a Vanta or Drata clone.
 
-**SCF is the right crosswalk source.** Everyone rolls their own control-mapping tables. They're usually incomplete, and nobody maintains them past the quarter they were built in. SCF has 1,468 controls mapped bidirectionally to 249 frameworks, publishes quarterly, and ships as a static JSON API. Use it as the backbone. Stop hand-maintaining CSVs.
+**SCF is the right crosswalk source.** Most GRC tools roll their own control-mapping tables. They're usually incomplete, and nobody maintains them past the quarter they were built in. SCF has 1,468 controls mapped bidirectionally to 249 frameworks, publishes quarterly, and ships as a static JSON API. The toolkit uses it as the backbone. No hand-maintained CSVs.
 
-**Connectors should be thin.** Most GRC platforms bundle giant agents that do everything. That's a vendor lock-in pattern, not an engineering pattern. Every connector here is a few hundred lines that shells out to tools you already have (`aws`, `gcloud`, `gh`, direct Okta API). You can rip and replace any of them without touching the rest of the toolkit.
+**Connectors should be thin.** Platform vendors bundle giant agents that do everything. That's a lock-in pattern, not an engineering pattern. Every connector here is a few hundred lines that shells out to tools teams already have (`aws`, `gcloud`, `gh`, direct Okta API). Any connector can be ripped out and replaced without touching the rest of the toolkit.
 
-**Framework plugins don't reproduce standard text.** ISO 27001, PCI DSS, and HITRUST CSF text is copyrighted. Plenty of GRC tools publish that text inside their product and hope nobody notices. This toolkit references control IDs and ships implementation guidance in my own words. Your licensed copy of the standard is the source of truth.
+**Framework plugins don't reproduce standard text.** ISO 27001, PCI DSS, and HITRUST CSF text is copyrighted. Plenty of GRC tools publish that text inside their product and hope nobody notices. This toolkit references control IDs and ships implementation guidance in paraphrased form. Each team's licensed copy of the standard is the source of truth.
 
-**Vanta, Drata, OneTrust, and Archer are good at what they do.** They're also expensive, slow to extend, and assume you have a compliance team. This is for teams that want the engineering layer without the platform lock-in, and for 3PAOs and assessors who want to cross-check what a platform is reporting.
+**Vanta, Drata, OneTrust, and Archer are good at what they do.** They're also expensive, slow to extend, and assume a dedicated compliance team. This toolkit is for teams that want the engineering layer without the platform lock-in, and for 3PAOs and assessors who want to cross-check what a platform is reporting.
 
 ## 60-second install
 
@@ -32,7 +30,7 @@ A few opinionated design choices worth naming up front, since they're most of wh
 /plugin install grc-engineer@grc-engineering-suite
 ```
 
-For a first run with no cloud credentials, use your GitHub account as the data source:
+For a first run with no cloud credentials, use a GitHub account as the data source:
 
 ```bash
 /plugin install github-inspector@grc-engineering-suite
@@ -134,6 +132,8 @@ Want a connector that isn't here? [Contribute one](docs/CONTRIBUTING.md). A typi
 | **fedramp-docs** | MCP integration with [`ethanolivertroy/fedramp-docs-mcp`](https://github.com/ethanolivertroy/fedramp-docs-mcp) for live FedRAMP documentation search (roadmap) |
 | **vanta-bridge** | `/vanta:export-evidence` using `vanta-go-export` to pull Vanta evidence and normalize to Findings (roadmap) |
 
+The OSCAL tooling plugins wrap independent upstream projects maintained outside the Club. Their attribution stays with the original authors; the plugin wrappers are part of this toolkit.
+
 ## The data contract
 
 Every connector emits Findings matching [`schemas/finding.schema.json`](schemas/finding.schema.json). One Finding is one resource with one or more control evaluations. Example:
@@ -174,7 +174,7 @@ The contract is versioned. Consumers pin a major version. Contract tests run in 
 
 SCF is the canonical control vocabulary. 1,468 SCF controls map bidirectionally to 249 frameworks. When a connector reports an SCF control failure, `/gap-assessment` expands it into every requested framework via the crosswalk.
 
-SCF data is fetched from [`hackidle.github.io/scf-api`](https://hackidle.github.io/scf-api/) and cached locally. Licensing (CC BY-ND 4.0): I fetch and redistribute verbatim, never modify. See [`docs/SCF-ATTRIBUTION.md`](docs/SCF-ATTRIBUTION.md).
+SCF data is fetched from [`hackidle.github.io/scf-api`](https://hackidle.github.io/scf-api/) and cached locally. Licensing (CC BY-ND 4.0): the toolkit fetches and redistributes verbatim, never modified. See [`docs/SCF-ATTRIBUTION.md`](docs/SCF-ATTRIBUTION.md).
 
 ## Documentation
 
@@ -202,16 +202,36 @@ export ANTHROPIC_VERTEX_PROJECT_ID=your-project-id
 
 Full guide: [`docs/ENTERPRISE-DEPLOYMENT.md`](docs/ENTERPRISE-DEPLOYMENT.md).
 
-## Related tools I built
+## Adjacent open-source tools
 
-This toolkit is the integration layer over a bunch of adjacent tools I maintain. Each can be used on its own:
+The toolkit wraps or interoperates with a number of independent projects maintained outside the Club. Each can be used on its own:
 
 - **Inspector family** ([`hackIDLE`](https://github.com/hackIDLE)): 30+ multi-framework compliance audit tools for AWS, Azure, GCP, OCI, Cloudflare, GitHub, Okta, Duo, Slack, Zoom, Webex, Salesforce, Snowflake, Datadog, Splunk, Sumologic, NewRelic, Elastic, Tenable, Qualys, Veracode, CrowdStrike, Palo Alto, Zscaler, KnowBe4, Box, ServiceNow, PagerDuty, Zendesk, LaunchDarkly, MuleSoft.
-- **OSCAL tooling** ([`ethanolivertroy`](https://github.com/ethanolivertroy)): `oscal-cli` (Go rewrite of NIST's Java tool), `compliance-trestle-skills`, `frdocx-to-froscal-ssp`, `fedramp-docs-mcp`, `emass-skills`.
+- **OSCAL tooling** (maintained by [`@ethanolivertroy`](https://github.com/ethanolivertroy)): `oscal-cli` (Go rewrite of NIST's Java tool), `compliance-trestle-skills`, `frdocx-to-froscal-ssp`, `fedramp-docs-mcp`, `emass-skills`.
 - **FedRAMP audit scripts**: cloud-shell-audit tools for AWS, Azure, and GCP, plus `duo-audit`, `slack-audit`, `splunk-audit`, `crypto-widget-evidence-collector`.
 - **Policy-as-code**: `terrascan` (fork), `llm-cloudpolicy-scanner`, `wilma` (AWS Bedrock security), `mesh-security`, `mesh-config-analyzer`.
 - **Reference datasets**: [`scf-api`](https://github.com/hackIDLE/scf-api) (this toolkit's crosswalk backbone), `NIST-CMVP-API`, `cmvp-tui`, `kevs-tui`, `fedramp-browser`.
 - **Curated lists**: [`awesome-grc-engineering`](https://github.com/ethanolivertroy/awesome-grc-engineering), [`awesome-grc-ai`](https://github.com/ethanolivertroy/awesome-grc-ai).
+
+These projects are not part of this repo or governed by the Club. They're listed here because they pair well with the toolkit.
+
+## Community
+
+This toolkit is developed openly by the [GRC Engineering Club](https://grcengclub.com). Contributions are welcome from anyone working in GRC: assessors, internal audit, security engineering, CISO teams, TPRM, platform operators, framework experts.
+
+- **Contributing**: [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md). The highest-value contributions are new connectors (Tier-2 roadmap above), framework plugin improvements, and real-world implementation guidance. A typical connector is ~200 lines.
+- **Discussions**: [github.com/GRCEngClub/claude-grc-engineering/discussions](https://github.com/GRCEngClub/claude-grc-engineering/discussions) — "how would I add a connector for X?" and similar design questions welcome.
+- **Issues**: Use a template when opening. Security-sensitive issues go to a private advisory; see `SECURITY.md`.
+- **Recognition**: contributors are credited via the [all-contributors](https://allcontributors.org) bot on every PR. Comment `@all-contributors please add @you for code,doc` after your PR merges, or ask a maintainer.
+
+### Maintainers
+
+This project is co-led by members of the [GRC Engineering Club leadership team](https://github.com/orgs/GRCEngClub/teams/grc-eng-leadership-team). Current co-leads:
+
+- **AJ Yawn** ([@ajy0127](https://github.com/ajy0127)) — founder of the GRC Engineering Club; GRC Engineering Lead at NR Labs; formerly VP/Director of GRC Engineering, Principal Consultant at Coalfire, and U.S. Army Captain.
+- **Ethan Troy** ([@ethanolivertroy](https://github.com/ethanolivertroy)) — founded this toolkit in 2025 and contributed it to the Club in 2026; former 3PAO FedRAMP assessor; multi-framework advisor across SOC 2, PCI DSS, FISMA, and NIST 800-53.
+
+See `GOVERNANCE.md` and `MAINTAINERS.md` for the decision process and how to become a maintainer.
 
 ## Status
 
@@ -219,8 +239,4 @@ Pre-1.0. The schema is versioned (v1.0.0) and Tier-1 connectors are the focus of
 
 ## License
 
-MIT for original code. Exceptions are documented in [LICENSE](LICENSE). One plugin (`plugins/frameworks/cis-controls/`) is CC BY-SA 4.0.
-
-## Contributing
-
-Contributions welcome. Start with [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md). The highest-value contributions are new connectors and improvements to existing ones.
+MIT for original code, copyright © GRC Engineering Club contributors. Exceptions are documented in [LICENSE](LICENSE). One plugin (`plugins/frameworks/cis-controls/`) is CC BY-SA 4.0 per upstream terms. SCF data is CC BY-ND 4.0 and redistributed verbatim.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,7 +84,7 @@ Without a contract, `/gap-assessment` would need bespoke parsers for every tool'
 
 Two independent fields. `status` is the pass/fail semantic; `severity` is the impact if the check were failing. A *low-severity failure* is real (just not urgent). A *passing critical-severity* control produces `status=pass, severity=critical`: it still matters because it tells `/gap-assessment` what the stakes would be if the control regressed.
 
-`inconclusive` is not a workaround for "I didn't check." Use it when the tool *tried* and *couldn't determine*: a dropped API call, missing permission, rate-limited. Consumers treat it as a signal to re-run, not a pass.
+`inconclusive` is not a workaround for "didn't check." Use it when the tool *tried* and *couldn't determine*: a dropped API call, missing permission, rate-limited. Consumers treat it as a signal to re-run, not a pass.
 
 ## The crosswalk layer
 
@@ -105,7 +105,7 @@ Report shows:          "Data at rest encryption is failing: violates 4 framework
 - **Coverage**: 249 frameworks including the obscure regional ones (Argentina LGPD, Bermuda BMA CoC, etc.).
 - **Maintained**: upstream publishes quarterly; the SCF API repo auto-syncs weekly.
 - **Neutral**: SCF is framework-agnostic, so mapping "SCF → everywhere else" is the minimum edit distance.
-- **Licensable**: SCF data is CC BY-ND. I fetch, attribute, and never modify it. See `docs/SCF-ATTRIBUTION.md`.
+- **Licensable**: SCF data is CC BY-ND. The toolkit fetches, attributes, and never modifies it. See `docs/SCF-ATTRIBUTION.md`.
 
 ### Non-SCF evaluations
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,7 +53,7 @@ mkdir -p plugins/connectors/<tool>/{commands,skills/<tool>-expert,scripts,tests/
   "description": "Connector for <tool>. Emits GRC findings against SCF + SOC 2/NIST/ISO/…",
   "author": "you <you@example.com>",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "<tool>"]
 }
 ```
@@ -163,4 +163,4 @@ Reviewers will look for:
 
 ## Questions?
 
-Open a discussion at https://github.com/ethanolivertroy/claude-grc-engineering/discussions. "How would I add a connector for X?" is a welcome question.
+Open a discussion at https://github.com/GRCEngClub/claude-grc-engineering/discussions. "How would I add a connector for X?" is a welcome question.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,16 @@
 # Contributing
 
-The most valuable contributions to `claude-grc-engineering` are **new connectors** and **improvements to existing connectors**. A second high-value lane is **framework plugin improvements**: especially control-mapping refinements and real-world implementation guidance.
+`claude-grc-engineering` is the official open-source toolkit of the [GRC Engineering Club](https://grcengclub.com). Contributions are welcome from anyone working in GRC — assessors, internal audit, security engineering, CISO teams, TPRM, platform operators, framework experts.
+
+The most valuable contributions are **new connectors** and **improvements to existing connectors**. A second high-value lane is **framework plugin improvements**: especially control-mapping refinements and real-world implementation guidance.
+
+## First-time contributors
+
+If this is your first PR here:
+
+1. Browse [`good-first-issue`](https://github.com/GRCEngClub/claude-grc-engineering/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) labels for a self-contained starting task (typically 2–4 hours of work).
+2. Open a **draft PR** early — even with a skeleton commit. A maintainer will review direction before you sink time into it.
+3. Stuck? Start a thread in [Discussions](https://github.com/GRCEngClub/claude-grc-engineering/discussions) and tag the area (`connector`, `framework`, `docs`). "How would I add a connector for X?" is a welcome question.
 
 ## Ground rules
 
@@ -155,9 +165,19 @@ Reviewers will look for:
 - Is the output schema-conformant and the user-facing text clear?
 - Does it earn its place in the toolkit (vs. something a user could script in 10 lines)?
 
+## Recognition
+
+Contributors are credited via the [all-contributors](https://allcontributors.org) bot. After a PR merges, a maintainer will add the contributor to `CONTRIBUTORS.md` — or contributors can self-nominate by commenting on their own PR:
+
+```
+@all-contributors please add @your-username for code,doc
+```
+
+Contribution types include `code`, `doc`, `review`, `question`, `ideas`, `infra`, `content`, `bug`, `example`, `test`. Use multiple types when applicable.
+
 ## Security
 
-- **Reporting vulnerabilities**: email (preferred) or open a private security advisory on GitHub. Don't file public issues for security problems.
+- **Reporting vulnerabilities**: open a [private security advisory](https://github.com/GRCEngClub/claude-grc-engineering/security/advisories/new) on GitHub. Don't file public issues for security problems.
 - **Secrets**: never commit credentials, tokens, org IDs, or internal URLs. Run a local secret scanner before pushing: [`git-secrets`](https://github.com/awslabs/git-secrets), [`detect-secrets`](https://github.com/Yelp/detect-secrets), or [`trufflehog`](https://github.com/trufflesecurity/trufflehog). A shipped pre-commit hook is on the v0.2 roadmap; until then, the only gate is the one you run locally.
 - **Evidence artifacts**: the evidence-checklist commands write to `evidence/` (gitignored). That directory holds real usernames, credential reports, MFA device states, and privileged-account inventories. Never commit it. If you find it in a PR, reject the PR and ask the contributor to rotate any exposed credentials. For GDPR-scoped work, raw exports may carry personal data subject to Art. 5 minimization and storage-limitation rules: keep only what you need and delete on a schedule.
 

--- a/docs/ENTERPRISE-DEPLOYMENT.md
+++ b/docs/ENTERPRISE-DEPLOYMENT.md
@@ -284,7 +284,7 @@ export ANTHROPIC_MODEL='us.anthropic.claude-sonnet-4-20250514'
 2. Configure authentication
 3. Install the GRC Engineering plugins:
    ```bash
-   /plugin marketplace add ethanolivertroy/claude-grc-engineering
-   /plugin install grc-engineer@ethanolivertroy-plugins
+   /plugin marketplace add GRCEngClub/claude-grc-engineering
+   /plugin install grc-engineer@grc-engineering-suite
    ```
 4. Start using GRC commands with enterprise-grade security!

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,7 +13,7 @@ From zero to your first gap assessment in about 10 minutes. This walkthrough use
 
 ```bash
 # Inside Claude Code
-/plugin marketplace add ethanolivertroy/claude-grc-engineering
+/plugin marketplace add GRCEngClub/claude-grc-engineering
 ```
 
 ## 2. Install the core plugins
@@ -21,9 +21,9 @@ From zero to your first gap assessment in about 10 minutes. This walkthrough use
 You need the engineering hub, one connector, and at least one framework plugin.
 
 ```bash
-/plugin install grc-engineer@ethanolivertroy-plugins
-/plugin install github-inspector@ethanolivertroy-plugins
-/plugin install soc2@ethanolivertroy-plugins
+/plugin install grc-engineer@grc-engineering-suite
+/plugin install github-inspector@grc-engineering-suite
+/plugin install soc2@grc-engineering-suite
 ```
 
 Confirm with:
@@ -127,7 +127,7 @@ Cached findings are reused; only the crosswalk join re-runs.
 
 **Add AWS to the picture**:
 ```bash
-/plugin install aws-inspector@ethanolivertroy-plugins
+/plugin install aws-inspector@grc-engineering-suite
 /aws-inspector:setup
 /aws-inspector:collect --profile=default --region=us-east-1
 /grc-engineer:gap-assessment SOC2,FedRAMP-Moderate --sources=github-inspector,aws-inspector

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
   ],
   "license": "(MIT AND CC-BY-SA-4.0)",
   "licenses": [
-    { "type": "MIT", "url": "https://github.com/ethanolivertroy/claude-grc-engineering/blob/main/LICENSE" },
-    { "type": "CC-BY-SA-4.0", "url": "https://github.com/ethanolivertroy/claude-grc-engineering/blob/main/plugins/frameworks/cis-controls/LICENSE-CIS.md" }
+    { "type": "MIT", "url": "https://github.com/GRCEngClub/claude-grc-engineering/blob/main/LICENSE" },
+    { "type": "CC-BY-SA-4.0", "url": "https://github.com/GRCEngClub/claude-grc-engineering/blob/main/plugins/frameworks/cis-controls/LICENSE-CIS.md" }
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ethanolivertroy/claude-grc-engineering.git"
+    "url": "git+https://github.com/GRCEngClub/claude-grc-engineering.git"
   },
-  "homepage": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "homepage": "https://github.com/GRCEngClub/claude-grc-engineering",
   "bugs": {
-    "url": "https://github.com/ethanolivertroy/claude-grc-engineering/issues"
+    "url": "https://github.com/GRCEngClub/claude-grc-engineering/issues"
   },
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "dependencies": {
     "dotenv": "^16.4.5",
     "js-yaml": "^4.1.1",

--- a/plugins/connectors/aws-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/aws-inspector/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "aws-inspector",
   "version": "0.1.0",
   "description": "GRC connector for AWS: evaluates IAM, S3, CloudTrail, EBS, and RDS for compliance misconfigurations. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "aws", "scf", "soc2", "fedramp", "connector"]
 }

--- a/plugins/connectors/gcp-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/gcp-inspector/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "gcp-inspector",
   "version": "0.1.0",
   "description": "GRC connector for Google Cloud: evaluates IAM, Cloud Storage, audit logs, KMS rotation, and Compute for compliance misconfigurations. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "gcp", "google-cloud", "scf", "fedramp", "connector"]
 }

--- a/plugins/connectors/github-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/github-inspector/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "github-inspector",
   "version": "0.1.0",
   "description": "GRC connector for GitHub: evaluates repo protections, branch policies, Actions, secret scanning, Dependabot, and deploy keys. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "github", "scf", "soc2", "connector"]
 }

--- a/plugins/connectors/github-inspector/commands/setup.md
+++ b/plugins/connectors/github-inspector/commands/setup.md
@@ -44,7 +44,7 @@ None. Reads from the environment:
 ```
 github-inspector:setup ✓
   gh version:       2.59.0
-  authenticated as: ethanolivertroy
+  authenticated as: octocat
   config written:   ~/.config/claude-grc/connectors/github-inspector.yaml
 
 Next: /github-inspector:collect --scope=@me

--- a/plugins/connectors/github-inspector/commands/status.md
+++ b/plugins/connectors/github-inspector/commands/status.md
@@ -19,7 +19,7 @@ bash plugins/connectors/github-inspector/scripts/status.sh
 github-inspector
   status:         ready
   gh:             /usr/local/bin/gh v2.59.0
-  auth:           valid (ethanolivertroy, scopes: repo,read:org)
+  auth:           valid (octocat, scopes: repo,read:org)
   config:         ~/.config/claude-grc/connectors/github-inspector.yaml
   scope:          @me
   last run:       2 hours ago (run_id 20260413-a1b2c3d4)

--- a/plugins/connectors/okta-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/okta-inspector/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "okta-inspector",
   "version": "0.1.0",
   "description": "GRC connector for Okta: evaluates authentication policies, MFA enrollment, password policy, session management, and admin/privileged accounts. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "okta", "identity", "iam", "scf", "fedramp", "connector"]
 }

--- a/plugins/fedramp-ssp/.claude-plugin/plugin.json
+++ b/plugins/fedramp-ssp/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "fedramp-ssp",
   "version": "0.1.0",
   "description": "Convert FedRAMP Rev 5 Moderate SSP DOCX templates to validated OSCAL 1.2.0 JSON. Wraps ethanolivertroy/frdocx-to-froscal-ssp — ready for oscal-cli, Compliance Trestle, eMASS, and FedRAMP 20X workflows.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["fedramp", "oscal", "ssp", "docx", "compliance-as-code"]
 }

--- a/plugins/fedramp-ssp/scripts/convert.sh
+++ b/plugins/fedramp-ssp/scripts/convert.sh
@@ -68,7 +68,7 @@ frdocx_to_froscal.py, convert.py, src/main.py, or a __main__.py.
 Fix:
   - Inspect $TOOL_DIR/README.md for the current invocation.
   - Run the pipeline manually once; the plugin calls 'python <entrypoint>'.
-  - Or file an issue at ethanolivertroy/claude-grc-engineering.
+  - Or file an issue at GRCEngClub/claude-grc-engineering.
 EOF
   exit 5
 fi

--- a/plugins/frameworks/cis-controls/.claude-plugin/plugin.json
+++ b/plugins/frameworks/cis-controls/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "cis-controls",
   "description": "CIS Controls v8 Plugin - Center for Internet Security baseline with IG1/IG2/IG3 implementation groups and 153 safeguards",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "CC-BY-SA-4.0 AND MIT",
   "license_note": "CIS-derived content (commands, skills) is CC BY-SA 4.0 per the upstream CIS Controls license. Original glue code is MIT. See LICENSE-CIS.md."
 }

--- a/plugins/frameworks/cis-controls/LICENSE-CIS.md
+++ b/plugins/frameworks/cis-controls/LICENSE-CIS.md
@@ -50,4 +50,4 @@ If you're unsure whether a contribution falls under CC BY-SA or MIT, bias toward
 ## Questions?
 
 - CIS Controls licensing: https://www.cisecurity.org/controls/v8
-- This plugin's licensing: open an issue at https://github.com/ethanolivertroy/claude-grc-engineering
+- This plugin's licensing: open an issue at https://github.com/GRCEngClub/claude-grc-engineering

--- a/plugins/frameworks/cmmc/.claude-plugin/plugin.json
+++ b/plugins/frameworks/cmmc/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "CMMC v2.0 Plugin - Cybersecurity Maturity Model Certification for DoD contractors with 5 levels and C3PAO assessment prep",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/csa-ccm/.claude-plugin/plugin.json
+++ b/plugins/frameworks/csa-ccm/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "csa-ccm",
   "description": "CSA CCM Plugin - Cloud Security Alliance Cloud Controls Matrix with 197 controls and CAIQ support",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/dora/.claude-plugin/plugin.json
+++ b/plugins/frameworks/dora/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dora",
   "description": "DORA Plugin - EU Digital Operational Resilience Act for financial entities with ICT risk management (effective January 2025)",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/essential8/.claude-plugin/plugin.json
+++ b/plugins/frameworks/essential8/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "essential8",
   "description": "Essential 8 Plugin - Australian Cyber Security Centre mitigation strategies with 3 maturity levels",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/fedramp-20x/.claude-plugin/plugin.json
+++ b/plugins/frameworks/fedramp-20x/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "FedRAMP 20X Plugin - Modern automated authorization with Key Security Indicators (KSIs), continuous monitoring, and machine-readable policies synced from official FedRAMP docs",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/fedramp-rev5/.claude-plugin/plugin.json
+++ b/plugins/frameworks/fedramp-rev5/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "FedRAMP Rev 5 Plugin - Traditional authorization path with SSP/SAP/SAR/POA&M documentation and NIST 800-53 Rev 5 control mapping",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/gdpr/.claude-plugin/plugin.json
+++ b/plugins/frameworks/gdpr/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "gdpr",
   "description": "GDPR Plugin - EU General Data Protection Regulation with DPIA, data subject rights, and 72-hour breach notification",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/glba/.claude-plugin/plugin.json
+++ b/plugins/frameworks/glba/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "glba",
   "description": "GLBA Plugin - Gramm-Leach-Bliley Act for financial institutions with Safeguards Rule and Privacy Rule compliance",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/hitrust/.claude-plugin/plugin.json
+++ b/plugins/frameworks/hitrust/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "HITRUST CSF Plugin - Healthcare Information Trust Alliance Common Security Framework with i1/r2 assessments and 156 controls",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/irap/.claude-plugin/plugin.json
+++ b/plugins/frameworks/irap/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "Australian IRAP (ISM + Essential Eight) for government cloud",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/ismap/.claude-plugin/plugin.json
+++ b/plugins/frameworks/ismap/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "Japanese ISMAP government cloud security (ISO 27001/27017/27018)",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/iso27001/.claude-plugin/plugin.json
+++ b/plugins/frameworks/iso27001/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "ISO 27001 Plugin - Annex A controls, ISMS implementation guidance, and certification support",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/nist-800-53/.claude-plugin/plugin.json
+++ b/plugins/frameworks/nist-800-53/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "NIST 800-53 Plugin - Control families, baseline selection (Low/Moderate/High), and FedRAMP alignment",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/nydfs/.claude-plugin/plugin.json
+++ b/plugins/frameworks/nydfs/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nydfs",
   "description": "NYDFS 23 NYCRR 500 Plugin - New York Department of Financial Services cybersecurity requirements with annual certification",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/pbmm/.claude-plugin/plugin.json
+++ b/plugins/frameworks/pbmm/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "Canadian PBMM (Protected B Medium Medium) with ITSG-33 controls",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/pci-dss/.claude-plugin/plugin.json
+++ b/plugins/frameworks/pci-dss/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "PCI DSS v4.0.1 Plugin - Payment Card Industry compliance with ROC guidance, SAQ selection, and March 2025 mandatory requirements",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/soc2/.claude-plugin/plugin.json
+++ b/plugins/frameworks/soc2/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "SOC 2 Compliance Plugin - Trust Service Criteria expertise, Type I/II assessment support, and control mapping",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/stateramp/.claude-plugin/plugin.json
+++ b/plugins/frameworks/stateramp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "stateramp",
   "description": "StateRAMP Plugin - State Risk and Authorization Management Program for state and local government cloud services",
   "version": "0.1.0",
-  "author": {"name": "Ethan Troy"},
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/frameworks/us-export/.claude-plugin/plugin.json
+++ b/plugins/frameworks/us-export/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "US Export Controls Plugin - ITAR and EAR compliance for defense and dual-use technologies",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/grc-auditor/.claude-plugin/plugin.json
+++ b/plugins/grc-auditor/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "GRC Auditor Plugin - Evidence review, control validation, and audit workpaper generation for external auditors and assessors",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/grc-engineer/.claude-plugin/plugin.json
+++ b/plugins/grc-engineer/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "GRC Engineering Plugin - Maps IaC to compliance controls, generates policies, collects evidence, reviews PRs for compliance, and transforms risks to Jira tickets",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/grc-engineer/commands/pipeline-status.md
+++ b/plugins/grc-engineer/commands/pipeline-status.md
@@ -20,7 +20,7 @@ CLAUDE-GRC PIPELINE STATUS (2026-04-13 15:04 UTC)
 
 github-inspector
   status:         ready
-  auth:           valid (ethanolivertroy, scopes: repo,read:org)
+  auth:           valid (octocat, scopes: repo,read:org)
   last run:       3h ago
   cached:         127 resources, 512 evaluations
   rate limit:     4872/5000 remaining

--- a/plugins/grc-engineer/scripts/gap-assessment.js
+++ b/plugins/grc-engineer/scripts/gap-assessment.js
@@ -528,7 +528,7 @@ function toSarif(r) {
     $schema: 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
     version: '2.1.0',
     runs: [{
-      tool: { driver: { name: 'claude-grc-engineering', version: '0.1.0', informationUri: 'https://github.com/ethanolivertroy/claude-grc-engineering' } },
+      tool: { driver: { name: 'claude-grc-engineering', version: '0.1.0', informationUri: 'https://github.com/GRCEngClub/claude-grc-engineering' } },
       invocations: [{ startTimeUtc: r.generated_at, endTimeUtc: r.generated_at }],
       results
     }]

--- a/plugins/grc-internal/.claude-plugin/plugin.json
+++ b/plugins/grc-internal/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "GRC Internal Plugin - Policy management, risk registers, and compliance tracking for internal GRC teams",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/grc-tprm/.claude-plugin/plugin.json
+++ b/plugins/grc-tprm/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "GRC Third-Party Risk Management Plugin - Vendor assessments, questionnaire analysis, and risk scoring",
   "version": "0.1.0",
   "author": {
-    "name": "Ethan Troy"
+    "name": "GRC Engineering Club Contributors"
   },
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "license": "MIT"
 }

--- a/plugins/oscal/.claude-plugin/plugin.json
+++ b/plugins/oscal/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "oscal",
   "version": "0.1.0",
   "description": "OSCAL (Open Security Controls Assessment Language) toolkit for Claude Code. Wraps ethanolivertroy/oscal-cli for validation and conversion of catalogs, profiles, SSPs, SAPs, SARs, POA&Ms, component definitions, and assessment results.",
-  "author": "Ethan Troy",
+  "author": "GRC Engineering Club Contributors",
   "license": "MIT",
-  "repository": "https://github.com/ethanolivertroy/claude-grc-engineering",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["oscal", "fedramp", "grc", "compliance", "nist"]
 }

--- a/schemas/finding.schema.json
+++ b/schemas/finding.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/ethanolivertroy/claude-grc-engineering/schemas/finding.schema.json",
+  "$id": "https://github.com/GRCEngClub/claude-grc-engineering/schemas/finding.schema.json",
   "title": "GRC Finding",
   "description": "Canonical output contract for claude-grc-engineering connectors. One document per resource-evaluation batch. See docs/ARCHITECTURE.md for the pipeline model.",
   "type": "object",


### PR DESCRIPTION
## Summary

Rewrites the README and top-level docs in community/Club voice. Stacked on #4 (ownership rebrand).

- **README**: drops the founder's first-person opener for a Club-framed lead (*"The official open-source GRC toolkit from the GRC Engineering Club — turning checkbox compliance into engineered systems"*). Design-positions section (SCF backbone, thin connectors, no verbatim standards) keeps its bite in toolkit voice. New **Community** section with contribution paths. New **Maintainers** section with bios for both co-leads: AJ Yawn (@ajy0127) and Ethan Troy (@ethanolivertroy). "Related tools I built" renamed to "Adjacent open-source tools" with an explicit note those aren't Club-governed.
- **docs/CONTRIBUTING.md**: adds *First-time contributors* path and a *Recognition* section pointing at the all-contributors bot. Security section now links a GitHub private advisory instead of an email-first flow.
- **docs/ARCHITECTURE.md**: neutralizes two remaining "I" references to the toolkit.
- **CLAUDE.md**: corrects plugin count (25 → 30), adds Club framing.

## Dependencies

Stacked on #4 (ownership rebrand). Merge #4 first, then rebase/retarget this to `main`.

## Known gaps

README and CONTRIBUTING now reference `GOVERNANCE.md`, `MAINTAINERS.md`, `SECURITY.md`, and `CONTRIBUTORS.md` which land in a follow-up community-scaffolding PR. These links 404 until that PR merges.

## Test plan

- [ ] Render README at HEAD — no broken markdown, no first-person voice outside the bio section.
- [ ] Every link in the new README and docs resolves (or is expected to 404 per the known-gaps note above).
- [ ] `/plugin marketplace add GRCEngClub/claude-grc-engineering` copy-paste still works from the new README.