### PR TITLE
fix(plugins): use object form for plugin.json author field

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,7 +64,7 @@ mkdir -p plugins/connectors/<tool>/{commands,skills/<tool>-expert,scripts,tests/
   "name": "<tool>-inspector",
   "version": "0.1.0",
   "description": "Connector for <tool>. Emits GRC findings against SCF + SOC 2/NIST/ISO/…",
-  "author": "you <you@example.com>",
+  "author": { "name": "you", "email": "you@example.com" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "<tool>"]

--- a/plugins/connectors/aws-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/aws-inspector/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "aws-inspector",
   "version": "0.1.0",
   "description": "GRC connector for AWS: evaluates IAM, S3, CloudTrail, EBS, and RDS for compliance misconfigurations. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "aws", "scf", "soc2", "fedramp", "connector"]

--- a/plugins/connectors/gcp-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/gcp-inspector/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "gcp-inspector",
   "version": "0.1.0",
   "description": "GRC connector for Google Cloud: evaluates IAM, Cloud Storage, audit logs, KMS rotation, and Compute for compliance misconfigurations. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "gcp", "google-cloud", "scf", "fedramp", "connector"]

--- a/plugins/connectors/github-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/github-inspector/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "github-inspector",
   "version": "0.1.0",
   "description": "GRC connector for GitHub: evaluates repo protections, branch policies, Actions, secret scanning, Dependabot, and deploy keys. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "github", "scf", "soc2", "connector"]

--- a/plugins/connectors/okta-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/okta-inspector/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "okta-inspector",
   "version": "0.1.0",
   "description": "GRC connector for Okta: evaluates authentication policies, MFA enrollment, password policy, session management, and admin/privileged accounts. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "okta", "identity", "iam", "scf", "fedramp", "connector"]

--- a/plugins/fedramp-ssp/.claude-plugin/plugin.json
+++ b/plugins/fedramp-ssp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "fedramp-ssp",
   "version": "0.1.0",
   "description": "Convert FedRAMP Rev 5 Moderate SSP DOCX templates to validated OSCAL 1.2.0 JSON. Wraps ethanolivertroy/frdocx-to-froscal-ssp — ready for oscal-cli, Compliance Trestle, eMASS, and FedRAMP 20X workflows.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["fedramp", "oscal", "ssp", "docx", "compliance-as-code"]

--- a/plugins/oscal/.claude-plugin/plugin.json
+++ b/plugins/oscal/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "oscal",
   "version": "0.1.0",
   "description": "OSCAL (Open Security Controls Assessment Language) toolkit for Claude Code. Wraps ethanolivertroy/oscal-cli for validation and conversion of catalogs, profiles, SSPs, SAPs, SARs, POA&Ms, component definitions, and assessment results.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["oscal", "fedramp", "grc", "compliance", "nist"]


### PR DESCRIPTION
## Summary

Six plugin manifests ship with `author` as a bare string, which the current Claude Code plugin loader rejects. The result: those plugins cannot be installed via `claude plugin install`.

```
$ claude plugin install github-inspector@grc-engineering-suite
✘ Failed to install plugin "github-inspector@grc-engineering-suite":
  Plugin … has an invalid manifest file.
  Validation errors: author: Invalid input: expected object, received string
```

The rest of the marketplace (`grc-engineer`, `soc2`, `nist-800-53`, all framework plugins) already uses the object form `{ "name": "..." }`. This PR normalises the six remaining manifests so they match — and so they install.

## Files changed

- `plugins/connectors/aws-inspector/.claude-plugin/plugin.json`
- `plugins/connectors/gcp-inspector/.claude-plugin/plugin.json`
- `plugins/connectors/github-inspector/.claude-plugin/plugin.json`
- `plugins/connectors/okta-inspector/.claude-plugin/plugin.json`
- `plugins/fedramp-ssp/.claude-plugin/plugin.json`
- `plugins/oscal/.claude-plugin/plugin.json`
- `docs/CONTRIBUTING.md` — updated the `plugin.json` example so new connector contributors land on the working schema by default

Diff is one line per file, no formatting changes elsewhere.

## Test plan

- [x] `claude plugin install github-inspector@grc-engineering-suite` succeeds after patch (verified locally)
- [x] `claude plugin install aws-inspector@grc-engineering-suite` succeeds after patch
- [x] `claude plugin install gcp-inspector@grc-engineering-suite` succeeds after patch
- [x] `claude plugin install okta-inspector@grc-engineering-suite` succeeds after patch
- [x] `claude plugin install oscal@grc-engineering-suite` succeeds after patch
- [x] `claude plugin install fedramp-ssp@grc-engineering-suite` succeeds after patch
- [x] All previously-working plugins (`grc-engineer`, `soc2`, etc.) still install — they already used the object form

## Notes

The Tier-1 connector plugins are critical for the QUICKSTART path — `/grc-engineer:gap-assessment` needs at least one connector emitting Findings, and right now none of them install on a current Claude Code CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated connector scaffold documentation to reflect changes in plugin author metadata structure.

* **Chores**
  * Standardized author metadata across all plugins and connectors from string format to structured object format containing a name field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->