### PR TITLE
chore: remove temporary RFC exclusion from lychee

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -28,8 +28,6 @@ exclude = [
   "^https://github\\.com/ethanolivertroy/frdocx-to-froscal-ssp$",
   # FedRAMP reorganized /resources/templates; dedicated docs pass needed to update affected links
   "^https://www\\.fedramp\\.gov/resources/templates",
-  # ARCHITECTURE-V2-RFC.md lands in PR #7; can remove this exclusion after that merge
-  "ARCHITECTURE-V2-RFC\\.md$",
 ]
 
 exclude_all_private = true


### PR DESCRIPTION
Follow-up cleanup now that #7 (RFC) is on main. docs/ARCHITECTURE-V2-RFC.md exists, so the file:// reference from ROADMAP.md will resolve. Reverts a one-line exclusion added in #6.