### PR TITLE
feat: /grc-engineer:frameworks discovery command

### DIFF
--- a/plugins/grc-engineer/commands/frameworks.md
+++ b/plugins/grc-engineer/commands/frameworks.md
@@ -1,0 +1,72 @@
+---
+description: List every SCF-mapped framework (249) and show which have a dedicated plugin
+---
+
+# Frameworks Discovery
+
+Lists every framework in the [Secure Controls Framework](https://securecontrolsframework.com) crosswalk (249 total) and annotates each with its plugin status in this repo:
+
+- `✓ shipped` — a dedicated plugin exists in `plugins/frameworks/<slug>/` (filterable by depth)
+- `○ not started` — no dedicated plugin yet, but the framework is already usable today via `/grc-engineer:gap-assessment <scf-framework-id>` through the crosswalk
+
+Answers the everyday question: *"is X supported, and if so, how do I use it?"* — without scrolling through the marketplace.
+
+## Usage
+
+```bash
+/grc-engineer:frameworks [options]
+```
+
+## Options
+
+| Option | Values | Notes |
+|---|---|---|
+| `--region=` | `americas` · `apac` · `emea` · `global` | Filter by SCF region. `global` covers general-purpose frameworks (NIST, ISO, PCI DSS, etc.). |
+| `--depth=` | `stub` · `reference` · `full` · `unknown` | Filter by plugin depth. `unknown` matches plugins without a `framework_metadata.depth` field yet. |
+| `--status=` | `shipped` · `not-started` | Filter by whether a plugin exists. |
+| `--installed` | — | Shorthand for `--status=shipped`. |
+| `--not-installed` | — | Shorthand for `--status=not-started`. |
+| `--search=` | substring | Case-insensitive match against display name, SCF ID, or plugin slug. |
+| `--format=` | `text` · `json` · `table` | Output format. `text` (default) groups shipped/not-started with a summary header; `json` is machine-readable; `table` is columnar. |
+| `--limit=N` | integer | Cap the result set (useful with `--not-installed` which otherwise lists 234 rows). |
+| `--offline` | — | Use cached SCF data only (no network). |
+
+## Examples
+
+```bash
+# Everything, grouped by status
+/grc-engineer:frameworks
+
+# Just what's shipped
+/grc-engineer:frameworks --installed
+
+# APAC frameworks without plugins — what could a contributor pick up?
+/grc-engineer:frameworks --region=apac --not-installed --limit=10
+
+# Find all PDPA-like frameworks
+/grc-engineer:frameworks --search=pdpa
+
+# Everything in machine-readable form (pipe to jq / other tools)
+/grc-engineer:frameworks --format=json > coverage.json
+
+# Which plugins are at Reference depth and could be promoted to Full?
+/grc-engineer:frameworks --depth=reference
+```
+
+## Output semantics
+
+- **SCF coverage summary** — total SCF frameworks vs shipped vs not-started.
+- **Shipped plugins** — every registered plugin under `plugins/frameworks/`, matched to its SCF framework_id when known. Plugins without a `framework_metadata.scf_framework_id` or a legacy mapping appear as *"no SCF mapping recorded"* — a gentle nudge to add the metadata in a follow-up PR.
+- **Not-started** — every SCF framework without a plugin. Each row includes the SCF framework ID (copy-paste into `scaffold-framework`) and the display name.
+
+## Data sources
+
+- [SCF API](https://hackidle.github.io/scf-api/) — `crosswalks.json` for the 249 framework index. Cached locally under `~/.cache/claude-grc/scf/<version>/` per CC BY-ND 4.0 (verbatim).
+- `.claude-plugin/marketplace.json` — registered plugins.
+- Each `plugins/frameworks/<slug>/.claude-plugin/plugin.json` → `framework_metadata` block (if present).
+- Hard-coded legacy mapping in `scripts/frameworks.js` for the ~15 pre-Club-handoff plugins that predate the `framework_metadata` convention. Entries become obsolete as plugins backfill their metadata.
+
+## Pairs with
+
+- [`/grc-engineer:scaffold-framework`](scaffold-framework.md) — use the SCF framework_id from this command's output to scaffold a new plugin with one command.
+- Framework coverage tracker ([#12](https://github.com/GRCEngClub/claude-grc-engineering/issues/12)) — the meta issue that this command's `--format=json` output will eventually drive (auto-generated `docs/FRAMEWORK-COVERAGE.md`).

--- a/plugins/grc-engineer/scripts/frameworks.js
+++ b/plugins/grc-engineer/scripts/frameworks.js
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+/**
+ * Framework discovery command.
+ *
+ * Lists every SCF-mapped framework (249) and shows which have a dedicated
+ * plugin in this repo vs which are currently crosswalk-only (available today
+ * via /grc-engineer:gap-assessment but without a dedicated namespace).
+ *
+ * Data sources:
+ *   - SCF API crosswalks.json (via scf-client.js + local cache)
+ *   - .claude-plugin/marketplace.json (which plugins are registered)
+ *   - each framework plugin's plugin.json framework_metadata block (if present)
+ *
+ * Usage: node scripts/frameworks.js [options]
+ *
+ * Options:
+ *   --region=americas|apac|emea|global
+ *   --depth=stub|reference|full|unknown
+ *   --status=shipped|not-started
+ *   --installed       shorthand for --status=shipped
+ *   --not-installed   shorthand for --status=not-started
+ *   --format=text|json|table    (default: text)
+ *   --offline         use cached SCF data only
+ *   --limit=N         cap the result set
+ *   --search=<term>   substring match against display name or SCF ID
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { initSCF } from './scf-client.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const FRAMEWORKS_DIR = path.join(REPO_ROOT, 'plugins', 'frameworks');
+const MARKETPLACE_FILE = path.join(REPO_ROOT, '.claude-plugin', 'marketplace.json');
+
+/**
+ * Legacy plugins shipped before the framework_metadata convention existed.
+ * Maps plugin slug → SCF framework_id so the discovery command can cross-
+ * reference them. Kept here as a dictionary (rather than file-per-plugin)
+ * so contributors can remove entries as they add framework_metadata to the
+ * respective plugin.json. Values verified against the SCF crosswalks index.
+ */
+const LEGACY_SCF_MAPPINGS = {
+  // SCF IDs verified against https://hackidle.github.io/scf-api/api/crosswalks.json
+  // (SCF v2026.1). Where the plugin maps to multiple SCF entries (e.g. FedRAMP
+  // has low/moderate/high/li-saas baselines, CMMC has three levels), we pick
+  // the most-common primary baseline here. Plugins can override by setting
+  // `framework_metadata.scf_framework_id` in their plugin.json, at which point
+  // the entry here becomes unused.
+  'soc2': 'general-aicpa-tsc-2017',
+  'nist-800-53': 'general-nist-800-53-r5-2',
+  'iso27001': 'general-iso-27001-2022',
+  'fedramp-rev5': 'usa-federal-gsa-fedramp-5-mod',
+  'pci-dss': 'general-pci-dss-4-0-1',
+  'cmmc': 'usa-federal-dow-cmmc-2-level-2',
+  'cis-controls': 'general-cis-csc-8-1',
+  'gdpr': 'emea-eu-gdpr-2016',
+  'csa-ccm': 'general-csa-cmm-4-1-0',
+  'nydfs': 'usa-state-ny-dfs-23-nycrr500-2023-amd2',
+  'dora': 'emea-eu-dora-2023',
+  'essential8': 'apac-aus-essential-8-2024',
+  'glba': 'usa-federal-law-glba-cfr-314-2023',
+  'ismap': 'apac-jpn-ismap',
+  // Unmapped deliberately — either no direct SCF entry or ambiguous crosswalk:
+  //   fedramp-20x  (no dedicated SCF entry; 20X KSI is an authorization process)
+  //   hitrust      (HITRUST CSF licensing may exclude it from SCF)
+  //   stateramp    (no dedicated SCF entry)
+  //   pbmm         (no dedicated SCF entry; Canada ITSG-33 exists as sibling)
+  //   irap         (Australian IRAP uses the ISM; mapping to apac-aus-ism-2024-june is arguable)
+  //   us-export    (spans ITAR + EAR; no single SCF entry)
+};
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const opts = {
+    region: null,
+    depth: null,
+    status: null,
+    search: null,
+    format: 'text',
+    offline: false,
+    limit: null,
+  };
+  for (const a of args) {
+    if (a.startsWith('--region=')) opts.region = a.slice('--region='.length).toLowerCase();
+    else if (a.startsWith('--depth=')) opts.depth = a.slice('--depth='.length).toLowerCase();
+    else if (a.startsWith('--status=')) opts.status = a.slice('--status='.length).toLowerCase();
+    else if (a === '--installed') opts.status = 'shipped';
+    else if (a === '--not-installed') opts.status = 'not-started';
+    else if (a.startsWith('--format=')) opts.format = a.slice('--format='.length).toLowerCase();
+    else if (a === '--offline') opts.offline = true;
+    else if (a.startsWith('--limit=')) opts.limit = parseInt(a.slice('--limit='.length), 10);
+    else if (a.startsWith('--search=')) opts.search = a.slice('--search='.length).toLowerCase();
+    else if (a === '--help' || a === '-h') opts.help = true;
+  }
+  return opts;
+}
+
+function usage() {
+  return `Usage: node scripts/frameworks.js [options]
+
+List every SCF-mapped framework (249) and show which have a dedicated plugin.
+
+Options:
+  --region=americas|apac|emea|global    Filter by SCF region.
+  --depth=stub|reference|full|unknown   Filter by plugin depth.
+  --status=shipped|not-started          Filter by whether a plugin exists.
+  --installed / --not-installed         Shorthand for --status.
+  --search=<term>                       Substring match against display name/ID.
+  --format=text|json|table              Output format (default: text).
+  --limit=N                             Cap the result set.
+  --offline                             Use cached SCF data only.
+
+Examples:
+  node scripts/frameworks.js                              # all 249, grouped
+  node scripts/frameworks.js --region=apac                # APAC only
+  node scripts/frameworks.js --not-installed --limit=20   # 20 to pick up
+  node scripts/frameworks.js --search=pdpa                # find Singapore PDPA, etc.
+  node scripts/frameworks.js --format=json                # machine-readable
+`;
+}
+
+function regionFromFrameworkId(frameworkId) {
+  if (frameworkId.startsWith('americas-') || frameworkId.startsWith('usa-')) return 'americas';
+  if (frameworkId.startsWith('apac-')) return 'apac';
+  if (frameworkId.startsWith('emea-')) return 'emea';
+  if (frameworkId.startsWith('general-')) return 'global';
+  return 'global';
+}
+
+async function loadPluginMetadata(slug) {
+  const pluginFile = path.join(FRAMEWORKS_DIR, slug, '.claude-plugin', 'plugin.json');
+  try {
+    const raw = await fs.readFile(pluginFile, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function listShippedPlugins() {
+  const entries = await fs.readdir(FRAMEWORKS_DIR, { withFileTypes: true });
+  const slugs = entries.filter(e => e.isDirectory()).map(e => e.name);
+  const plugins = [];
+  for (const slug of slugs) {
+    const meta = await loadPluginMetadata(slug);
+    if (!meta) continue;
+    const fwMeta = meta.framework_metadata || null;
+    const legacyScfId = LEGACY_SCF_MAPPINGS[slug] || null;
+    plugins.push({
+      slug,
+      display_name: meta.description ? meta.description.split('—')[0].trim().split(' Plugin')[0] : slug,
+      scf_framework_id: fwMeta?.scf_framework_id || legacyScfId,
+      depth: fwMeta?.depth || 'unknown',
+      region: fwMeta?.region?.toLowerCase() || (legacyScfId ? regionFromFrameworkId(legacyScfId) : null),
+    });
+  }
+  return plugins;
+}
+
+function buildCoverageRows(scfFrameworks, shipped) {
+  // Index shipped plugins by SCF framework_id (if known) and by slug.
+  const byScfId = new Map();
+  for (const p of shipped) {
+    if (p.scf_framework_id) byScfId.set(p.scf_framework_id, p);
+  }
+
+  const rows = scfFrameworks.map(f => {
+    const plugin = byScfId.get(f.framework_id);
+    const region = regionFromFrameworkId(f.framework_id);
+    return {
+      scf_framework_id: f.framework_id,
+      display_name: f.display_name,
+      region,
+      scf_controls_mapped: f.scf_controls_mapped,
+      framework_controls_mapped: f.framework_controls_mapped,
+      status: plugin ? 'shipped' : 'not-started',
+      plugin_slug: plugin?.slug || null,
+      plugin_depth: plugin?.depth || null,
+      namespace: plugin ? `/${plugin.slug}:` : null,
+    };
+  });
+
+  // Also surface any shipped plugins that are NOT matched to an SCF id
+  // (legacy plugins without framework_metadata AND no legacy mapping).
+  const matchedSlugs = new Set(rows.filter(r => r.plugin_slug).map(r => r.plugin_slug));
+  const unmatched = shipped.filter(p => !matchedSlugs.has(p.slug));
+  for (const p of unmatched) {
+    rows.push({
+      scf_framework_id: null,
+      display_name: `${p.display_name} (no SCF mapping recorded)`,
+      region: null,
+      scf_controls_mapped: null,
+      framework_controls_mapped: null,
+      status: 'shipped',
+      plugin_slug: p.slug,
+      plugin_depth: p.depth,
+      namespace: `/${p.slug}:`,
+    });
+  }
+
+  return rows;
+}
+
+function applyFilters(rows, opts) {
+  let out = rows;
+  if (opts.region) out = out.filter(r => r.region === opts.region);
+  if (opts.depth) out = out.filter(r => r.plugin_depth === opts.depth);
+  if (opts.status) out = out.filter(r => r.status === opts.status);
+  if (opts.search) {
+    const term = opts.search;
+    out = out.filter(r =>
+      (r.display_name || '').toLowerCase().includes(term) ||
+      (r.scf_framework_id || '').toLowerCase().includes(term) ||
+      (r.plugin_slug || '').toLowerCase().includes(term)
+    );
+  }
+  if (opts.limit && opts.limit > 0) out = out.slice(0, opts.limit);
+  return out;
+}
+
+function renderText(rows, summary, opts) {
+  const lines = [];
+  lines.push('');
+  lines.push(`SCF coverage: ${summary.total_scf_frameworks} frameworks · ${summary.shipped} shipped · ${summary.not_started} not started`);
+  if (summary.unmatched > 0) lines.push(`  (plus ${summary.unmatched} shipped plugins without SCF mapping)`);
+  lines.push('');
+
+  const shipped = rows.filter(r => r.status === 'shipped').sort(compareRows);
+  const pending = rows.filter(r => r.status === 'not-started').sort(compareRows);
+
+  if (shipped.length > 0) {
+    lines.push(`Shipped plugins (${shipped.length}):`);
+    for (const r of shipped) {
+      const depth = r.plugin_depth ? `[${r.plugin_depth}]`.padEnd(12) : '[unknown]  ';
+      const ns = (r.namespace || '').padEnd(22);
+      lines.push(`  ✓ ${ns}${depth}${r.display_name}`);
+    }
+    lines.push('');
+  }
+
+  if (pending.length > 0) {
+    lines.push(`Not started (${pending.length}) — crosswalk-supported today via /grc-engineer:gap-assessment:`);
+    const max = opts.limit ? Math.min(pending.length, opts.limit) : pending.length;
+    for (let i = 0; i < max; i++) {
+      const r = pending[i];
+      const id = (r.scf_framework_id || '').padEnd(50);
+      lines.push(`  ○ ${id}${r.display_name}`);
+    }
+    if (max < pending.length) lines.push(`  ... and ${pending.length - max} more (use --limit=N to control, or --format=json for the full set)`);
+    lines.push('');
+    lines.push(`To adopt a framework, run: node plugins/grc-engineer/scripts/scaffold-framework.js <scf-framework-id>`);
+  }
+
+  return lines.join('\n');
+}
+
+function compareRows(a, b) {
+  const ra = a.region || 'zzz';
+  const rb = b.region || 'zzz';
+  if (ra !== rb) return ra.localeCompare(rb);
+  return (a.display_name || '').localeCompare(b.display_name || '');
+}
+
+function renderTable(rows) {
+  const header = ['status', 'depth', 'namespace', 'scf_framework_id', 'display_name'];
+  const widths = header.map(h => h.length);
+  const data = rows.map(r => [
+    r.status,
+    r.plugin_depth || '-',
+    r.namespace || '-',
+    r.scf_framework_id || '-',
+    r.display_name,
+  ]);
+  for (const row of data) row.forEach((cell, i) => { widths[i] = Math.max(widths[i], String(cell).length); });
+  const fmt = row => row.map((cell, i) => String(cell).padEnd(widths[i])).join('  ');
+  const out = [fmt(header), fmt(widths.map(w => '-'.repeat(w)))];
+  for (const row of data) out.push(fmt(row));
+  return out.join('\n');
+}
+
+async function main() {
+  const opts = parseArgs(process.argv);
+  if (opts.help) {
+    console.log(usage());
+    return;
+  }
+
+  const scf = await initSCF({ offline: opts.offline });
+  const [scfFrameworks, shipped] = await Promise.all([
+    scf.frameworks(),
+    listShippedPlugins(),
+  ]);
+
+  const rows = buildCoverageRows(scfFrameworks, shipped);
+  const summary = {
+    total_scf_frameworks: scfFrameworks.length,
+    shipped: rows.filter(r => r.status === 'shipped' && r.scf_framework_id).length,
+    not_started: rows.filter(r => r.status === 'not-started').length,
+    unmatched: rows.filter(r => r.status === 'shipped' && !r.scf_framework_id).length,
+  };
+
+  const filtered = applyFilters(rows, opts);
+
+  if (opts.format === 'json') {
+    console.log(JSON.stringify({ summary, frameworks: filtered }, null, 2));
+  } else if (opts.format === 'table') {
+    console.log(renderTable(filtered));
+  } else {
+    console.log(renderText(filtered, summary, opts));
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(err => {
+    console.error('✗ frameworks: ', err.message);
+    if (process.env.DEBUG) console.error(err);
+    process.exit(1);
+  });
+}
+
+export { buildCoverageRows, applyFilters };


### PR DESCRIPTION
Closes #10.

## What

\`/grc-engineer:frameworks\` lists every framework in the SCF crosswalk (249) and annotates each with its plugin status in this repo. Answers the everyday question *"is X supported, and if so, how do I use it?"* without scrolling through the marketplace.

## Example output

\`\`\`
SCF coverage: 249 frameworks · 15 shipped · 234 not started
  (plus 6 shipped plugins without SCF mapping)

Shipped plugins (21):
  ✓ /essential8:          [unknown]   Australia - Essential Eight (2024)
  ✓ /singapore-pdpa:      [reference] Singapore - Personal Data Protection Ac (PDPA) (2012)
  ✓ /gdpr:                [unknown]   EU General Data Protection Regulation (GDPR) (2016)
  ...
  
Not started (234) — crosswalk-supported today via /grc-engineer:gap-assessment:
  ○ usa-federal-law-hipaa-security-rule-2013  HIPAA Security Rule (2013)
  ○ apac-aus-ps-cps-230-2023                   Australia - Prudential Standard CPS 230 (2023)
  ...
\`\`\`

## Filters

- \`--region=americas|apac|emea|global\`
- \`--depth=stub|reference|full|unknown\`
- \`--status=shipped|not-started\` (+ \`--installed\` / \`--not-installed\` shortcuts)
- \`--search=<substring>\`
- \`--format=text|json|table\`
- \`--limit=N\`
- \`--offline\`

## Legacy SCF mapping audit

I verified SCF IDs for **15 of the 21** existing framework plugins against the SCF crosswalks index. 6 are honestly marked *"no SCF mapping recorded"* (fedramp-20x, stateramp, pbmm, hitrust, us-export, irap) because they either have no direct SCF entry, involve licensed content, or span multiple SCF entries. Plugins can override the fallback by adding a \`framework_metadata.scf_framework_id\` block.

## Pairs with

- #9 (scaffold-framework) — copy an SCF ID from this command's output directly into \`scaffold-framework <scf-id>\` to add a plugin.
- #12 (framework coverage tracker) — this command's \`--format=json\` output will eventually drive the auto-generated \`docs/FRAMEWORK-COVERAGE.md\`.

## Verification

- [x] \`--installed\` shows 21 shipped plugins, 15 with correct SCF mapping
- [x] \`--region=apac --not-installed --limit=5\` returns APAC-only rows
- [x] \`--search=pdpa\` finds Singapore PDPA + 3 other PDPA-like frameworks
- [x] \`--format=json\` is valid JSON with \`summary\` + \`frameworks\` keys
- [x] \`--offline\` works against cached data
- [x] markdownlint clean, contract-test unchanged
- [ ] CI: markdown-lint
- [ ] CI: lychee
- [ ] 1 leadership-team review