### PR TITLE
docs(roadmap): add Platform integrations section

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,6 +61,29 @@ proposes these new categories:
 - Program management
 - Meetings
 
+## Platform integrations (MCP bridges and knowledge sources)
+
+Teams using commercial GRC platforms shouldn't have to choose between their
+platform and this toolkit. Bridges pull platform-owned data into the Finding
+schema so `/grc-engineer:gap-assessment` can consume it alongside the toolkit's
+direct connectors.
+
+- **Vanta MCP bridge** — wraps [`VantaInc/vanta-mcp-server`](https://github.com/VantaInc/vanta-mcp-server)
+  (official, MIT). Replaces the stale `vanta-go-export` entry.
+- **Drata MCP bridge** — wraps [Drata's AI MCP](https://drata.com/products/ai/mcp).
+- **OneTrust / Archer / ServiceNow GRC** — candidates for future MCP or SDK bridges
+  once those platforms ship stable programmatic surfaces.
+
+Knowledge-source plugins query authoritative external docs at assessment time
+rather than baking stale guidance into framework plugins:
+
+- **Google Developer Knowledge API** — GCP and Workspace security/compliance
+  documentation retrieval with citation-backed answers.
+- **FedRAMP docs MCP** — live FedRAMP documentation lookup (candidate for
+  in-house maintenance).
+- **NIST / SCF** — the Club already fetches SCF crosswalks; cross-reference
+  with NIST 800-53 rev data via the existing SCF API.
+
 ## Schema v1.1 candidates
 
 Potential contract work after the current schema baseline stabilizes:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,11 +66,14 @@ proposes these new categories:
 Teams using commercial GRC platforms shouldn't have to choose between their
 platform and this toolkit. Bridges pull platform-owned data into the Finding
 schema so `/grc-engineer:gap-assessment` can consume it alongside the toolkit's
-direct connectors.
+direct connectors. Vendor-owned Claude Code plugins (when they exist) are
+**installed alongside** the Club toolkit, not vendored — bridges are
+normalization layers, not forks.
 
-- **Vanta MCP bridge** — wraps [`VantaInc/vanta-mcp-server`](https://github.com/VantaInc/vanta-mcp-server)
-  (official, MIT). Replaces the stale `vanta-go-export` entry.
-- **Drata MCP bridge** — wraps [Drata's AI MCP](https://drata.com/products/ai/mcp).
+- **Vanta bridge** — normalizes output from [`VantaInc/vanta-mcp-plugin`](https://github.com/VantaInc/vanta-mcp-plugin)
+  (official Vanta Claude Code plugin, MIT) into Finding schema. Replaces the
+  stale `vanta-go-export` entry.
+- **Drata bridge** — companion pattern for [Drata's AI MCP](https://drata.com/products/ai/mcp).
 - **OneTrust / Archer / ServiceNow GRC** — candidates for future MCP or SDK bridges
   once those platforms ship stable programmatic surfaces.
 


### PR DESCRIPTION
Adds a **Platform integrations** section to ROADMAP.md naming three near-term directions with corresponding tracked issues:

- [#44 Vanta MCP bridge](../issues/44) — wraps [`VantaInc/vanta-mcp-server`](https://github.com/VantaInc/vanta-mcp-server) (official, MIT). Replaces the stale `vanta-go-export` roadmap entry.
- [#45 Drata MCP bridge](../issues/45) — companion pattern for [Drata's AI MCP](https://drata.com/products/ai/mcp).
- [#46 Google Developer Knowledge API plugin](../issues/46) — new `knowledge-source` plugin category for runtime citation-backed GCP/Workspace documentation lookup.

## Why

The toolkit currently frames itself as an alternative to Vanta/Drata/Archer. In practice, most GRC teams already use one of these platforms — the toolkit should *augment* them by normalizing their data into the Finding schema so `/grc-engineer:gap-assessment`, `/grc-engineer:generate-implementation`, and SCF crosswalks all work on top of Vanta/Drata evidence.

The Google Knowledge API plugin is a different pattern — a knowledge-source plugin that other plugins invoke to cite authoritative external docs at assessment time, avoiding baked-in stale guidance.

## What's not in this PR

This is a roadmap + issues PR only. No implementation code. The actual plugins will land in separate PRs claimed by contributors with platform access.