### PR TITLE
feat: /grc-engineer:scaffold-framework command + Singapore PDPA demo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -189,6 +189,12 @@
       "source": "./plugins/fedramp-ssp",
       "description": "Convert FedRAMP Rev 5 SSP DOCX templates to validated OSCAL 1.2.0 SSP JSON. Wraps ethanolivertroy/frdocx-to-froscal-ssp.",
       "version": "0.1.0"
+    },
+    {
+      "name": "singapore-pdpa",
+      "source": "./plugins/frameworks/singapore-pdpa",
+      "description": "Singapore - Personal Data Protection Ac (PDPA) (2012) — reference-depth plugin backed by the SCF crosswalk (30 SCF → 14 framework controls).",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/frameworks/singapore-pdpa/.claude-plugin/plugin.json
+++ b/plugins/frameworks/singapore-pdpa/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "singapore-pdpa",
+  "description": "Singapore - Personal Data Protection Ac (PDPA) (2012) — Reference plugin with evidence checklist, scope determination, and SCF-backed gap assessment. Level up to Full by adding framework-specific workflow commands.",
+  "version": "0.1.0",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "framework_metadata": {
+    "scf_framework_id": "apac-sgp-pdpa-2012",
+    "display_name": "Singapore - Personal Data Protection Ac (PDPA) (2012)",
+    "region": "APAC",
+    "country": "SG",
+    "depth": "reference",
+    "scf_controls_mapped": 30,
+    "framework_controls_mapped": 14,
+    "industry": [],
+    "regulator": ""
+  }
+}

--- a/plugins/frameworks/singapore-pdpa/README.md
+++ b/plugins/frameworks/singapore-pdpa/README.md
@@ -15,7 +15,7 @@ This plugin is at **Reference depth** — it provides scope determination, evide
 
 ### Level up to Full
 
