### PR TITLE
chore: release v0.0.2 (Club handoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes follow the format from [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+## [0.0.2] — 2026-04-18
+
+This release marks the official handoff of the toolkit to the [GRC Engineering Club](https://grcengclub.com). Content below summarizes the handoff + community scaffolding that landed between 0.0.1 and 0.0.2.
+
+### Added
+
+**Community scaffolding**
+
+- `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1)
+- `CONTRIBUTORS.md` seeded via the all-contributors pattern; AJ Yawn and Ethan Troy listed as co-leads
+- `GOVERNANCE.md` — co-lead governance model, decision process, path to maintainership
+- `MAINTAINERS.md` — leadership team with expertise areas
+- `SECURITY.md` — private advisory-first vulnerability reporting
+- `ROADMAP.md` — Tier-2 connectors, framework gaps, schema v1.1 candidates
+- `.github/ISSUE_TEMPLATE/{bug_report, connector_request, framework_request, plugin_proposal, config}.yml`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/CODEOWNERS` with leadership team ownership and sensitive-file routing
+
+**Continuous integration**
+
+- `.github/workflows/contract-test.yml` — validates every `tests/fixtures/findings/**/*.json` against `schemas/finding.schema.json` v1 on every PR
+- `.github/workflows/markdown-lint.yml` — `markdownlint-cli2` with a docs-aware config
+- `.github/workflows/link-check.yml` — `lychee` on PR and weekly cron
+- `.github/workflows/all-contributors.yml` — contributor-recognition bot wired to PR comments
+- `package.json` gains `test:contract` and `lint:md` scripts plus `ajv-cli` / `markdownlint-cli2` devDependencies
+
+**Architecture v2 RFC**
+
+- `docs/ARCHITECTURE-V2-RFC.md` — design proposal for five new plugin categories (reporting, dashboards, transforms, programs, meetings), sibling schemas for metrics/risks/exceptions/vendors/policies, a new `grc-ciso` persona, and a GitOps-first statefulness model. 2-week community comment window tracked in [#38](https://github.com/GRCEngClub/claude-grc-engineering/issues/38).
+
+**Roadmap seeding**
+
+- Public project board at [github.com/orgs/GRCEngClub/projects/1](https://github.com/orgs/GRCEngClub/projects/1) with custom fields (Category, Difficulty, Target release, Plugin depth, Region) and 29 seeded issues covering 15 framework-plugin gaps, 7 Tier-2 connectors, tooling, docs, and the framework-coverage meta tracker.
+
 ### Changed
 
 **Ownership transfer to GRC Engineering Club**

--- a/docs/ARCHITECTURE-V2-RFC.md
+++ b/docs/ARCHITECTURE-V2-RFC.md
@@ -151,6 +151,7 @@ plugins/
 **Breaking change**: moving persona plugins into `plugins/personas/` changes their path. The marketplace registers plugins by `source` path — marketplace.json must update, and any external references to `plugins/grc-engineer/**` break. This is the sharpest downside of the restructure.
 
 **Mitigation options**:
+
 - (A) Full move + deprecation notice in CHANGELOG v0.3. One clean break.
 - (B) Add symlinks from old paths for one minor version, remove in v0.4. Reduces blast radius for external consumers but complicates tooling.
 - (C) Leave persona plugins at top level; only new categories get new dirs. Less clean but zero breakage.

--- a/lychee.toml
+++ b/lychee.toml
@@ -18,8 +18,9 @@ exclude = [
   "^https://hooks\\.slack\\.com/\\.\\.\\.",
   # LinkedIn gates most profile URLs behind auth
   "^https://(www\\.)?linkedin\\.com",
-  # GitHub org pages that require auth (teams, private org views) bounce to login
+  # GitHub org pages that require auth (teams, private projects) bounce to login or 404
   "^https://github\\.com/orgs/.*/teams/",
+  "^https://github\\.com/orgs/.*/projects/",
   # Some regulator sites return 5xx to scrapers but render fine in browsers
   "^https://www\\.ecfr\\.gov",
   # canada.ca returns HTTP/2 protocol errors to lychee's client; renders fine in browsers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grc-engineering-plugin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "GRC engineering toolkit for Claude Code: connector findings to SCF crosswalk to multi-framework gap reports, policy-as-code, OSCAL workflows.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bumps package.json version 0.0.1 → 0.0.2 and dates the CHANGELOG entry. Summarizes the community-handoff work that landed between 0.0.1 and 0.0.2: ownership transfer, community scaffolding, CI, Architecture v2 RFC, roadmap seeding.

After merge I'll tag v0.0.2 and publish the GitHub release.