### PR TITLE
[codex] Add PR2 community scaffolding

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,88 @@
+{
+  "projectName": "claude-grc-engineering",
+  "projectOwner": "GRCEngClub",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "CONTRIBUTORS.md"
+  ],
+  "imageSize": 100,
+  "contributorsPerLine": 6,
+  "commit": false,
+  "skipCi": true,
+  "contributors": [
+    {
+      "login": "ajy0127",
+      "name": "AJ Yawn",
+      "avatar_url": "https://github.com/ajy0127.png?size=100",
+      "profile": "https://github.com/ajy0127",
+      "contributions": [
+        "maintenance",
+        "ideas",
+        "content"
+      ]
+    },
+    {
+      "login": "ethanolivertroy",
+      "name": "Ethan Troy",
+      "avatar_url": "https://github.com/ethanolivertroy.png?size=100",
+      "profile": "https://github.com/ethanolivertroy",
+      "contributions": [
+        "projectManagement",
+        "code",
+        "doc",
+        "maintenance"
+      ]
+    }
+  ],
+  "types": {
+    "code": {
+      "symbol": "💻",
+      "description": "Code"
+    },
+    "doc": {
+      "symbol": "📖",
+      "description": "Documentation"
+    },
+    "review": {
+      "symbol": "👀",
+      "description": "Reviewed pull requests"
+    },
+    "question": {
+      "symbol": "💬",
+      "description": "Answered questions"
+    },
+    "ideas": {
+      "symbol": "🤔",
+      "description": "Ideas, planning, and feedback"
+    },
+    "infra": {
+      "symbol": "🚇",
+      "description": "Infrastructure"
+    },
+    "content": {
+      "symbol": "🖋",
+      "description": "Content"
+    },
+    "bug": {
+      "symbol": "🐛",
+      "description": "Bug reports"
+    },
+    "example": {
+      "symbol": "💡",
+      "description": "Examples"
+    },
+    "test": {
+      "symbol": "⚠️",
+      "description": "Tests"
+    },
+    "maintenance": {
+      "symbol": "🚧",
+      "description": "Maintenance"
+    },
+    "projectManagement": {
+      "symbol": "📆",
+      "description": "Project management"
+    }
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,15 @@
-# Default ownership
-* @GRCEngClub/GRC-Eng-Leadership-Team
+# CODEOWNERS — GRC Engineering Club leadership team reviews everything by default.
+# See GOVERNANCE.md for the decision model and path to maintainership.
 
-# Sensitive contract and licensing areas
-/schemas/** @GRCEngClub/GRC-Eng-Leadership-Team
-/plugins/frameworks/cis-controls/** @GRCEngClub/GRC-Eng-Leadership-Team
+*                                       @GRCEngClub/grc-eng-leadership-team
+
+# Critical contracts and sensitive licensing — always reviewed by leadership.
+/schemas/                               @GRCEngClub/grc-eng-leadership-team
+/plugins/frameworks/cis-controls/       @GRCEngClub/grc-eng-leadership-team
+/LICENSE                                @GRCEngClub/grc-eng-leadership-team
+/.claude-plugin/marketplace.json        @GRCEngClub/grc-eng-leadership-team
+
+# CI and automation — changes affect every PR, so leadership reviews.
+/.github/                               @GRCEngClub/grc-eng-leadership-team
+/.markdownlint-cli2.jsonc               @GRCEngClub/grc-eng-leadership-team
+/lychee.toml                            @GRCEngClub/grc-eng-leadership-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Default ownership
+* @GRCEngClub/GRC-Eng-Leadership-Team
+
+# Sensitive contract and licensing areas
+/schemas/** @GRCEngClub/GRC-Eng-Leadership-Team
+/plugins/frameworks/cis-controls/** @GRCEngClub/GRC-Eng-Leadership-Team

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# Add the Club's preferred public funding channels here when they are ready.
+custom: []

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Report a defect in a plugin, schema, workflow, or documentation path.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the toolkit. Please include enough detail for
+        a maintainer to reproduce the problem without guessing.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the bug and the impact it had on your work.
+      placeholder: The connector collected findings, but the generated JSON failed schema validation...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Share the smallest repeatable sequence that shows the problem.
+      placeholder: |
+        1. Run ...
+        2. Use ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect instead?
+      placeholder: The command should have emitted schema-valid findings and exited 0.
+    validations:
+      required: true
+
+  - type: input
+    id: area
+    attributes:
+      label: Affected area
+      description: Name the plugin, schema, script, or doc page involved.
+      placeholder: connectors/github-inspector, schemas/finding.schema.json, README.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: Include OS, shell, Node version, Claude Code version, and any relevant external tool versions.
+      render: shell
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or failing output
+      description: Paste sanitized output. Remove secrets and internal-only data before submitting.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/GRCEngClub/claude-grc-engineering/discussions
+    about: Ask open-ended questions, workshop ideas, or get help choosing the right contribution path.
+  - name: Security policy
+    url: https://github.com/GRCEngClub/claude-grc-engineering/blob/main/SECURITY.md
+    about: Please review the private reporting process for vulnerabilities before opening anything public.

--- a/.github/ISSUE_TEMPLATE/connector_request.yml
+++ b/.github/ISSUE_TEMPLATE/connector_request.yml
@@ -1,0 +1,70 @@
+name: Connector request
+description: Propose a new connector or an expansion of an existing connector.
+title: "[Connector]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Connector requests are strongest when they show a real tool, a clear
+        auth story, and a path to schema-valid Findings.
+
+  - type: input
+    id: tool_name
+    attributes:
+      label: Tool or platform
+      placeholder: Azure, Datadog, ServiceNow, CrowdStrike...
+    validations:
+      required: true
+
+  - type: input
+    id: cli_sdk
+    attributes:
+      label: CLI or SDK availability
+      description: Link the CLI or SDK that the connector would wrap.
+      placeholder: https://learn.microsoft.com/cli/azure/
+    validations:
+      required: true
+
+  - type: textarea
+    id: auth_model
+    attributes:
+      label: Authentication model
+      description: Explain how users would authenticate without inventing a new secret store.
+      placeholder: Existing CLI profile, OAuth token, service account, API token in env var...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: connector_tier
+    attributes:
+      label: Priority tier
+      description: Pick the best fit for the request.
+      options:
+        - Tier-1 candidate
+        - Tier-2 candidate
+        - Not sure yet
+    validations:
+      required: true
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Why does this belong in the toolkit?
+      description: Explain the user problem, the audience, and why the connector should exist here instead of as a one-off script.
+    validations:
+      required: true
+
+  - type: textarea
+    id: output_shape
+    attributes:
+      label: Expected findings or control coverage
+      description: Describe the kinds of checks, data, or controls this connector can evaluate well.
+      placeholder: Access reviews, MFA coverage, branch protection, vulnerability findings...
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References or prior art
+      description: Share docs, sample output, or related open-source tooling if available.

--- a/.github/ISSUE_TEMPLATE/framework_request.yml
+++ b/.github/ISSUE_TEMPLATE/framework_request.yml
@@ -1,0 +1,61 @@
+name: Framework request
+description: Propose a new framework plugin or a major gap in an existing framework plugin.
+title: "[Framework]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Framework plugins should rely on SCF crosswalks and implementation
+        guidance, not verbatim standard text.
+
+  - type: input
+    id: framework_name
+    attributes:
+      label: Framework or baseline
+      placeholder: HIPAA, APRA CPS 234, MAS TRM, FedRAMP Low...
+    validations:
+      required: true
+
+  - type: input
+    id: issuer
+    attributes:
+      label: Issuing body
+      placeholder: HHS, APRA, MAS, FedRAMP PMO...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: licensing
+    attributes:
+      label: Licensing or access model
+      options:
+        - Publicly available
+        - Publicly available with attribution requirements
+        - Licensed or paywalled
+        - Not sure yet
+    validations:
+      required: true
+
+  - type: input
+    id: baselines
+    attributes:
+      label: Target baselines, profiles, or maturity levels
+      description: Name the versions or profiles that matter first.
+      placeholder: FedRAMP Low Rev. 5, CPS 234 core requirements, MAS TRM 2021...
+
+  - type: textarea
+    id: scf_status
+    attributes:
+      label: SCF crosswalk status
+      description: Tell us whether SCF already maps this framework or whether that mapping work is still missing.
+      placeholder: SCF appears to cover..., SCF gap unknown..., custom mapping likely needed...
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Why is this framework important for the community?
+      description: Share the real-world audience, geography, or customer pressure behind the request.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/plugin_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_proposal.yml
@@ -1,0 +1,77 @@
+name: Plugin proposal
+description: Propose a plugin in a new or expanding category such as reporting, dashboards, transforms, programs, or meetings.
+title: "[Plugin]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for Architecture v2 ideas that are not simply a new
+        connector or framework plugin.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Proposed category
+      options:
+        - Reporting
+        - Dashboards
+        - Document transformation
+        - Program management
+        - Meetings
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: command_name
+    attributes:
+      label: Proposed command or plugin name
+      placeholder: /report:executive-summary, /dashboard:standup, /program:risk-register
+    validations:
+      required: true
+
+  - type: dropdown
+    id: persona
+    attributes:
+      label: Primary persona or audience
+      options:
+        - grc-engineer
+        - grc-auditor
+        - grc-internal
+        - grc-tprm
+        - Executive / leadership audience
+        - Multi-persona
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the workflow gap and why current plugins do not cover it cleanly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: inputs
+    attributes:
+      label: Expected inputs
+      description: List the data or artifacts the plugin would consume.
+      placeholder: Findings JSON, metrics time-series, risk register entries, markdown policies...
+    validations:
+      required: true
+
+  - type: textarea
+    id: outputs
+    attributes:
+      label: Expected outputs
+      description: Describe what the plugin should produce and who would consume it.
+      placeholder: Markdown brief, PDF, PPTX, updated YAML state, terminal dashboard...
+    validations:
+      required: true
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: References, mockups, or similar workflows
+      description: Share examples, screenshots, or tools that illustrate the shape of the idea.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## Summary
+
+Describe the user problem this change solves and the main approach you took.
+
+## Type of change
+
+- [ ] Connector
+- [ ] Framework plugin
+- [ ] Persona plugin
+- [ ] Documentation
+- [ ] Community / governance
+- [ ] CI / automation
+- [ ] Other
+
+## Schema impact
+
+- [ ] No schema changes
+- [ ] `schemas/finding.schema.json` changed
+- [ ] Another schema or contract surface changed
+
+If there is a schema impact, explain the compatibility story and any migration
+notes.
+
+## Test plan
+
+List the commands, fixtures, or manual checks you ran.
+
+```text
+Paste command output here.
+```
+
+## CHANGELOG
+
+- [ ] No CHANGELOG entry needed
+- [ ] I added a CHANGELOG entry
+- [ ] A maintainer should add the CHANGELOG entry during merge
+
+## Notes for reviewers
+
+Call out risk areas, follow-up work, or any context that will help reviewers
+move quickly.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of the GRC Engineering Club
+community pledge to make participation in `claude-grc-engineering` a
+harassment-free experience for everyone, regardless of age, body size,
+disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Showing empathy and patience with other community members
+- Giving and receiving constructive feedback with respect
+- Assuming good intent while still naming concrete problems clearly
+- Sharing context, references, and examples that help others succeed
+- Taking responsibility for mistakes and learning from them
+- Focusing on what is best for the project and the broader community
+
+Examples of unacceptable behavior include:
+
+- Sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Sustained disruption of discussions, reviews, or community events
+- Other conduct that could reasonably be considered inappropriate in a
+  professional community setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior. They may remove, edit, or reject comments, commits, code,
+wiki edits, issues, and other contributions that are not aligned with this Code
+of Conduct, and they will communicate reasons for moderation decisions when
+appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and any public or
+private communication channels where someone is representing the project or the
+GRC Engineering Club community. This includes GitHub repositories, issues, pull
+requests, discussions, live events, and related social channels.
+
+## Reporting
+
+If you experience or witness behavior that violates this Code of Conduct,
+report it to the leadership team at `conduct@grcengclub.com`.
+
+If that alias is not yet active, contact a maintainer listed in
+`MAINTAINERS.md` privately and clearly mark the message as a conduct report.
+
+All reports will be reviewed promptly and handled with care. The leadership
+team will respect the privacy and security of the reporter to the extent
+possible.
+
+## Enforcement Guidelines
+
+When leaders determine that a violation occurred, they will use consequences
+they believe are proportionate to the behavior. Possible responses include:
+
+1. Private feedback and a request to change course
+2. A warning describing what behavior must stop
+3. Temporary or permanent removal from specific community spaces
+4. Temporary or permanent bans from the project or Club-managed channels
+
+## Attribution
+
+This Code of Conduct is informed by the Contributor Covenant, version 2.1, and
+adapted for the GRC Engineering Club community.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,51 @@
+# Contributors
+
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
+This project follows the [all-contributors](https://allcontributors.org)
+specification to recognize community work across code, docs, maintenance,
+review, ideas, content, and project stewardship.
+
+After a contribution lands, a maintainer can recognize it with:
+
+```text
+@all-contributors please add @username for code,doc
+```
+
+Thanks goes to these wonderful people
+([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/ajy0127">
+        <img src="https://github.com/ajy0127.png?size=100" width="100px;" alt="AJ Yawn"/>
+        <br />
+        <sub><b>AJ Yawn</b></sub>
+      </a>
+      <br />
+      <a href="#maintenance-ajy0127" title="Maintenance">🚧</a>
+      <a href="#ideas-ajy0127" title="Ideas, Planning, and Feedback">🤔</a>
+      <a href="#content-ajy0127" title="Content">🖋</a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/ethanolivertroy">
+        <img src="https://github.com/ethanolivertroy.png?size=100" width="100px;" alt="Ethan Troy"/>
+        <br />
+        <sub><b>Ethan Troy</b></sub>
+      </a>
+      <br />
+      <a href="#projectManagement-ethanolivertroy" title="Project Management">📆</a>
+      <a href="#code-ethanolivertroy" title="Code">💻</a>
+      <a href="#doc-ethanolivertroy" title="Documentation">📖</a>
+      <a href="#maintenance-ethanolivertroy" title="Maintenance">🚧</a>
+    </td>
+  </tr>
+</table>
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+The leadership team maintains this file through the bot workflow and the
+configuration in `.all-contributorsrc`.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,60 @@
+# Governance
+
+`claude-grc-engineering` is the official open-source toolkit of the GRC
+Engineering Club. This document explains how we make decisions, who stewards
+the repository, and how contributors can grow into maintainership.
+
+## Leadership team
+
+The project is co-led by AJ Yawn and Ethan Troy through
+`@GRCEngClub/GRC-Eng-Leadership-Team`.
+
+The leadership team is responsible for:
+
+- Setting the direction of the toolkit and approving major roadmap changes
+- Approving changes to governance, licensing, security policy, and CODEOWNERS
+- Resolving contested technical or community decisions
+- Appointing and rotating maintainers as the project grows
+
+## Decision process
+
+We default to lazy consensus for routine work:
+
+- Open the work in a pull request, issue, or discussion
+- Leave reasonable space for review and objections
+- Merge once a maintainer approves and no substantive objections remain
+
+When consensus does not emerge, the leadership team makes the final call. For
+changes that affect schemas, licensing, governance, security, or sensitive
+framework content, leadership-team approval is required before merge.
+
+## Maintainers
+
+Maintainers are trusted contributors who help review pull requests, triage
+issues, guide new contributors, and keep the project aligned with Club goals.
+The current maintainer roster lives in `MAINTAINERS.md`.
+
+Maintainers are expected to:
+
+- Review contributions with empathy and technical rigor
+- Protect the project contract, especially schema stability and licensing rules
+- Escalate governance, security, or conduct concerns quickly
+- Help contributors understand feedback and move work across the finish line
+
+## Path to maintainership
+
+Contributors can be nominated for maintainership after demonstrating sustained,
+high-quality participation. Our default bar is:
+
+- At least three meaningful pull requests over time
+- Consistent collaboration in issues, reviews, or discussions
+- Evidence of good judgment around the project's quality and community norms
+- Nomination by an existing maintainer and approval by the leadership team
+
+Maintainership is a stewardship role, not just a merge permission.
+
+## History
+
+The toolkit was founded by Ethan Troy in 2025 and contributed to the GRC
+Engineering Club in 2026. The Club now owns the project and stewards it as a
+community-maintained open-source toolkit.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,7 +7,7 @@ the repository, and how contributors can grow into maintainership.
 ## Leadership team
 
 The project is co-led by AJ Yawn and Ethan Troy through
-`@GRCEngClub/GRC-Eng-Leadership-Team`.
+`@GRCEngClub/grc-eng-leadership-team`.
 
 The leadership team is responsible for:
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,23 @@
+# Maintainers
+
+The GRC Engineering Club leadership team is the initial maintainer group for
+`claude-grc-engineering`. Maintainers steward releases, review contributions,
+triage community work, and handle sensitive repository areas such as schemas,
+licensing, governance, and security response.
+
+## Current maintainers
+
+| Maintainer | GitHub | Typical coverage | Areas of focus | Preferred contact |
+| --- | --- | --- | --- | --- |
+| AJ Yawn | [`@ajy0127`](https://github.com/ajy0127) | North America, async-friendly | Club direction, GRC engineering practice, reporting and program-management workflows, community growth | GitHub Issues or Discussions for public collaboration; private maintainer outreach for conduct or security matters |
+| Ethan Troy | [`@ethanolivertroy`](https://github.com/ethanolivertroy) | America/New_York, async-friendly | Toolkit architecture, OSCAL workflows, framework mapping, connector design, schema stewardship | GitHub Issues or Discussions for public collaboration; private maintainer outreach for conduct or security matters |
+
+## Maintainer notes
+
+**AJ Yawn** is the founder of the GRC Engineering Club and a GRC Engineering
+Lead at NR Labs. He brings an engineering-first compliance philosophy and helps
+shape the community direction of the toolkit.
+
+**Ethan Troy** founded the toolkit and previously worked as a 3PAO FedRAMP
+assessor. He focuses on framework translation, OSCAL workflows, and practical
+connector patterns that turn evidence into reusable GRC engineering artifacts.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,73 @@
+# Roadmap
+
+This roadmap tracks the next layer of community and product work for the GRC
+Engineering Club toolkit. It is directional, not a promise of exact ordering.
+
+## Near-term platform work
+
+- Complete the community foundation: governance, maintainers, contributor
+  recognition, issue templates, and CODEOWNERS
+- Add contract, markdown, link-check, and contributor-automation workflows
+- Seed good first issues that help new contributors land meaningful work
+
+## Tier-2 connector expansion
+
+Priority candidates for new connector scaffolds:
+
+- Azure
+- Slack
+- Duo
+- Zoom
+- Webex
+- Salesforce
+- Datadog
+- Splunk
+- Sumo Logic
+- New Relic
+- Elastic
+- Tenable
+- Qualys
+- Veracode
+- CrowdStrike
+- Palo Alto
+- Zscaler
+- Snowflake
+- Box
+- ServiceNow
+- PagerDuty
+- Zendesk
+- LaunchDarkly
+- MuleSoft
+- KnowBe4
+
+## Framework gaps
+
+High-value framework additions called out in planning:
+
+- HIPAA
+- APRA CPS 234
+- MAS TRM
+- FedRAMP Low
+
+## Architecture v2 categories
+
+The toolkit is expanding beyond framework-centric workflows. The current RFC
+lives in [`docs/ARCHITECTURE-V2-RFC.md`](docs/ARCHITECTURE-V2-RFC.md) and
+proposes these new categories:
+
+- Reporting
+- Dashboards
+- Document transformation
+- Program management
+- Meetings
+
+## Schema v1.1 candidates
+
+Potential contract work after the current schema baseline stabilizes:
+
+- Stronger provenance fields for connector source, tool version, and collection
+  timestamps
+- Better evidence references for generated artifacts and supporting materials
+- Optional ownership or routing metadata for findings and exceptions
+- Companion schemas for metrics, risks, exceptions, vendors, and policy
+  lifecycle data

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not open public GitHub issues for security vulnerabilities.
+
+Use one of these private channels instead:
+
+1. Open a private GitHub security advisory:
+   `https://github.com/GRCEngClub/claude-grc-engineering/security/advisories/new`
+2. If you cannot use GitHub advisories, email `security@grcengclub.com`
+3. If that alias is not yet active, contact a maintainer privately and note
+   that the message is a security report
+
+When you report a vulnerability, please include:
+
+- A short summary of the issue and the affected surface
+- Steps to reproduce or validate the problem
+- Any proof-of-concept material that helps us confirm impact safely
+- Suggested mitigations, if you have them
+
+## What to expect
+
+We will acknowledge new reports as quickly as possible, coordinate validation,
+and work with reporters on a responsible disclosure timeline. We may ask for
+extra reproduction detail or environment context before we publish a fix.
+
+## Supported versions
+
+| Version | Supported |
+| --- | --- |
+| `main` | Yes |
+| Earlier releases | Best effort only |
+
+## Secure contribution expectations
+
+For everyday contribution guidance, secure handling of evidence artifacts, and
+secret-scanning expectations, see the Security section in
+`docs/CONTRIBUTING.md`.


### PR DESCRIPTION
## What changed

This PR adds the PR2 community scaffolding for the GRC Engineering Club handoff:

- adds root community docs for code of conduct, contributors, governance, maintainers, security, and roadmap
- seeds all-contributors configuration with AJ Yawn and Ethan Troy
- adds GitHub issue forms for bugs, connector requests, framework requests, and Architecture v2 plugin proposals
- adds a pull request template, CODEOWNERS, and funding placeholder

## Why

The repo had the ownership and architecture planning work underway, but it was still missing the community-operating scaffolding described in the handoff plan. These files establish the basic contribution, review, and stewardship surface needed before wider community growth.

## Impact

- contributors get clear contribution paths and structured issue intake
- maintainers get CODEOWNERS coverage and a seeded maintainer/governance model
- the Club gets a baseline all-contributors workflow and public-facing community docs

## Validation

- parsed `.all-contributorsrc` with Node
- parsed all `.github/**/*.yml` files with Ruby YAML
- confirmed the PR is isolated to the new PR2 scaffolding files

## Notes

- `conduct@grcengclub.com` and `security@grcengclub.com` are assumed aliases and may need follow-up if the Club wants different routing
- `.github/FUNDING.yml` is intentionally a placeholder until the Club decides on a public funding channel