-Full depth adds framework-native workflow commands tied to the audit ritual. If you have domain expertise for Singapore - Personal Data Protection Ac (PDPA) (2012), see [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the level-up checklist.
+Full depth adds framework-native workflow commands tied to the audit ritual. If you have domain expertise for Singapore - Personal Data Protection Ac (PDPA) (2012), see the [FRAMEWORK-PLUGIN-GUIDE tracking issue](https://github.com/GRCEngClub/claude-grc-engineering/issues/11) for the level-up checklist.
 
 ## Metadata
 

--- a/plugins/frameworks/singapore-pdpa/README.md
+++ b/plugins/frameworks/singapore-pdpa/README.md
@@ -1,0 +1,34 @@
+# singapore-pdpa — Singapore - Personal Data Protection Ac (PDPA) (2012)
+
+Reference-depth framework plugin. Install and run:
+
+```bash
+/plugin install singapore-pdpa@grc-engineering-suite
+/singapore-pdpa:scope                    # determine applicability first
+/singapore-pdpa:evidence-checklist       # see what to collect
+/singapore-pdpa:assess                   # run the gap assessment
+```
+
+## Status: Reference
+
+This plugin is at **Reference depth** — it provides scope determination, evidence checklist, and a framework-specific gap assessment, all backed by the SCF crosswalk (30 SCF controls → 14 Singapore - Personal Data Protection Ac (PDPA) (2012) controls).
+
+### Level up to Full
+
+Full depth adds framework-native workflow commands tied to the audit ritual. If you have domain expertise for Singapore - Personal Data Protection Ac (PDPA) (2012), see [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the level-up checklist.
+
+## Metadata
+
+| | |
+|---|---|
+| SCF framework ID | `apac-sgp-pdpa-2012` |
+| Region | APAC |
+| Country | SG |
+| SCF controls mapped | 30 |
+| Framework controls mapped | 14 |
+| Depth | Reference |
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com) — crosswalk source (CC BY-ND 4.0)
+- [SCF API entry](https://hackidle.github.io/scf-api/api/crosswalks/apac-sgp-pdpa-2012.json)

--- a/plugins/frameworks/singapore-pdpa/commands/assess.md
+++ b/plugins/frameworks/singapore-pdpa/commands/assess.md
@@ -1,0 +1,45 @@
+---
+description: Singapore - Personal Data Protection Ac (PDPA) (2012) compliance gap assessment
+---
+
+# Singapore - Personal Data Protection Ac (PDPA) (2012) Assessment
+
+Runs a compliance gap assessment against **Singapore - Personal Data Protection Ac (PDPA) (2012)** by delegating to `/grc-engineer:gap-assessment` with the framework's SCF identifier, then overlays framework-specific context and evidence requirements.
+
+## Usage
+
+```
+/singapore-pdpa:assess [--scope=<scope>] [--sources=<connector-list>]
+```
+
+## Arguments
+
+- `--scope=<scope>` (optional) — narrow the assessment to a specific part of the framework. Valid scopes depend on the framework; TODO: enumerate the standard sections/articles of Singapore - Personal Data Protection Ac (PDPA) (2012) here.
+- `--sources=<connector-list>` (optional) — comma-separated connector plugins.
+
+## What the assessment produces
+
+1. **Compliance score** — overall Singapore - Personal Data Protection Ac (PDPA) (2012) readiness percentage, weighted by mapped SCF controls.
+2. **Applicable-requirements summary** — which parts of the framework apply to the organization (see `/singapore-pdpa:scope` to narrow this down first).
+3. **Control-by-control gap** — every 14 mapped control, with pass/fail/inconclusive status from connector findings.
+4. **Evidence gaps** — controls where no evidence source is configured.
+5. **Remediation roadmap** — prioritized by severity and effort.
+
+## Delegation
+
+Under the hood:
+
+```
+/grc-engineer:gap-assessment "apac-sgp-pdpa-2012" [--sources=<connector-list>]
+```
+
+The SCF crosswalk expands 30 SCF controls into the 14 Singapore - Personal Data Protection Ac (PDPA) (2012) controls.
+
+## Framework-specific notes
+
+TODO: replace this section with framework-specific assessment guidance. At Reference depth, include at minimum:
+
+- Which assessment scope is most commonly requested
+- Known interactions with sibling frameworks (e.g. GDPR + UK DPA, or CMMC + NIST 800-171)
+- Any mandatory cadence (annual self-attestation, biennial external audit, etc.)
+- Common misinterpretations in community guidance that this plugin corrects

--- a/plugins/frameworks/singapore-pdpa/commands/evidence-checklist.md
+++ b/plugins/frameworks/singapore-pdpa/commands/evidence-checklist.md
@@ -1,0 +1,35 @@
+---
+description: Evidence checklist for Singapore - Personal Data Protection Ac (PDPA) (2012), organized by control family
+---
+
+# Singapore - Personal Data Protection Ac (PDPA) (2012) Evidence Checklist
+
+Baseline evidence checklist for a Singapore - Personal Data Protection Ac (PDPA) (2012) assessment. The SCF crosswalk maps 30 SCF controls to the 14 Singapore - Personal Data Protection Ac (PDPA) (2012) controls; this command enumerates what evidence tends to be expected for each SCF family that's in scope.
+
+## Usage
+
+```
+/singapore-pdpa:evidence-checklist [--family=<SCF_family_code>]
+```
+
+## Arguments
+
+- `--family=<SCF_family_code>` (optional) — restrict to a single SCF family (e.g. `IAC`, `CRY`, `AST`, `BCD`). Defaults to all families mapped for this framework.
+
+## Output
+
+Markdown checklist grouped by SCF family with:
+
+- SCF control ID → framework-native control ID(s) (from crosswalk)
+- Evidence types typically expected (logs, configs, policy documents, tickets, training records)
+- Which connector plugins can collect each type automatically
+- Which items require manual upload / narrative
+
+## Framework-specific evidence
+
+TODO: at Reference depth, replace this section with framework-specific evidence patterns. Items worth capturing:
+
+- Mandatory artifacts unique to Singapore - Personal Data Protection Ac (PDPA) (2012) (e.g. DPIA for GDPR, ROC for PCI DSS, SSP for FedRAMP)
+- Assessor expectations per control family
+- Retention periods required by the regulator
+- Artifacts auditors request repeatedly across engagements

--- a/plugins/frameworks/singapore-pdpa/commands/scope.md
+++ b/plugins/frameworks/singapore-pdpa/commands/scope.md
@@ -1,0 +1,33 @@
+---
+description: Determine which parts of Singapore - Personal Data Protection Ac (PDPA) (2012) apply to the organization
+---
+
+# Singapore - Personal Data Protection Ac (PDPA) (2012) Scope
+
+Determines whether and how **Singapore - Personal Data Protection Ac (PDPA) (2012)** applies to the organization. Reference-depth scope is a decision-tree prompt; Full-depth plugins extend this with jurisdiction-aware logic.
+
+## Usage
+
+```
+/singapore-pdpa:scope
+```
+
+## What this produces
+
+- **Applicability verdict**: In-scope / out-of-scope / partially in-scope, with the triggers that led there
+- **In-scope entity types**: (controller, processor, covered entity, critical-entity operator, etc. — framework-dependent)
+- **In-scope data/systems**: what the framework's definitions pull in
+- **Jurisdiction reach**: where operations must comply (single country, EU member states, EEA, etc.)
+- **Carve-outs**: exemptions the organization can claim
+- **Next steps**: whether to proceed with `/singapore-pdpa:assess` or `/singapore-pdpa:evidence-checklist`
+
+## Framework-specific scope triggers
+
+TODO: replace with framework-specific triggers. Singapore - Personal Data Protection Ac (PDPA) (2012) scope depends on (at minimum):
+
+- Territorial reach — where operations happen and where customers/subjects are
+- Entity classification — how the framework defines in-scope actors
+- Sector/industry fit — financial, healthcare, critical infrastructure, government
+- Thresholds — revenue, headcount, user base, transaction volume
+
+This scope command should ask only the questions that actually matter for this framework, then output the applicability verdict without asking the user to search through the whole regulation.

--- a/plugins/frameworks/singapore-pdpa/skills/singapore-pdpa-expert/SKILL.md
+++ b/plugins/frameworks/singapore-pdpa/skills/singapore-pdpa-expert/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: singapore-pdpa-expert
+description: Singapore - Personal Data Protection Ac (PDPA) (2012) expert. Reference-depth framework plugin with assessment, scope determination, and evidence checklist — backed by the SCF crosswalk. Level up to Full by adding framework-specific workflow commands.
+allowed-tools: Read, Glob, Grep, Write
+---
+
+# Singapore - Personal Data Protection Ac (PDPA) (2012) Expert
+
+Reference-depth expertise for **Singapore - Personal Data Protection Ac (PDPA) (2012)**. This plugin bundles the SCF crosswalk (30 SCF controls → 14 framework controls) with framework-specific context.
+
+## Framework identity
+
+- **SCF framework ID**: `apac-sgp-pdpa-2012`
+- **Region**: APAC
+- **Country**: SG
+
+TODO: add the following when filling in expertise. Reference depth expects all of these to have at least two-sentence answers.
+
+### Framework in plain language
+
+TODO: one-paragraph summary of what Singapore - Personal Data Protection Ac (PDPA) (2012) exists to do and who it affects. Avoid verbatim regulation text — paraphrase and cite articles/sections by number.
+
+### Territorial scope and applicability
+
+TODO: who must comply, where operations must be happening, what the carve-outs are.
+
+### Mandatory artifacts
+
+TODO: the named documents or registers the framework requires (e.g. GDPR's ROPA/DPIA, PCI DSS's ROC/SAQ, ISO 27001's Statement of Applicability). Stub if uncertain; a Full-depth PR can add commands to generate each.
+
+### Cadence and timelines
+
+TODO: notification windows (e.g. GDPR 72 hours), assessment frequency, recertification cycles.
+
+### Regulator and enforcement
+
+TODO: who enforces, how penalties are calculated, recent enforcement patterns worth knowing.
+
+### Interaction with other frameworks
+
+TODO: overlaps with GDPR / ISO / NIST / sectoral rules. Reference the [cross-framework analyzer](../../../scripts/cross-framework-analyzer.js) outputs when useful.
+
+### Common misinterpretations
+
+TODO: at least 2–3 community-level misunderstandings this plugin should correct. Example: "ITAR only affects munitions" (it covers technical data too).
+
+## Command routing
+
+- `/singapore-pdpa:scope` — determine applicability
+- `/singapore-pdpa:assess` — run a gap assessment
+- `/singapore-pdpa:evidence-checklist` — enumerate evidence requirements
+
+All three delegate to `/grc-engineer:gap-assessment` with SCF framework ID `apac-sgp-pdpa-2012` for the control-by-control mechanics, and wrap the results in Singapore - Personal Data Protection Ac (PDPA) (2012)-specific terminology.
+
+## Levelling up to Full
+
+Full-depth plugins add framework-specific workflow commands tied to the audit ritual. Candidates for this framework:
+
+TODO: propose 2–4 framework-specific commands. Examples from existing Full-depth plugins:
+
+- `soc2`: `/soc2:service-auditor-prep`, `/soc2:trust-service-matrix`
+- `fedramp-rev5`: `/fedramp-rev5:poam-review`, `/fedramp-rev5:ssp-outline`
+- `pci-dss`: `/pci-dss:roc-walkthrough`, `/pci-dss:saq-route`
+- `cmmc`: `/cmmc:c3pao-readiness`
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com)
+- [SCF API entry for this framework](https://hackidle.github.io/scf-api/api/crosswalks/apac-sgp-pdpa-2012.json)
+- Official regulator publications (TODO: add primary-source links)

--- a/plugins/frameworks/singapore-pdpa/skills/singapore-pdpa-expert/SKILL.md
+++ b/plugins/frameworks/singapore-pdpa/skills/singapore-pdpa-expert/SKILL.md
@@ -38,7 +38,7 @@ TODO: who enforces, how penalties are calculated, recent enforcement patterns wo
 
 ### Interaction with other frameworks
 
-TODO: overlaps with GDPR / ISO / NIST / sectoral rules. Reference the [cross-framework analyzer](../../../scripts/cross-framework-analyzer.js) outputs when useful.
+TODO: overlaps with GDPR / ISO / NIST / sectoral rules. Reference the [cross-framework analyzer](../../../../grc-engineer/scripts/cross-framework-analyzer.js) outputs when useful.
 
 ### Common misinterpretations
 

--- a/plugins/grc-engineer/commands/scaffold-framework.md
+++ b/plugins/grc-engineer/commands/scaffold-framework.md
@@ -1,0 +1,91 @@
+---
+description: Scaffold a new framework plugin from the SCF crosswalk (Stub or Reference depth)
+---
+
+# Scaffold Framework Plugin
+
+Generates a new framework plugin directory under `plugins/frameworks/<slug>/` from templates, filling in framework metadata from the SCF crosswalk ({{SCF_FRAMEWORK_ID}} → 249 possible frameworks).
+
+Turns the usual half-day of hand-authoring `plugin.json` + `SKILL.md` + `commands/*.md` + `README.md` + marketplace registration into a one-command operation. The output is intentionally a starting point, not a finished plugin — you add the framework-specific expertise (`TODO:` markers throughout the templates point at what to fill in).
+
+## Usage
+
+```bash
+/grc-engineer:scaffold-framework <scf-framework-id-or-label> [options]
+```
+
+## Arguments
+
+| Argument | Required | Notes |
+|---|---|---|
+| `<scf-framework-id-or-label>` | yes | Either the raw SCF ID (e.g. `apac-sgp-pdpa-2012`) or a human label (`"Singapore PDPA"`, `"Brazil LGPD"`). The script resolves aliases via `scf-client.js`. |
+| `--depth=stub\|reference` | optional | Template depth. Default `stub`. Full-depth plugins are authored manually — Full isn't scaffolded because the framework-specific workflow commands are the whole point. |
+| `--slug=<name>` | optional | Override the auto-derived plugin directory name. Default strips the SCF region prefix and year suffix (`americas-bra-lgpd-2018` → `bra-lgpd`). |
+| `--no-register` | optional | Skip writing to `.claude-plugin/marketplace.json`. Useful when preparing changes to stage manually. |
+| `--force` | optional | Overwrite an existing plugin directory. Used for idempotent re-scaffolding. |
+| `--offline` | optional | Use cached SCF data only (no network). Fails if cache misses. |
+| `--dry-run` | optional | Print the actions that would be taken; don't touch the filesystem. |
+
+## What gets created
+
+### Stub depth (default)
+
+```
+plugins/frameworks/<slug>/
+├── .claude-plugin/plugin.json             # Plugin metadata + framework_metadata block
+├── commands/assess.md                     # Routes to /grc-engineer:gap-assessment
+├── skills/<slug>-expert/SKILL.md          # Framework identity + TODO sections
+└── README.md                              # Install + level-up instructions
+```
+
+Plus a new entry in `.claude-plugin/marketplace.json` (unless `--no-register`).
+
+### Reference depth
+
+Stub, plus:
+
+```
+plugins/frameworks/<slug>/
+├── commands/scope.md                      # Applicability determination
+├── commands/evidence-checklist.md         # Evidence baseline by control family
+└── skills/...                             # Richer SKILL.md with TODO scaffolding
+```
+
+Full depth (framework-specific workflow commands, persona-specific UX) is not auto-scaffolded — add those commands manually when promoting a Reference plugin to Full.
+
+## Examples
+
+```bash
+# Stub scaffold from SCF ID
+node plugins/grc-engineer/scripts/scaffold-framework.js apac-sgp-pdpa-2012
+
+# Reference depth with a custom slug
+node plugins/grc-engineer/scripts/scaffold-framework.js "Singapore PDPA" \
+  --depth=reference --slug=singapore-pdpa
+
+# Preview without writing
+node plugins/grc-engineer/scripts/scaffold-framework.js americas-bra-lgpd-2018 --dry-run
+
+# Staging workflow: scaffold files but skip marketplace.json until human review
+node plugins/grc-engineer/scripts/scaffold-framework.js emea-che-fadp-2023 --no-register
+```
+
+## Error modes
+
+- **Unknown SCF ID / label** → exits with code 2, lists the 5 closest matches.
+- **Plugin directory already exists** → exits with code 3 unless `--force` is passed.
+- **Offline + cache miss** → exits with a clear message pointing at `~/.cache/claude-grc/scf/`.
+- **Invalid slug** → exits with code 1; slug must match `^[a-z][a-z0-9-]*$`.
+
+## Data provenance
+
+Framework metadata (display name, region, country, SCF control counts) comes from the [SCF API](https://hackidle.github.io/scf-api/) (`api/crosswalks.json` and per-framework `api/crosswalks/<id>.json`). Cached locally under `~/.cache/claude-grc/scf/<version>/` per CC BY-ND 4.0 terms — cached data is redistributed verbatim, never modified.
+
+See [`docs/SCF-ATTRIBUTION.md`](../../../docs/SCF-ATTRIBUTION.md) for licensing detail.
+
+## Next steps after scaffolding
+
+1. Edit `skills/<slug>-expert/SKILL.md` — fill in the `TODO:` sections with framework-specific context.
+2. At Reference depth, edit `commands/assess.md`, `commands/scope.md`, `commands/evidence-checklist.md` for framework-specific guidance.
+3. Commit. Markdown lint + CODEOWNERS review run on every PR.
+4. Claim the matching issue in the [framework coverage tracker](https://github.com/GRCEngClub/claude-grc-engineering/issues/12).

--- a/plugins/grc-engineer/scripts/scaffold-framework.js
+++ b/plugins/grc-engineer/scripts/scaffold-framework.js
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+
+/**
+ * Scaffold a new framework plugin from the SCF crosswalk.
+ *
+ * Usage:
+ *   node scripts/scaffold-framework.js <scf-framework-id-or-label> [options]
+ *
+ * Options:
+ *   --depth=stub|reference     Template depth. Default: stub.
+ *   --slug=<name>              Override auto-derived plugin slug (directory name).
+ *   --no-register              Skip writing to marketplace.json.
+ *   --force                    Overwrite an existing plugin directory.
+ *   --offline                  Use cached SCF data only (fail if cache miss).
+ *   --dry-run                  Print what would happen; don't touch the filesystem.
+ *
+ * Examples:
+ *   node scripts/scaffold-framework.js apac-sgp-pdpa-2012
+ *   node scripts/scaffold-framework.js "Singapore PDPA" --depth=reference
+ *   node scripts/scaffold-framework.js americas-bra-lgpd-2018 --slug=brazil-lgpd
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { initSCF } from './scf-client.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const TEMPLATES_DIR = path.join(__dirname, '..', 'templates', 'framework-plugin');
+const PLUGINS_DIR = path.join(REPO_ROOT, 'plugins', 'frameworks');
+const MARKETPLACE_FILE = path.join(REPO_ROOT, '.claude-plugin', 'marketplace.json');
+
+const REGION_NAMES = {
+  americas: 'Americas',
+  apac: 'APAC',
+  emea: 'EMEA',
+  general: 'Global',
+};
+
+const COUNTRY_CODES_3_TO_2 = {
+  usa: 'US', can: 'CA', mex: 'MX', bra: 'BR', arg: 'AR', chl: 'CL', col: 'CO',
+  gbr: 'GB', deu: 'DE', fra: 'FR', ita: 'IT', esp: 'ES', nld: 'NL', che: 'CH',
+  irl: 'IE', bel: 'BE', aut: 'AT', swe: 'SE', nor: 'NO', dnk: 'DK', fin: 'FI',
+  pol: 'PL', cze: 'CZ', hun: 'HU', rou: 'RO', bgr: 'BG', grc: 'GR', prt: 'PT',
+  jpn: 'JP', kor: 'KR', chn: 'CN', twn: 'TW', hkg: 'HK', sgp: 'SG', ind: 'IN',
+  idn: 'ID', tha: 'TH', vnm: 'VN', phl: 'PH', mys: 'MY', aus: 'AU', nzl: 'NZ',
+  isr: 'IL', are: 'AE', sau: 'SA', qat: 'QA', kwt: 'KW', bhr: 'BH', omn: 'OM',
+  zaf: 'ZA', egy: 'EG', nga: 'NG', ken: 'KE',
+  bhs: 'BS', bmu: 'BM', cym: 'KY', bra: 'BR',
+};
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const opts = {
+    depth: 'stub',
+    slug: null,
+    register: true,
+    force: false,
+    offline: false,
+    dryRun: false,
+    positional: [],
+  };
+  for (const a of args) {
+    if (a === '--no-register') opts.register = false;
+    else if (a === '--force') opts.force = true;
+    else if (a === '--offline') opts.offline = true;
+    else if (a === '--dry-run') opts.dryRun = true;
+    else if (a.startsWith('--depth=')) opts.depth = a.slice('--depth='.length).toLowerCase();
+    else if (a.startsWith('--slug=')) opts.slug = a.slice('--slug='.length);
+    else if (a.startsWith('--help') || a === '-h') opts.help = true;
+    else opts.positional.push(a);
+  }
+  return opts;
+}
+
+function usage() {
+  return `Usage: node scripts/scaffold-framework.js <scf-framework-id-or-label> [options]
+
+Generate a new framework plugin stub from the SCF crosswalk.
+
+Options:
+  --depth=stub|reference     Template depth. Default: stub.
+  --slug=<name>              Override auto-derived plugin slug.
+  --no-register              Skip writing to marketplace.json.
+  --force                    Overwrite existing plugin directory.
+  --offline                  Use cached SCF data only.
+  --dry-run                  Print actions without touching the filesystem.
+
+Examples:
+  node scripts/scaffold-framework.js apac-sgp-pdpa-2012
+  node scripts/scaffold-framework.js "Singapore PDPA" --depth=reference
+`;
+}
+
+/**
+ * Derive a human-friendly plugin slug from the SCF framework_id.
+ * SCF IDs look like "americas-bra-lgpd-2018" or "apac-sgp-pdpa-2012" —
+ * we strip the region prefix and trailing year to get "bra-lgpd" / "sgp-pdpa".
+ * Caller can override with --slug.
+ */
+function deriveSlug(frameworkId) {
+  let slug = frameworkId.toLowerCase();
+  // Drop known region prefixes
+  slug = slug.replace(/^(americas|apac|emea|general)-/, '');
+  // Drop trailing -YYYY (year)
+  slug = slug.replace(/-\d{4}$/, '');
+  // Collapse duplicate dashes just in case
+  slug = slug.replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return slug;
+}
+
+function deriveNamespace(slug) {
+  // Namespace = slug. Claude Code command namespace is the plugin name.
+  return slug;
+}
+
+function deriveRegion(frameworkId) {
+  const m = frameworkId.match(/^(americas|apac|emea|general)-/);
+  if (!m) return { slug: 'general', display: 'Global' };
+  return { slug: m[1], display: REGION_NAMES[m[1]] };
+}
+
+function deriveCountry(frameworkId) {
+  // After region, the next segment is typically a 3-letter ISO-3166-1 alpha-3 code.
+  const parts = frameworkId.toLowerCase().split('-');
+  if (parts.length < 2) return '';
+  const candidate = parts[1];
+  if (candidate.length !== 3) return '';
+  return COUNTRY_CODES_3_TO_2[candidate] || candidate.toUpperCase();
+}
+
+async function loadTemplate(depth, relativePath) {
+  const filePath = path.join(TEMPLATES_DIR, depth, relativePath);
+  return fs.readFile(filePath, 'utf8');
+}
+
+function fillTemplate(template, vars) {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    if (key in vars) return vars[key];
+    throw new Error(`Template referenced unknown variable: {{${key}}}`);
+  });
+}
+
+async function walkTemplate(depth) {
+  // Return a list of relative paths of all *.tmpl files in the template dir.
+  const root = path.join(TEMPLATES_DIR, depth);
+  const out = [];
+  async function walk(dir, prefix) {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const rel = path.join(prefix, e.name);
+      if (e.isDirectory()) await walk(path.join(dir, e.name), rel);
+      else if (e.name.endsWith('.tmpl')) out.push(rel);
+    }
+  }
+  await walk(root, '');
+  return out;
+}
+
+/** Map a template path → output path inside the plugin directory. */
+function targetForTemplate(tmplRelPath, slug) {
+  // Strip .tmpl suffix. SKILL.md.tmpl lives under skills/; it becomes skills/<slug>-expert/SKILL.md.
+  const withoutTmpl = tmplRelPath.replace(/\.tmpl$/, '');
+  const parts = withoutTmpl.split(path.sep);
+  if (parts[0] === 'skills' && parts[parts.length - 1] === 'SKILL.md') {
+    return path.join('skills', `${slug}-expert`, 'SKILL.md');
+  }
+  return withoutTmpl;
+}
+
+async function registerInMarketplace({ slug, description, source }) {
+  const raw = await fs.readFile(MARKETPLACE_FILE, 'utf8');
+  const mp = JSON.parse(raw);
+  if (!Array.isArray(mp.plugins)) {
+    throw new Error('marketplace.json missing plugins array');
+  }
+  if (mp.plugins.some(p => p.name === slug)) {
+    return { alreadyRegistered: true };
+  }
+  mp.plugins.push({ name: slug, source, description, version: '0.1.0' });
+  await fs.writeFile(MARKETPLACE_FILE, JSON.stringify(mp, null, 2) + '\n');
+  return { alreadyRegistered: false };
+}
+
+function suggestClosest(label, frameworks) {
+  const needle = label.toLowerCase();
+  const scored = frameworks.map(f => {
+    const hay = (f.display_name + ' ' + f.framework_id).toLowerCase();
+    let score = 0;
+    if (hay.includes(needle)) score += 100;
+    for (const token of needle.split(/[\s-_]+/).filter(Boolean)) {
+      if (hay.includes(token)) score += 10;
+    }
+    return { f, score };
+  });
+  return scored.sort((a, b) => b.score - a.score).slice(0, 5).filter(x => x.score > 0).map(x => x.f);
+}
+
+async function main() {
+  const opts = parseArgs(process.argv);
+  if (opts.help || opts.positional.length === 0) {
+    console.log(usage());
+    process.exit(opts.help ? 0 : 1);
+  }
+  if (!['stub', 'reference'].includes(opts.depth)) {
+    console.error(`Unknown depth: ${opts.depth}. Use --depth=stub or --depth=reference.`);
+    process.exit(1);
+  }
+
+  const rawLabel = opts.positional[0];
+
+  // 1) Resolve the label to a real SCF framework_id.
+  const scf = await initSCF({ offline: opts.offline });
+  const frameworks = await scf.frameworks();
+  let resolvedId = frameworks.find(f => f.framework_id === rawLabel)?.framework_id;
+  if (!resolvedId) {
+    resolvedId = await scf.resolveFrameworkId(rawLabel);
+  }
+  if (!resolvedId) {
+    console.error(`✗ No SCF framework matched "${rawLabel}".`);
+    const matches = suggestClosest(rawLabel, frameworks);
+    if (matches.length > 0) {
+      console.error('Closest matches:');
+      for (const m of matches) {
+        console.error(`  - ${m.framework_id}  ${m.display_name}`);
+      }
+    }
+    process.exit(2);
+  }
+
+  const summary = frameworks.find(f => f.framework_id === resolvedId);
+
+  // 2) Derive slug, namespace, region, country.
+  const slug = (opts.slug || deriveSlug(resolvedId));
+  if (!/^[a-z][a-z0-9-]*$/.test(slug)) {
+    console.error(`✗ Derived slug "${slug}" is invalid. Use --slug=<name> to override.`);
+    process.exit(1);
+  }
+  const namespace = deriveNamespace(slug);
+  const region = deriveRegion(resolvedId);
+  const country = deriveCountry(resolvedId);
+  const pluginDir = path.join(PLUGINS_DIR, slug);
+  const marketplaceSource = `./plugins/frameworks/${slug}`;
+
+  // 3) Check for collisions.
+  let alreadyExists = false;
+  try {
+    await fs.access(pluginDir);
+    alreadyExists = true;
+  } catch { /* doesn't exist, good */ }
+  if (alreadyExists && !opts.force) {
+    console.error(`✗ Plugin directory already exists: ${path.relative(REPO_ROOT, pluginDir)}`);
+    console.error('  Use --force to overwrite, or --slug=<other> to pick a different name.');
+    process.exit(3);
+  }
+
+  // 4) Build template variables.
+  const vars = {
+    SLUG: slug,
+    NAMESPACE: namespace,
+    DISPLAY_NAME: summary.display_name,
+    SCF_FRAMEWORK_ID: resolvedId,
+    SCF_CONTROLS_MAPPED: String(summary.scf_controls_mapped ?? 0),
+    FRAMEWORK_CONTROLS_MAPPED: String(summary.framework_controls_mapped ?? 0),
+    REGION: region.display,
+    COUNTRY: country || 'TBD',
+  };
+
+  // 5) Enumerate templates.
+  const templateFiles = await walkTemplate(opts.depth);
+
+  // 6) Plan output.
+  console.log(`Scaffolding framework plugin "${slug}" at ${opts.depth} depth`);
+  console.log(`  SCF framework:   ${resolvedId}`);
+  console.log(`  Display name:    ${summary.display_name}`);
+  console.log(`  Region/country:  ${region.display} / ${country || '?'}`);
+  console.log(`  SCF controls:    ${summary.scf_controls_mapped} mapped to ${summary.framework_controls_mapped} framework controls`);
+  console.log(`  Plugin dir:      ${path.relative(REPO_ROOT, pluginDir)}`);
+  console.log('');
+
+  if (opts.dryRun) {
+    console.log('[dry-run] Would create:');
+    for (const tmpl of templateFiles) {
+      const target = targetForTemplate(tmpl, slug);
+      const targetFull = (target === 'plugin.json')
+        ? path.join(pluginDir, '.claude-plugin', target)
+        : path.join(pluginDir, target);
+      console.log(`  ${path.relative(REPO_ROOT, targetFull)}`);
+    }
+    if (opts.register) console.log('[dry-run] Would register in .claude-plugin/marketplace.json');
+    return;
+  }
+
+  // 7) Render and write.
+  await fs.mkdir(pluginDir, { recursive: true });
+  const written = [];
+  for (const tmpl of templateFiles) {
+    const raw = await loadTemplate(opts.depth, tmpl);
+    const rendered = fillTemplate(raw, vars);
+    const target = targetForTemplate(tmpl, slug);
+    const targetFull = (target === 'plugin.json')
+      ? path.join(pluginDir, '.claude-plugin', target)
+      : path.join(pluginDir, target);
+    await fs.mkdir(path.dirname(targetFull), { recursive: true });
+    await fs.writeFile(targetFull, rendered);
+    written.push(path.relative(REPO_ROOT, targetFull));
+  }
+
+  for (const w of written) console.log(`  ✓ ${w}`);
+
+  // 8) Register in marketplace.json.
+  if (opts.register) {
+    const description = `${summary.display_name} — ${opts.depth}-depth plugin backed by the SCF crosswalk (${summary.scf_controls_mapped} SCF → ${summary.framework_controls_mapped} framework controls).`;
+    const { alreadyRegistered } = await registerInMarketplace({ slug, description, source: marketplaceSource });
+    console.log(`  ${alreadyRegistered ? '=' : '✓'} marketplace.json ${alreadyRegistered ? 'entry already present' : 'registered'}`);
+  }
+
+  console.log('');
+  console.log(`Done. Next:`);
+  console.log(`  - Edit plugins/frameworks/${slug}/skills/${slug}-expert/SKILL.md and fill in the TODO sections.`);
+  if (opts.depth === 'reference') {
+    console.log(`  - Edit plugins/frameworks/${slug}/commands/*.md for framework-specific assessment and evidence guidance.`);
+  }
+  console.log(`  - Commit and open a PR; CI will validate markdown and CODEOWNERS will route review.`);
+}
+
+// Only run main when invoked directly (not when imported).
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(err => {
+    console.error('✗ scaffold-framework failed:', err.message);
+    if (process.env.DEBUG) console.error(err);
+    process.exit(1);
+  });
+}

--- a/plugins/grc-engineer/templates/framework-plugin/reference/README.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/reference/README.md.tmpl
@@ -1,0 +1,34 @@
+# {{SLUG}} — {{DISPLAY_NAME}}
+
+Reference-depth framework plugin. Install and run:
+
+```bash
+/plugin install {{SLUG}}@grc-engineering-suite
+/{{NAMESPACE}}:scope                    # determine applicability first
+/{{NAMESPACE}}:evidence-checklist       # see what to collect
+/{{NAMESPACE}}:assess                   # run the gap assessment
+```
+
+## Status: Reference
+
+This plugin is at **Reference depth** — it provides scope determination, evidence checklist, and a framework-specific gap assessment, all backed by the SCF crosswalk ({{SCF_CONTROLS_MAPPED}} SCF controls → {{FRAMEWORK_CONTROLS_MAPPED}} {{DISPLAY_NAME}} controls).
+
+### Level up to Full
+
+Full depth adds framework-native workflow commands tied to the audit ritual. If you have domain expertise for {{DISPLAY_NAME}}, see [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the level-up checklist.
+
+## Metadata
+
+| | |
+|---|---|
+| SCF framework ID | `{{SCF_FRAMEWORK_ID}}` |
+| Region | {{REGION}} |
+| Country | {{COUNTRY}} |
+| SCF controls mapped | {{SCF_CONTROLS_MAPPED}} |
+| Framework controls mapped | {{FRAMEWORK_CONTROLS_MAPPED}} |
+| Depth | Reference |
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com) — crosswalk source (CC BY-ND 4.0)
+- [SCF API entry](https://hackidle.github.io/scf-api/api/crosswalks/{{SCF_FRAMEWORK_ID}}.json)

--- a/plugins/grc-engineer/templates/framework-plugin/reference/README.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/reference/README.md.tmpl
@@ -15,7 +15,7 @@ This plugin is at **Reference depth** — it provides scope determination, evide
 
 ### Level up to Full
 
-Full depth adds framework-native workflow commands tied to the audit ritual. If you have domain expertise for {{DISPLAY_NAME}}, see [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the level-up checklist.
+Full depth adds framework-native workflow commands tied to the audit ritual. If you have domain expertise for {{DISPLAY_NAME}}, see the [FRAMEWORK-PLUGIN-GUIDE tracking issue](https://github.com/GRCEngClub/claude-grc-engineering/issues/11) for the level-up checklist.
 
 ## Metadata
 

--- a/plugins/grc-engineer/templates/framework-plugin/reference/commands/assess.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/reference/commands/assess.md.tmpl
@@ -1,0 +1,45 @@
+---
+description: {{DISPLAY_NAME}} compliance gap assessment
+---
+
+# {{DISPLAY_NAME}} Assessment
+
+Runs a compliance gap assessment against **{{DISPLAY_NAME}}** by delegating to `/grc-engineer:gap-assessment` with the framework's SCF identifier, then overlays framework-specific context and evidence requirements.
+
+## Usage
+
+```
+/{{NAMESPACE}}:assess [--scope=<scope>] [--sources=<connector-list>]
+```
+
+## Arguments
+
+- `--scope=<scope>` (optional) — narrow the assessment to a specific part of the framework. Valid scopes depend on the framework; TODO: enumerate the standard sections/articles of {{DISPLAY_NAME}} here.
+- `--sources=<connector-list>` (optional) — comma-separated connector plugins.
+
+## What the assessment produces
+
+1. **Compliance score** — overall {{DISPLAY_NAME}} readiness percentage, weighted by mapped SCF controls.
+2. **Applicable-requirements summary** — which parts of the framework apply to the organization (see `/{{NAMESPACE}}:scope` to narrow this down first).
+3. **Control-by-control gap** — every {{FRAMEWORK_CONTROLS_MAPPED}} mapped control, with pass/fail/inconclusive status from connector findings.
+4. **Evidence gaps** — controls where no evidence source is configured.
+5. **Remediation roadmap** — prioritized by severity and effort.
+
+## Delegation
+
+Under the hood:
+
+```
+/grc-engineer:gap-assessment "{{SCF_FRAMEWORK_ID}}" [--sources=<connector-list>]
+```
+
+The SCF crosswalk expands {{SCF_CONTROLS_MAPPED}} SCF controls into the {{FRAMEWORK_CONTROLS_MAPPED}} {{DISPLAY_NAME}} controls.
+
+## Framework-specific notes
+
+TODO: replace this section with framework-specific assessment guidance. At Reference depth, include at minimum:
+
+- Which assessment scope is most commonly requested
+- Known interactions with sibling frameworks (e.g. GDPR + UK DPA, or CMMC + NIST 800-171)
+- Any mandatory cadence (annual self-attestation, biennial external audit, etc.)
+- Common misinterpretations in community guidance that this plugin corrects

--- a/plugins/grc-engineer/templates/framework-plugin/reference/commands/evidence-checklist.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/reference/commands/evidence-checklist.md.tmpl
@@ -1,0 +1,35 @@
+---
+description: Evidence checklist for {{DISPLAY_NAME}}, organized by control family
+---
+
+# {{DISPLAY_NAME}} Evidence Checklist
+
+Baseline evidence checklist for a {{DISPLAY_NAME}} assessment. The SCF crosswalk maps {{SCF_CONTROLS_MAPPED}} SCF controls to the {{FRAMEWORK_CONTROLS_MAPPED}} {{DISPLAY_NAME}} controls; this command enumerates what evidence tends to be expected for each SCF family that's in scope.
+
+## Usage
+
+```
+/{{NAMESPACE}}:evidence-checklist [--family=<SCF_family_code>]
+```
+
+## Arguments
+
+- `--family=<SCF_family_code>` (optional) — restrict to a single SCF family (e.g. `IAC`, `CRY`, `AST`, `BCD`). Defaults to all families mapped for this framework.
+
+## Output
+
+Markdown checklist grouped by SCF family with:
+
+- SCF control ID → framework-native control ID(s) (from crosswalk)
+- Evidence types typically expected (logs, configs, policy documents, tickets, training records)
+- Which connector plugins can collect each type automatically
+- Which items require manual upload / narrative
+
+## Framework-specific evidence
+
+TODO: at Reference depth, replace this section with framework-specific evidence patterns. Items worth capturing:
+
+- Mandatory artifacts unique to {{DISPLAY_NAME}} (e.g. DPIA for GDPR, ROC for PCI DSS, SSP for FedRAMP)
+- Assessor expectations per control family
+- Retention periods required by the regulator
+- Artifacts auditors request repeatedly across engagements

--- a/plugins/grc-engineer/templates/framework-plugin/reference/commands/scope.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/reference/commands/scope.md.tmpl
@@ -1,0 +1,33 @@
+---
+description: Determine which parts of {{DISPLAY_NAME}} apply to the organization
+---
+
+# {{DISPLAY_NAME}} Scope
+
+Determines whether and how **{{DISPLAY_NAME}}** applies to the organization. Reference-depth scope is a decision-tree prompt; Full-depth plugins extend this with jurisdiction-aware logic.
+
+## Usage
+
+```
+/{{NAMESPACE}}:scope
+```
+
+## What this produces
+
+- **Applicability verdict**: In-scope / out-of-scope / partially in-scope, with the triggers that led there
+- **In-scope entity types**: (controller, processor, covered entity, critical-entity operator, etc. — framework-dependent)
+- **In-scope data/systems**: what the framework's definitions pull in
+- **Jurisdiction reach**: where operations must comply (single country, EU member states, EEA, etc.)
+- **Carve-outs**: exemptions the organization can claim
+- **Next steps**: whether to proceed with `/{{NAMESPACE}}:assess` or `/{{NAMESPACE}}:evidence-checklist`
+
+## Framework-specific scope triggers
+
+TODO: replace with framework-specific triggers. {{DISPLAY_NAME}} scope depends on (at minimum):
+
+- Territorial reach — where operations happen and where customers/subjects are
+- Entity classification — how the framework defines in-scope actors
+- Sector/industry fit — financial, healthcare, critical infrastructure, government
+- Thresholds — revenue, headcount, user base, transaction volume
+
+This scope command should ask only the questions that actually matter for this framework, then output the applicability verdict without asking the user to search through the whole regulation.

--- a/plugins/grc-engineer/templates/framework-plugin/reference/plugin.json.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/reference/plugin.json.tmpl
@@ -1,0 +1,19 @@
+{
+  "name": "{{SLUG}}",
+  "description": "{{DISPLAY_NAME}} — Reference plugin with evidence checklist, scope determination, and SCF-backed gap assessment. Level up to Full by adding framework-specific workflow commands.",
+  "version": "0.1.0",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "framework_metadata": {
+    "scf_framework_id": "{{SCF_FRAMEWORK_ID}}",
+    "display_name": "{{DISPLAY_NAME}}",
+    "region": "{{REGION}}",
+    "country": "{{COUNTRY}}",
+    "depth": "reference",
+    "scf_controls_mapped": {{SCF_CONTROLS_MAPPED}},
+    "framework_controls_mapped": {{FRAMEWORK_CONTROLS_MAPPED}},
+    "industry": [],
+    "regulator": ""
+  }
+}

--- a/plugins/grc-engineer/templates/framework-plugin/reference/skills/SKILL.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/reference/skills/SKILL.md.tmpl
@@ -1,0 +1,70 @@
+---
+name: {{SLUG}}-expert
+description: {{DISPLAY_NAME}} expert. Reference-depth framework plugin with assessment, scope determination, and evidence checklist — backed by the SCF crosswalk. Level up to Full by adding framework-specific workflow commands.
+allowed-tools: Read, Glob, Grep, Write
+---
+
+# {{DISPLAY_NAME}} Expert
+
+Reference-depth expertise for **{{DISPLAY_NAME}}**. This plugin bundles the SCF crosswalk ({{SCF_CONTROLS_MAPPED}} SCF controls → {{FRAMEWORK_CONTROLS_MAPPED}} framework controls) with framework-specific context.
+
+## Framework identity
+
+- **SCF framework ID**: `{{SCF_FRAMEWORK_ID}}`
+- **Region**: {{REGION}}
+- **Country**: {{COUNTRY}}
+
+TODO: add the following when filling in expertise. Reference depth expects all of these to have at least two-sentence answers.
+
+### Framework in plain language
+
+TODO: one-paragraph summary of what {{DISPLAY_NAME}} exists to do and who it affects. Avoid verbatim regulation text — paraphrase and cite articles/sections by number.
+
+### Territorial scope and applicability
+
+TODO: who must comply, where operations must be happening, what the carve-outs are.
+
+### Mandatory artifacts
+
+TODO: the named documents or registers the framework requires (e.g. GDPR's ROPA/DPIA, PCI DSS's ROC/SAQ, ISO 27001's Statement of Applicability). Stub if uncertain; a Full-depth PR can add commands to generate each.
+
+### Cadence and timelines
+
+TODO: notification windows (e.g. GDPR 72 hours), assessment frequency, recertification cycles.
+
+### Regulator and enforcement
+
+TODO: who enforces, how penalties are calculated, recent enforcement patterns worth knowing.
+
+### Interaction with other frameworks
+
+TODO: overlaps with GDPR / ISO / NIST / sectoral rules. Reference the [cross-framework analyzer](../../../scripts/cross-framework-analyzer.js) outputs when useful.
+
+### Common misinterpretations
+
+TODO: at least 2–3 community-level misunderstandings this plugin should correct. Example: "ITAR only affects munitions" (it covers technical data too).
+
+## Command routing
+
+- `/{{NAMESPACE}}:scope` — determine applicability
+- `/{{NAMESPACE}}:assess` — run a gap assessment
+- `/{{NAMESPACE}}:evidence-checklist` — enumerate evidence requirements
+
+All three delegate to `/grc-engineer:gap-assessment` with SCF framework ID `{{SCF_FRAMEWORK_ID}}` for the control-by-control mechanics, and wrap the results in {{DISPLAY_NAME}}-specific terminology.
+
+## Levelling up to Full
+
+Full-depth plugins add framework-specific workflow commands tied to the audit ritual. Candidates for this framework:
+
+TODO: propose 2–4 framework-specific commands. Examples from existing Full-depth plugins:
+
+- `soc2`: `/soc2:service-auditor-prep`, `/soc2:trust-service-matrix`
+- `fedramp-rev5`: `/fedramp-rev5:poam-review`, `/fedramp-rev5:ssp-outline`
+- `pci-dss`: `/pci-dss:roc-walkthrough`, `/pci-dss:saq-route`
+- `cmmc`: `/cmmc:c3pao-readiness`
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com)
+- [SCF API entry for this framework](https://hackidle.github.io/scf-api/api/crosswalks/{{SCF_FRAMEWORK_ID}}.json)
+- Official regulator publications (TODO: add primary-source links)

--- a/plugins/grc-engineer/templates/framework-plugin/reference/skills/SKILL.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/reference/skills/SKILL.md.tmpl
@@ -38,7 +38,7 @@ TODO: who enforces, how penalties are calculated, recent enforcement patterns wo
 
 ### Interaction with other frameworks
 
-TODO: overlaps with GDPR / ISO / NIST / sectoral rules. Reference the [cross-framework analyzer](../../../scripts/cross-framework-analyzer.js) outputs when useful.
+TODO: overlaps with GDPR / ISO / NIST / sectoral rules. Reference the [cross-framework analyzer](../../../../grc-engineer/scripts/cross-framework-analyzer.js) outputs when useful.
 
 ### Common misinterpretations
 

--- a/plugins/grc-engineer/templates/framework-plugin/stub/README.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/stub/README.md.tmpl
@@ -1,0 +1,36 @@
+# {{SLUG}} — {{DISPLAY_NAME}}
+
+Stub-depth framework plugin scaffolded from the SCF crosswalk. Install and use it to run a gap assessment against **{{DISPLAY_NAME}}**:
+
+```bash
+/plugin install {{SLUG}}@grc-engineering-suite
+/{{NAMESPACE}}:assess --sources=aws-inspector,github-inspector
+```
+
+## Status: Stub
+
+This plugin is at **Stub depth** — it routes to `/grc-engineer:gap-assessment` via the SCF crosswalk ({{SCF_CONTROLS_MAPPED}} SCF controls → {{FRAMEWORK_CONTROLS_MAPPED}} {{DISPLAY_NAME}} controls) without any framework-specific workflow commands yet.
+
+### Level up to Reference
+
+Reference-depth adds an evidence checklist and framework-specific context. If you have domain expertise for {{DISPLAY_NAME}}, see [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) and open a PR.
+
+### Level up to Full
+
+Full depth adds framework-native workflow commands tied to the audit ritual (e.g. `/fedramp-rev5:poam-review`, `/soc2:service-auditor-prep`). See the existing Full-depth plugins (`soc2`, `fedramp-rev5`, `pci-dss`, `nist-800-53`) for reference.
+
+## Metadata
+
+| | |
+|---|---|
+| SCF framework ID | `{{SCF_FRAMEWORK_ID}}` |
+| Region | {{REGION}} |
+| Country | {{COUNTRY}} |
+| SCF controls mapped | {{SCF_CONTROLS_MAPPED}} |
+| Framework controls mapped | {{FRAMEWORK_CONTROLS_MAPPED}} |
+| Depth | Stub |
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com) — crosswalk source (CC BY-ND 4.0)
+- [SCF API entry](https://hackidle.github.io/scf-api/api/crosswalks/{{SCF_FRAMEWORK_ID}}.json)

--- a/plugins/grc-engineer/templates/framework-plugin/stub/README.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/stub/README.md.tmpl
@@ -13,7 +13,7 @@ This plugin is at **Stub depth** — it routes to `/grc-engineer:gap-assessment`
 
 ### Level up to Reference
 
-Reference-depth adds an evidence checklist and framework-specific context. If you have domain expertise for {{DISPLAY_NAME}}, see [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) and open a PR.
+Reference-depth adds an evidence checklist and framework-specific context. If you have domain expertise for {{DISPLAY_NAME}}, see the [FRAMEWORK-PLUGIN-GUIDE tracking issue](https://github.com/GRCEngClub/claude-grc-engineering/issues/11) and open a PR.
 
 ### Level up to Full
 

--- a/plugins/grc-engineer/templates/framework-plugin/stub/commands/assess.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/stub/commands/assess.md.tmpl
@@ -6,7 +6,7 @@ description: {{DISPLAY_NAME}} compliance gap assessment via the SCF crosswalk
 
 Runs a compliance gap assessment against **{{DISPLAY_NAME}}** by delegating to `/grc-engineer:gap-assessment` with the framework's SCF identifier.
 
-This is a **stub plugin** — the underlying gap assessment is powered by the SCF crosswalk ({{SCF_CONTROLS_MAPPED}} SCF controls mapped to {{FRAMEWORK_CONTROLS_MAPPED}} framework controls). To add framework-specific workflow commands, evidence checklists, or implementation guidance, see [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](../../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the level-up path to Reference or Full depth.
+This is a **stub plugin** — the underlying gap assessment is powered by the SCF crosswalk ({{SCF_CONTROLS_MAPPED}} SCF controls mapped to {{FRAMEWORK_CONTROLS_MAPPED}} framework controls). To add framework-specific workflow commands, evidence checklists, or implementation guidance, see the [FRAMEWORK-PLUGIN-GUIDE tracking issue](https://github.com/GRCEngClub/claude-grc-engineering/issues/11) for the level-up path to Reference or Full depth.
 
 ## Usage
 

--- a/plugins/grc-engineer/templates/framework-plugin/stub/commands/assess.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/stub/commands/assess.md.tmpl
@@ -1,0 +1,34 @@
+---
+description: {{DISPLAY_NAME}} compliance gap assessment via the SCF crosswalk
+---
+
+# {{DISPLAY_NAME}} Assessment
+
+Runs a compliance gap assessment against **{{DISPLAY_NAME}}** by delegating to `/grc-engineer:gap-assessment` with the framework's SCF identifier.
+
+This is a **stub plugin** — the underlying gap assessment is powered by the SCF crosswalk ({{SCF_CONTROLS_MAPPED}} SCF controls mapped to {{FRAMEWORK_CONTROLS_MAPPED}} framework controls). To add framework-specific workflow commands, evidence checklists, or implementation guidance, see [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](../../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the level-up path to Reference or Full depth.
+
+## Usage
+
+```
+/{{NAMESPACE}}:assess [--sources=<connector-list>]
+```
+
+Delegates to:
+
+```
+/grc-engineer:gap-assessment "{{SCF_FRAMEWORK_ID}}" [--sources=<connector-list>]
+```
+
+## Arguments
+
+- `--sources=<connector-list>` (optional) — comma-separated list of connector plugins to pull evidence from (e.g. `aws-inspector,github-inspector,okta-inspector`). Defaults to whichever connectors are configured and have recent runs.
+
+## Output
+
+A prioritized gap report listing unmet {{DISPLAY_NAME}} requirements, severity-tagged and grouped by SCF family. The report maps back to the {{FRAMEWORK_CONTROLS_MAPPED}} framework-native controls via the SCF crosswalk.
+
+## Further reading
+
+- [Secure Controls Framework](https://securecontrolsframework.com)
+- [SCF API entry for this framework](https://hackidle.github.io/scf-api/api/crosswalks/{{SCF_FRAMEWORK_ID}}.json)

--- a/plugins/grc-engineer/templates/framework-plugin/stub/plugin.json.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/stub/plugin.json.tmpl
@@ -1,0 +1,19 @@
+{
+  "name": "{{SLUG}}",
+  "description": "{{DISPLAY_NAME}} — stub plugin routing to /grc-engineer:gap-assessment via the SCF crosswalk. Level up by adding framework-specific commands, implementation guidance, and evidence patterns.",
+  "version": "0.1.0",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "framework_metadata": {
+    "scf_framework_id": "{{SCF_FRAMEWORK_ID}}",
+    "display_name": "{{DISPLAY_NAME}}",
+    "region": "{{REGION}}",
+    "country": "{{COUNTRY}}",
+    "depth": "stub",
+    "scf_controls_mapped": {{SCF_CONTROLS_MAPPED}},
+    "framework_controls_mapped": {{FRAMEWORK_CONTROLS_MAPPED}},
+    "industry": [],
+    "regulator": ""
+  }
+}

--- a/plugins/grc-engineer/templates/framework-plugin/stub/skills/SKILL.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/stub/skills/SKILL.md.tmpl
@@ -36,4 +36,4 @@ Full-depth plugins add framework-specific workflow commands (examples in sibling
 
 ## Levelling up
 
-See [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](../../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the Stub → Reference → Full progression checklist.
+See the [FRAMEWORK-PLUGIN-GUIDE tracking issue](https://github.com/GRCEngClub/claude-grc-engineering/issues/11) for the Stub → Reference → Full progression checklist.

--- a/plugins/grc-engineer/templates/framework-plugin/stub/skills/SKILL.md.tmpl
+++ b/plugins/grc-engineer/templates/framework-plugin/stub/skills/SKILL.md.tmpl
@@ -1,0 +1,39 @@
+---
+name: {{SLUG}}-expert
+description: {{DISPLAY_NAME}} expert. Stub-depth framework plugin that routes to the SCF crosswalk. Level up by adding framework-specific context, assessment workflow, and evidence patterns.
+allowed-tools: Read, Glob, Grep
+---
+
+# {{DISPLAY_NAME}} Expert
+
+Stub-depth expertise for **{{DISPLAY_NAME}}**. This plugin is scaffolded from the SCF crosswalk ({{SCF_CONTROLS_MAPPED}} SCF controls map to {{FRAMEWORK_CONTROLS_MAPPED}} framework controls) and defers to `/grc-engineer:gap-assessment` for the actual compliance check.
+
+## Framework identity
+
+- **SCF framework ID**: `{{SCF_FRAMEWORK_ID}}`
+- **Region**: {{REGION}}
+- **Country**: {{COUNTRY}}
+- **Canonical source**: the issuing regulator or standards body (see below)
+
+## Scope and posture (placeholder — fill in when leveling up)
+
+TODO: replace with framework-specific overview. Minimum sections for Reference-depth upgrade:
+
+- Territorial scope (who and where the framework applies)
+- Controlled-entity obligations (controller, processor, covered entity, etc.)
+- Mandatory timelines (breach notification, assessment cadence)
+- Regulator and enforcement mechanism
+- Interaction with other frameworks (adequacy decisions, mutual recognition)
+
+## Command routing
+
+All commands in this plugin route through `/grc-engineer:gap-assessment` with framework ID `{{SCF_FRAMEWORK_ID}}`. Reference-depth plugins add:
+
+- `evidence-checklist` — framework-native evidence by control family
+- `scope` — applicability determination for the organization
+
+Full-depth plugins add framework-specific workflow commands (examples in sibling plugins like `soc2`, `fedramp-rev5`, `pci-dss`).
+
+## Levelling up
+
+See [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](../../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the Stub → Reference → Full progression checklist.


### PR DESCRIPTION
Closes #9. Demonstrates with Singapore PDPA (also closes part of #27).

## What

- **`plugins/grc-engineer/scripts/scaffold-framework.js`** — CLI that generates a new framework plugin from the SCF crosswalk. Reuses the existing `scf-client.js` (fetch + cache + alias resolution).
- **`plugins/grc-engineer/commands/scaffold-framework.md`** — command spec.
- **`plugins/grc-engineer/templates/framework-plugin/{stub,reference}/`** — templates with `{{PLACEHOLDER}}` substitution.
- **`plugins/frameworks/singapore-pdpa/`** — first real scaffold output, Reference depth. Registered in marketplace.json. Demonstrates what the command produces end-to-end.

## Usage

```bash
node plugins/grc-engineer/scripts/scaffold-framework.js apac-sgp-pdpa-2012 --depth=reference --slug=singapore-pdpa
```

Auto-derives region (`APAC`), country (`SG`), SCF control counts (30 mapped → 14 framework controls), and the plugin slug from the SCF framework ID. Registers in `.claude-plugin/marketplace.json`. Prints a next-steps summary pointing at the `TODO:` markers contributors fill in with framework-specific expertise.

## Why this unblocks everything

Every framework plugin after this becomes dramatically cheaper. Previous workflow: hand-author 5+ files + marketplace entry per framework (half-day of boilerplate). New workflow: one command, then spend time on framework-specific expertise. Unblocks the 15 seeded framework issues (#13–#27) and the long-tail 200+ frameworks in the coverage tracker (#12).

## Error modes (tested)

| Scenario | Exit code | Output |
|---|---|---|
| Unknown SCF ID or label | 2 | Lists 5 closest matches |
| Plugin dir already exists | 3 | Refuses; `--force` to override |
| Invalid slug | 1 | Rejects; `--slug=` to override |
| `--dry-run` | 0 | Lists files; no FS change |
| Offline + cache miss | non-zero | Clear message pointing at `~/.cache/claude-grc/scf/` |

## Depth tiers

- **Stub** (default): `plugin.json` + `commands/assess.md` + `skills/<slug>-expert/SKILL.md` + `README.md`. Routes to `/grc-engineer:gap-assessment` via the SCF crosswalk.
- **Reference**: Stub + `commands/scope.md` + `commands/evidence-checklist.md` + richer SKILL with TODO scaffolding.
- **Full**: *Not auto-scaffolded*. Framework-specific workflow commands (e.g. `/fedramp-rev5:poam-review`) are the whole point of Full — they can't be templated.

## Verification

Locally (all green):

- [x] Unknown framework → exit 2, suggests closest matches
- [x] Valid ID → scaffolds 6 files + marketplace entry
- [x] Re-run without `--force` → exit 3, refuses
- [x] `--dry-run` → 0 files written
- [x] `markdownlint-cli2` passes on every generated file
- [x] `ajv` contract test still green
- [x] Generated `plugin.json` parses and conforms to existing plugin.json shape

On this PR:

- [ ] CI: markdown-lint
- [ ] CI: lychee
- [ ] 1 leadership-team review (CODEOWNERS)

## Singapore PDPA caveats

The included `plugins/frameworks/singapore-pdpa/` is a demo of the scaffold's output, not a shipped Reference plugin. All the `TODO:` markers in SKILL.md and the command files mark where framework-specific expertise needs to go. Anyone with PDPA domain knowledge can level it up in a follow-up PR.