### PR TITLE
ci(plugins): validate manifests against JSON Schema on every PR

### DIFF
--- a/.github/workflows/validate-plugin-manifests.yml
+++ b/.github/workflows/validate-plugin-manifests.yml
@@ -1,0 +1,41 @@
+name: Validate plugin manifests
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/**/plugin.json'
+      - '.claude-plugin/marketplace.json'
+      - 'schemas/plugin.schema.json'
+      - 'schemas/marketplace.schema.json'
+      - 'tests/validate-plugin-manifests.sh'
+      - '.github/workflows/validate-plugin-manifests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/**/plugin.json'
+      - '.claude-plugin/marketplace.json'
+      - 'schemas/plugin.schema.json'
+      - 'schemas/marketplace.schema.json'
+      - 'tests/validate-plugin-manifests.sh'
+      - '.github/workflows/validate-plugin-manifests.yml'
+
+concurrency:
+  group: validate-plugin-manifests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-manifests:
+    name: Validate plugin and marketplace manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install ajv-cli + formats
+        run: npm install --no-save ajv-cli@5 ajv-formats@3
+
+      - name: Validate every plugin and marketplace manifest
+        run: bash tests/validate-plugin-manifests.sh

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,7 +64,7 @@ mkdir -p plugins/connectors/<tool>/{commands,skills/<tool>-expert,scripts,tests/
   "name": "<tool>-inspector",
   "version": "0.1.0",
   "description": "Connector for <tool>. Emits GRC findings against SCF + SOC 2/NIST/ISO/…",
-  "author": "you <you@example.com>",
+  "author": { "name": "you", "email": "you@example.com" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "<tool>"]

--- a/plugins/connectors/aws-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/aws-inspector/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "aws-inspector",
   "version": "0.1.0",
   "description": "GRC connector for AWS: evaluates IAM, S3, CloudTrail, EBS, and RDS for compliance misconfigurations. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "aws", "scf", "soc2", "fedramp", "connector"]

--- a/plugins/connectors/gcp-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/gcp-inspector/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "gcp-inspector",
   "version": "0.1.0",
   "description": "GRC connector for Google Cloud: evaluates IAM, Cloud Storage, audit logs, KMS rotation, and Compute for compliance misconfigurations. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "gcp", "google-cloud", "scf", "fedramp", "connector"]

--- a/plugins/connectors/github-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/github-inspector/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "github-inspector",
   "version": "0.1.0",
   "description": "GRC connector for GitHub: evaluates repo protections, branch policies, Actions, secret scanning, Dependabot, and deploy keys. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "github", "scf", "soc2", "connector"]

--- a/plugins/connectors/okta-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/okta-inspector/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "okta-inspector",
   "version": "0.1.0",
   "description": "GRC connector for Okta: evaluates authentication policies, MFA enrollment, password policy, session management, and admin/privileged accounts. Emits findings conforming to schemas/finding.schema.json v1.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["grc", "compliance", "okta", "identity", "iam", "scf", "fedramp", "connector"]

--- a/plugins/fedramp-ssp/.claude-plugin/plugin.json
+++ b/plugins/fedramp-ssp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "fedramp-ssp",
   "version": "0.1.0",
   "description": "Convert FedRAMP Rev 5 Moderate SSP DOCX templates to validated OSCAL 1.2.0 JSON. Wraps ethanolivertroy/frdocx-to-froscal-ssp — ready for oscal-cli, Compliance Trestle, eMASS, and FedRAMP 20X workflows.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["fedramp", "oscal", "ssp", "docx", "compliance-as-code"]

--- a/plugins/oscal/.claude-plugin/plugin.json
+++ b/plugins/oscal/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "oscal",
   "version": "0.1.0",
   "description": "OSCAL (Open Security Controls Assessment Language) toolkit for Claude Code. Wraps ethanolivertroy/oscal-cli for validation and conversion of catalogs, profiles, SSPs, SAPs, SARs, POA&Ms, component definitions, and assessment results.",
-  "author": "GRC Engineering Club Contributors",
+  "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
   "keywords": ["oscal", "fedramp", "grc", "compliance", "nist"]

--- a/schemas/marketplace.schema.json
+++ b/schemas/marketplace.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/GRCEngClub/claude-grc-engineering/main/schemas/marketplace.schema.json",
+  "title": "Claude Code marketplace manifest",
+  "description": "Schema for .claude-plugin/marketplace.json. Validates the shape `claude plugin marketplace add` expects.",
+  "type": "object",
+  "required": ["name", "owner", "plugins"],
+  "additionalProperties": true,
+  "properties": {
+    "name": { "type": "string", "minLength": 1 },
+    "owner": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "url": { "type": "string" },
+        "email": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "plugins": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "source"],
+        "additionalProperties": true,
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "source": { "type": "string", "minLength": 1 },
+          "version": { "type": "string" },
+          "description": { "type": "string" },
+          "category": { "type": "string" },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/marketplace.schema.json
+++ b/schemas/marketplace.schema.json
@@ -32,7 +32,10 @@
         "properties": {
           "name": { "type": "string", "minLength": 1 },
           "source": { "type": "string", "minLength": 1 },
-          "version": { "type": "string" },
+          "version": {
+            "type": "string",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+          },
           "description": { "type": "string" },
           "category": { "type": "string" },
           "tags": {

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/GRCEngClub/claude-grc-engineering/main/schemas/plugin.schema.json",
+  "title": "Claude Code plugin manifest",
+  "description": "Schema for plugin.json files in this marketplace. Mirrors the install-time validation that `claude plugin install` performs, so any manifest that passes here is installable. Extension keys such as `framework_metadata` are permitted via additionalProperties.",
+  "type": "object",
+  "required": ["name", "version"],
+  "additionalProperties": true,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Plugin identifier. Must match the directory name and the marketplace.json entry."
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Semver-compatible version string, e.g. 0.1.0."
+    },
+    "description": {
+      "type": "string"
+    },
+    "author": {
+      "type": "object",
+      "description": "Author metadata. Must be an object — bare strings are rejected by `claude plugin install`.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "email": { "type": "string" },
+        "url": { "type": "string" }
+      }
+    },
+    "license": { "type": "string" },
+    "repository": { "type": "string" },
+    "homepage": { "type": "string" },
+    "keywords": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -15,7 +15,8 @@
     "version": {
       "type": "string",
       "minLength": 1,
-      "description": "Semver-compatible version string, e.g. 0.1.0."
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+      "description": "Semver-compatible version string, e.g. 0.1.0. Pattern enforces the semver 2.0.0 grammar (major.minor.patch with optional prerelease and build-metadata segments)."
     },
     "description": {
       "type": "string"

--- a/tests/validate-plugin-manifests.sh
+++ b/tests/validate-plugin-manifests.sh
@@ -17,7 +17,10 @@ set -uo pipefail
 PATH="./node_modules/.bin:$PATH"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$repo_root"
+cd "$repo_root" || {
+  echo "Failed to cd to repo root: $repo_root" >&2
+  exit 2
+}
 
 if ! command -v ajv >/dev/null 2>&1; then
   echo "ajv-cli not found. Install with: npm install --no-save ajv-cli@5 ajv-formats@3" >&2
@@ -96,6 +99,9 @@ validate_file() {
 
 if [[ -f .claude-plugin/marketplace.json ]]; then
   validate_file "$marketplace_schema" .claude-plugin/marketplace.json
+else
+  emit_summary_error "Missing required .claude-plugin/marketplace.json (this repository is a Claude Code plugin marketplace; the top-level marketplace manifest must exist)"
+  exit 1
 fi
 
 while IFS= read -r manifest; do

--- a/tests/validate-plugin-manifests.sh
+++ b/tests/validate-plugin-manifests.sh
@@ -34,12 +34,20 @@ fail=0
 checked=0
 in_ci="${GITHUB_ACTIONS:-false}"
 
-# Escape values that get interpolated into GitHub Actions workflow commands
-# (`::group::`, `::error file=…::…`). Filenames here come from `find` over a
-# PR-controlled tree, so a crafted path containing `%`, CR, or LF could
-# otherwise inject additional workflow commands into the CI log.
+# Escape values that get interpolated into GitHub Actions workflow commands.
+# Filenames here come from `find` over a PR-controlled tree, so a crafted path
+# containing `%`, CR, LF, `:`, or `,` could otherwise inject additional
+# workflow commands or break annotation property parsing.
+#
+# Two escape modes mirror @actions/toolkit's escapeData / escapeProperty:
+# - data:     used in the message body (`::name::message` and `::group::value`)
+# - property: used in `key=value` parameters (`::error file=...,line=...::msg`).
+#             Properties additionally escape `:` and `,` because those are the
+#             property delimiters; failing to escape them lets a crafted file
+#             path inject fake `line=`/`title=` parameters or break the `::`.
 # See: https://docs.github.com/actions/reference/workflow-commands-for-github-actions
-gha_escape() {
+# Reference: https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+gha_escape_data() {
   local s="$1"
   s="${s//%/%25}"
   s="${s//$'\r'/%0D}"
@@ -47,9 +55,17 @@ gha_escape() {
   printf '%s' "$s"
 }
 
+gha_escape_property() {
+  local s
+  s="$(gha_escape_data "$1")"
+  s="${s//:/%3A}"
+  s="${s//,/%2C}"
+  printf '%s' "$s"
+}
+
 emit_group_start() {
   if [[ "$in_ci" == "true" ]]; then
-    printf '::group::%s\n' "$(gha_escape "$1")"
+    printf '::group::%s\n' "$(gha_escape_data "$1")"
   else
     printf '── %s\n' "$1"
   fi
@@ -64,7 +80,7 @@ emit_group_end() {
 emit_error() {
   local file="$1" message="$2"
   if [[ "$in_ci" == "true" ]]; then
-    printf '::error file=%s::%s\n' "$(gha_escape "$file")" "$(gha_escape "$message")"
+    printf '::error file=%s::%s\n' "$(gha_escape_property "$file")" "$(gha_escape_data "$message")"
   else
     printf 'ERROR (%s): %s\n' "$file" "$message" >&2
   fi
@@ -73,7 +89,7 @@ emit_error() {
 emit_summary_error() {
   local message="$1"
   if [[ "$in_ci" == "true" ]]; then
-    printf '::error::%s\n' "$(gha_escape "$message")"
+    printf '::error::%s\n' "$(gha_escape_data "$message")"
   else
     printf 'ERROR: %s\n' "$message" >&2
   fi

--- a/tests/validate-plugin-manifests.sh
+++ b/tests/validate-plugin-manifests.sh
@@ -29,23 +29,69 @@ marketplace_schema="schemas/marketplace.schema.json"
 
 fail=0
 checked=0
+in_ci="${GITHUB_ACTIONS:-false}"
+
+# Escape values that get interpolated into GitHub Actions workflow commands
+# (`::group::`, `::error file=…::…`). Filenames here come from `find` over a
+# PR-controlled tree, so a crafted path containing `%`, CR, or LF could
+# otherwise inject additional workflow commands into the CI log.
+# See: https://docs.github.com/actions/reference/workflow-commands-for-github-actions
+gha_escape() {
+  local s="$1"
+  s="${s//%/%25}"
+  s="${s//$'\r'/%0D}"
+  s="${s//$'\n'/%0A}"
+  printf '%s' "$s"
+}
+
+emit_group_start() {
+  if [[ "$in_ci" == "true" ]]; then
+    printf '::group::%s\n' "$(gha_escape "$1")"
+  else
+    printf '── %s\n' "$1"
+  fi
+}
+
+emit_group_end() {
+  if [[ "$in_ci" == "true" ]]; then
+    printf '::endgroup::\n'
+  fi
+}
+
+emit_error() {
+  local file="$1" message="$2"
+  if [[ "$in_ci" == "true" ]]; then
+    printf '::error file=%s::%s\n' "$(gha_escape "$file")" "$(gha_escape "$message")"
+  else
+    printf 'ERROR (%s): %s\n' "$file" "$message" >&2
+  fi
+}
+
+emit_summary_error() {
+  local message="$1"
+  if [[ "$in_ci" == "true" ]]; then
+    printf '::error::%s\n' "$(gha_escape "$message")"
+  else
+    printf 'ERROR: %s\n' "$message" >&2
+  fi
+}
 
 validate_file() {
   local schema="$1"
   local file="$2"
   checked=$((checked + 1))
-  echo "::group::$file"
+  emit_group_start "$file"
   if ajv validate \
       --spec=draft2020 \
       -s "$schema" \
       -d "$file" \
       --errors=line; then
-    echo "  ✓ $file"
+    printf '  ✓ %s\n' "$file"
   else
-    echo "::error file=$file::Manifest failed schema validation against $schema"
+    emit_error "$file" "Manifest failed schema validation against $schema"
     fail=1
   fi
-  echo "::endgroup::"
+  emit_group_end
 }
 
 if [[ -f .claude-plugin/marketplace.json ]]; then
@@ -59,7 +105,7 @@ done < <(find plugins -type f -name plugin.json -path '*/.claude-plugin/*' | sor
 echo
 echo "Validated $checked manifest(s)."
 if [[ $fail -ne 0 ]]; then
-  echo "::error::One or more manifests failed schema validation"
+  emit_summary_error "One or more manifests failed schema validation"
   exit 1
 fi
 echo "All manifests valid."

--- a/tests/validate-plugin-manifests.sh
+++ b/tests/validate-plugin-manifests.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Validate every plugin.json and the marketplace.json against the
+# Claude Code plugin schemas in schemas/.
+#
+# This guards against the common failure mode where a manifest looks
+# fine to the contributor but is rejected at install time by
+# `claude plugin install`. The most frequent offender is the `author`
+# field — Claude Code requires an object form `{ "name": "..." }`,
+# not a bare string.
+#
+# Run locally:
+#   npm install --no-save ajv-cli@5 ajv-formats@3
+#   bash tests/validate-plugin-manifests.sh
+
+set -uo pipefail
+
+PATH="./node_modules/.bin:$PATH"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v ajv >/dev/null 2>&1; then
+  echo "ajv-cli not found. Install with: npm install --no-save ajv-cli@5 ajv-formats@3" >&2
+  exit 2
+fi
+
+plugin_schema="schemas/plugin.schema.json"
+marketplace_schema="schemas/marketplace.schema.json"
+
+fail=0
+checked=0
+
+validate_file() {
+  local schema="$1"
+  local file="$2"
+  checked=$((checked + 1))
+  echo "::group::$file"
+  if ajv validate \
+      --spec=draft2020 \
+      -s "$schema" \
+      -d "$file" \
+      --errors=line; then
+    echo "  ✓ $file"
+  else
+    echo "::error file=$file::Manifest failed schema validation against $schema"
+    fail=1
+  fi
+  echo "::endgroup::"
+}
+
+if [[ -f .claude-plugin/marketplace.json ]]; then
+  validate_file "$marketplace_schema" .claude-plugin/marketplace.json
+fi
+
+while IFS= read -r manifest; do
+  validate_file "$plugin_schema" "$manifest"
+done < <(find plugins -type f -name plugin.json -path '*/.claude-plugin/*' | sort)
+
+echo
+echo "Validated $checked manifest(s)."
+if [[ $fail -ne 0 ]]; then
+  echo "::error::One or more manifests failed schema validation"
+  exit 1
+fi
+echo "All manifests valid."


### PR DESCRIPTION
## Summary

- Adds a CI workflow that schema-validates every `plugin.json` plus the top-level `.claude-plugin/marketplace.json` on each PR.
- Catches the exact class of bug fixed in #70 (`author` field as bare string instead of object) before it lands on `main` and breaks `claude plugin install` for end users.
- Ships two committed JSON Schemas (`schemas/plugin.schema.json`, `schemas/marketplace.schema.json`) so the manifest contract is documented in the repo, and contributors can validate locally with one command.

> Stacked on #70. The validator passes against the patched tree on that branch; against current `main`, it would correctly fail on the six manifests #70 fixes. Best reviewed after #70 merges.

## Why a custom schema, not `claude plugin validate`

`claude plugin validate` works locally but rejects unknown keys in strict mode — including `framework_metadata`, which framework plugins (`soc2`, `nist-800-53`, `cmmc`, …) use intentionally. Running it across the repo would false-flag ~20 plugins.

The schemas here mirror what `claude plugin install` actually enforces at install time: required fields and field types, with `additionalProperties: true` for extension keys. Any manifest that passes here installs cleanly; any that fails won't.

## Files

- `schemas/plugin.schema.json` — plugin.json contract. Requires `author` to be an object, requires `name` and `version`, allows extension keys.
- `schemas/marketplace.schema.json` — marketplace.json contract.
- `tests/validate-plugin-manifests.sh` — ajv-cli loop, emits GitHub Actions error annotations on failure.
- `.github/workflows/validate-plugin-manifests.yml` — triggers on manifest or schema changes. Matches the existing `contract-test.yml` style: Node 20, ajv-cli@5, ajv-formats@3, concurrency cancellation.

## Test plan

- [x] All 33 current manifests pass against the new schemas (verified locally with `bash tests/validate-plugin-manifests.sh`)
- [x] Reverting any one manifest to the broken `"author": "<string>"` form fails the job with an inline `::error file=...` annotation pointing at the offending file
- [x] Exit code is 1 on failure, 0 on success
- [x] Workflow path filter only triggers on relevant changes (manifest, schema, workflow, validation script)

## Local usage

```bash
npm install --no-save ajv-cli@5 ajv-formats@3
bash tests/validate-plugin-manifests.sh
```

Same command CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflow to validate plugin and marketplace manifests against JSON schemas
  * Updated plugin author metadata from string to structured object across connectors and plugins
  * Added JSON schemas for plugin and marketplace manifest validation
  * Added a validation script to check manifest compliance and fail on invalid manifests

* **Documentation**
  * Updated contributing guide to reflect the new plugin manifest author structure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->