### PR TITLE
feat(frameworks): Reference-depth India DPDPA plugin (ind-dpdpa)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -219,6 +219,12 @@
       "source": "./plugins/frameworks/cyber-essentials-plus",
       "description": "UK NCSC Cyber Essentials Plus (CE+) v3.3 Danzell — gap assessments, evidence checklists, remediation plans, and cross-framework mapping to ISO 27001 and NIST CSF.",
       "version": "0.1.0"
+    },
+    {
+      "name": "ind-dpdpa",
+      "source": "./plugins/frameworks/ind-dpdpa",
+      "description": "India Digital Personal Data Protection Act, 2023 — reference-depth plugin with scope determination, evidence checklist, and breach-process workflow backed by the SCF crosswalk.",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/frameworks/ind-dpdpa/.claude-plugin/plugin.json
+++ b/plugins/frameworks/ind-dpdpa/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "ind-dpdpa",
+  "description": "India DPDPA 2023 + DPDP Rules 2025 — Reference-depth plugin: scope, evidence checklist, breach process, and sectoral overlap (RBI / SEBI / IRDAI / TRAI) for Data Fiduciaries operating in India.",
+  "version": "0.2.0",
+  "author": {
+    "name": "Devam Shah",
+    "url": "https://github.com/DevamShah"
+  },
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "framework_metadata": {
+    "scf_framework_id": "apac-ind-dpdpa-2023",
+    "display_name": "India - DPDPA (2023) + DPDP Rules (2025)",
+    "region": "APAC",
+    "country": "IN",
+    "depth": "reference",
+    "scf_controls_mapped": 41,
+    "framework_controls_mapped": 96,
+    "industry": [],
+    "regulator": "Data Protection Board of India (DPB) under MeitY"
+  }
+}

--- a/plugins/frameworks/ind-dpdpa/.claude-plugin/plugin.json
+++ b/plugins/frameworks/ind-dpdpa/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ind-dpdpa",
   "description": "India DPDPA 2023 + DPDP Rules 2025 — Reference-depth plugin: scope, evidence checklist, breach process, and sectoral overlap (RBI / SEBI / IRDAI / TRAI) for Data Fiduciaries operating in India.",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "author": {
     "name": "Devam Shah",
     "url": "https://github.com/DevamShah"

--- a/plugins/frameworks/ind-dpdpa/README.md
+++ b/plugins/frameworks/ind-dpdpa/README.md
@@ -1,0 +1,99 @@
+# ind-dpdpa — India DPDPA (2023) + DPDP Rules (2025)
+
+Reference-depth framework plugin for India's **Digital Personal Data Protection Act, 2023** and its operational rules **DPDP Rules, 2025**. Built for CISOs, DPOs, GRC engineers, and platform teams operating in India or offering goods and services to Data Principals located in India.
+
+```bash
+# Install
+/plugin install ind-dpdpa@grc-engineering-suite
+
+# Use
+/ind-dpdpa:scope                  # confirm applicability + role + SDF triggers
+/ind-dpdpa:evidence-checklist     # collect evidence by Act theme
+/ind-dpdpa:breach-process         # walk through the 72-hour notification timeline
+/ind-dpdpa:assess                 # run the gap assessment
+```
+
+## What this plugin covers
+
+DPDPA + DPDP Rules together regulate **digital personal data processing** in India and by entities outside India that offer goods or services to Data Principals located in India. This plugin treats the two as one body of law:
+
+| Layer | What it sets | Status |
+|---|---|---|
+| **DPDPA 2023** (the Act) | Substantive obligations on Data Fiduciaries; rights of Data Principals; penalty schedule; Data Protection Board structure | Enacted 2023 |
+| **DPDP Rules 2025** | Operational detail — breach notification timelines, Consent Manager registration, exemption procedures, SDF-related thresholds | Notified November 2025 |
+| **Data Protection Board (DPB) orders** | Binding interpretations through enforcement actions | Emerging |
+
+The plugin maps to the **SCF crosswalk** for `apac-ind-dpdpa-2023`: 41 SCF controls cover the 96 mapped DPDPA control identifiers (Act sections + Rules clauses).
+
+## Roles
+
+| Role | DPDPA term | What it means in practice |
+|---|---|---|
+| Determines purpose and means of processing | **Data Fiduciary** | A bank, e-commerce platform, SaaS vendor, healthcare provider, government body — anyone who decides what to do with personal data |
+| Processes on behalf of a Fiduciary under contract | **Data Processor** | Cloud providers, payroll vendors, KYC vendors, analytics partners |
+| Whose data is processed | **Data Principal** | The natural person; if a child, the parent/guardian acts |
+| Manages consents on behalf of Data Principals | **Consent Manager** | A Board-registered entity that brokers, withdraws, and produces evidence of consents |
+| Notified by the Central Government for higher-risk processing | **Significant Data Fiduciary (SDF)** | Subset of Fiduciaries — additional obligations: appointed DPO based in India, periodic DPIA, periodic audit |
+
+`/ind-dpdpa:scope` walks through the SDF triggers (volume of data, sensitivity, sovereignty / electoral / public-order risk).
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `/ind-dpdpa:scope` | Determine applicability, role assignment, and whether SDF criteria apply. Run this first. |
+| `/ind-dpdpa:assess` | Compliance gap assessment via SCF crosswalk. Supports `--scope=`, `--role=`, `--sources=`. |
+| `/ind-dpdpa:evidence-checklist` | Evidence patterns grouped by DPDPA theme — Notice, Consent, Purpose Limitation, Retention, Rights, Security, Breach, Cross-border, Children, SDF obligations. |
+| `/ind-dpdpa:breach-process` | DPDP Rules 2025 R7 — the 72-hour breach notification timeline, parallel sectoral clocks (RBI 6-hour, CERT-In 6-hour), notice content, and Board-side procedure. |
+
+## Sectoral overlap
+
+DPDPA does **not** displace sectoral data and security rules — they stack. A Data Fiduciary that is also a regulated entity must comply with both. The plugin flags overlaps in assessment output but does not enforce sectoral rules itself; for those, install the sector-specific plugin (when available) or refer to the org's sectoral playbook.
+
+| Sector | Regulator | Key overlap |
+|---|---|---|
+| **Banking, NBFCs, payment systems** | RBI | Master Direction on Information Technology Governance, Risk, Controls and Assurance Practices (2023); Cyber Security Framework for Banks; 6-hour incident reporting on cyber events. RBI's incident clock runs in parallel with DPDPA's 72-hour breach clock. |
+| **Capital markets** | SEBI | Cyber Security and Cyber Resilience Framework (CSCRF); 6-hour reporting for cyber incidents at MIIs and intermediaries. |
+| **Insurance** | IRDAI | Information and Cyber Security Guidelines (2023); breach reporting timelines per IRDAI directives. |
+| **Telecom / DPI** | DoT, TRAI | Indian Telecommunications Act 2023 user-data rules; Telecom Cyber Security Rules 2024 incident reporting. |
+| **Digital health** | NHA / MoH&FW | Ayushman Bharat Digital Mission (ABDM) data policy; Health Data Management Policy. Children's-data rules under DPDPA Section 9 interact with parental consent for ABDM accounts. |
+| **All sectors (cyber)** | CERT-In | Direction No. 20(3)/2022 — 6-hour reporting of cyber incidents (broader than DPDPA's data-breach scope; both can apply). |
+
+## Penalty exposure (Schedule to the Act)
+
+Penalties are imposed by the Data Protection Board after inquiry. Headline bands (per breach):
+
+- Up to **₹250 crore** — failure to take reasonable security safeguards (Section 8(5)) leading to a personal data breach
+- Up to **₹200 crore** — failure to fulfil obligations relating to children (Section 9)
+- Up to **₹150 crore** — failure to fulfil additional obligations of an SDF (Section 10)
+- Up to **₹50 crore** — failure to notify the Board / affected Principals of a breach (Section 8(6))
+
+Use these to prioritise remediation in `/ind-dpdpa:assess` output.
+
+## What this plugin does **not** claim
+
+- **Not legal advice.** DPDPA enforcement and binding interpretation come from the Data Protection Board of India, MeitY notifications, and the courts — not this plugin. Confirm postures with qualified counsel.
+- **Not a Consent Manager.** Consent Managers are Board-registered entities; this plugin is GRC tooling.
+- **Not a substitute for the Act or Rules.** The plugin paraphrases obligations and references sections by number. The licensed text of the Act and the gazette notifications of the Rules are the source of truth.
+- **No restricted-territories list.** Section 16 cross-border transfer restrictions are governed by lists notified by the Central Government. Those lists change. This plugin does not vendor a copy.
+
+## Metadata
+
+| | |
+|---|---|
+| SCF framework ID | `apac-ind-dpdpa-2023` |
+| Region | APAC |
+| Country | IN |
+| SCF controls mapped | 41 |
+| Framework controls mapped | 96 |
+| Depth | Reference |
+| Regulator | Data Protection Board of India (DPB) under MeitY |
+| Plugin author | [Devam Shah](https://github.com/DevamShah) |
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com) — crosswalk source (CC BY-ND 4.0)
+- [SCF API entry](https://grcengclub.github.io/scf-api/api/crosswalks/apac-ind-dpdpa-2023.json) — 41 SCF → 96 DPDPA mappings
+- [Framework Plugin Guide](../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) — depth tiers and level-up checklist
+- DPDPA 2023 — text published in the Gazette of India, August 2023
+- DPDP Rules 2025 — text published in the Gazette of India, November 2025

--- a/plugins/frameworks/ind-dpdpa/commands/assess.md
+++ b/plugins/frameworks/ind-dpdpa/commands/assess.md
@@ -1,0 +1,88 @@
+---
+description: India DPDPA 2023 + DPDP Rules 2025 compliance gap assessment
+---
+
+# India DPDPA Assessment
+
+Runs a compliance gap assessment against the **Digital Personal Data Protection Act, 2023 (DPDPA)** together with the operational obligations notified under the **Digital Personal Data Protection Rules, 2025 (DPDP Rules)**, by delegating to `/grc-engineer:gap-assessment` with the SCF crosswalk and overlaying India-specific context.
+
+## Usage
+
+```
+/ind-dpdpa:assess [--scope=<scope>] [--sources=<connector-list>] [--role=<fiduciary|processor|consent-manager>]
+```
+
+## Arguments
+
+- `--scope=<scope>` (optional) — narrow the assessment. Valid values:
+  - `full` (default) — every applicable obligation
+  - `notice-and-consent` — Sections 5–7 (notice, consent, legitimate uses)
+  - `principal-rights` — Sections 11–14 (access, correction, erasure, grievance, nomination)
+  - `fiduciary-obligations` — Section 8 (accuracy, security, breach, retention)
+  - `sdf` — Significant Data Fiduciary obligations (Section 10 + Rules)
+  - `cross-border` — Section 16 + restricted-territories rule
+  - `children` — Section 9 (verifiable parental consent)
+  - `breach-readiness` — Section 8(6) + DPDP Rules 2025 R7 (72-hour timeline)
+- `--sources=<connector-list>` (optional) — comma-separated connector plugins (`aws-inspector`, `gcp-inspector`, `okta-inspector`, `github-inspector`, etc.).
+- `--role=<role>` (optional) — `fiduciary` (controller-equivalent), `processor`, or `consent-manager`. Defaults to `fiduciary`. Determines which obligation set is assessed.
+
+## Applicability
+
+DPDPA applies to processing of digital personal data:
+
+- **Within India**, regardless of where the Data Fiduciary is established; **and**
+- **Outside India**, where the processing is in connection with offering goods or services to Data Principals located in India (Section 3).
+
+It does **not** apply to:
+
+- Personal data processed by a Data Principal for personal/domestic purposes
+- Personal data made publicly available by the Data Principal themselves, or by a person under a legal obligation
+- Certain notified exemptions for research, statistical, archival processing; instrumentalities of the State for sovereign functions; and prevention/detection of offences (Section 17)
+
+Use `/ind-dpdpa:scope` to walk through these triggers in detail before running an assessment.
+
+## Roles under DPDPA
+
+| Role | DPDPA term | GDPR analogue |
+|---|---|---|
+| The party that determines purpose and means of processing | **Data Fiduciary** | Controller |
+| The party that processes on behalf of a Fiduciary under contract | **Data Processor** | Processor |
+| The natural person whose data is processed | **Data Principal** | Data Subject |
+| A registrable entity that manages consents on behalf of Principals | **Consent Manager** | (no direct analogue) |
+| A Fiduciary the Central Government notifies as having higher-risk processing | **Significant Data Fiduciary (SDF)** | (broader than GDPR's "large-scale" qualifier) |
+
+Significant Data Fiduciary status carries additional obligations (DPO, DPIA, periodic audits) — see `/ind-dpdpa:scope` for the designation criteria.
+
+## What the assessment produces
+
+1. **Compliance score** — overall DPDPA readiness, weighted by the 41 SCF controls mapped to DPDPA in the SCF crosswalk.
+2. **Applicable-obligations summary** — which Act sections and Rules apply given the supplied `--role` and `--scope`.
+3. **Control-by-control gap** — for each of the 96 mapped DPDPA control identifiers (e.g. `8(6)`, `10(2)(a)`, `27(1)(a)`), pass/fail/inconclusive status from connector findings.
+4. **Evidence gaps** — obligations where no connector source is configured. Use `/ind-dpdpa:evidence-checklist` to list what to collect manually.
+5. **Cross-border posture** — flags processing into restricted territories (Section 16). The list is published by the Central Government; this plugin does not maintain it locally.
+6. **Breach-readiness check** — whether the organisation can meet the DPDP Rules 2025 R7 timeline (72-hour notification to the Data Protection Board and to affected Data Principals). See `/ind-dpdpa:breach-process`.
+7. **Sectoral-overlap notes** — where DPDPA obligations stack on top of RBI / SEBI / IRDAI / TRAI / NHA rules (banking, securities, insurance, telecom, healthcare). These are flagged, not enforced — sectoral rules are separate plugins or out of scope.
+8. **Remediation roadmap** — prioritised by penalty exposure (Schedule of penalties: up to ₹250 crore per breach class).
+
+## Delegation
+
+Under the hood:
+
+```
+/grc-engineer:gap-assessment "apac-ind-dpdpa-2023" [--sources=<connector-list>]
+```
+
+The SCF crosswalk expands the 41 mapped SCF controls into the 96 DPDPA control identifiers. DPDPA control IDs follow the Act's section numbering, e.g. `8(6)` = Section 8, sub-section (6); `27(1)(a)` = Section 27, sub-section (1), clause (a).
+
+## Framework-specific notes
+
+- **Act + Rules read together.** The Act establishes obligations; the DPDP Rules 2025 (notified November 2025) set the operational timelines and procedural detail. Treat them as one body of law for assessment purposes — gaps in either side count.
+- **No registration of Data Fiduciaries.** Unlike some regimes, DPDPA does not require general registration. Only Consent Managers register with the Data Protection Board.
+- **Verifiable parental consent.** Section 9 prohibits behavioural tracking and targeted advertising directed at children, and requires verifiable parental consent for processing children's data. This is a distinct posture check, not just a sub-case of consent.
+- **Cross-border default-allow-with-blocklist.** Section 16 permits transfer outside India unless the Central Government notifies a restricted territory. This is the inverse of GDPR's default-restrict approach. The blocklist is a separate compliance lookup; see `/ind-dpdpa:scope --section=cross-border`.
+- **Penalty exposure differs by obligation.** The Schedule attached to the Act sets penalty bands (up to ₹250 crore for breach-of-security-safeguards failures; up to ₹200 crore for failure to fulfil obligations to children). Prioritise remediation by exposure.
+- **Sectoral overlay.** Where the Data Fiduciary is also regulated by RBI (banks, NBFCs, payment systems), SEBI (capital markets), IRDAI (insurance), TRAI/DoT (telecom) or governed by ABDM (digital health), those sectoral rules may impose stricter or earlier-deadline obligations (e.g. RBI's 6-hour cyber-incident reporting under the Cyber Security Framework runs in parallel with DPDPA's 72-hour breach notification — both clocks must run). This plugin flags overlaps; the relevant sectoral plugin (or the org's own sectoral playbook) handles those rules.
+
+## Disclaimer
+
+This plugin provides **engineering and assessment guidance only**. It is not legal advice. DPDPA enforcement is by the Data Protection Board of India and binding interpretations come from the Board's orders and notifications by MeitY. Confirm postures with qualified counsel before treating any output as compliant.

--- a/plugins/frameworks/ind-dpdpa/commands/assess.md
+++ b/plugins/frameworks/ind-dpdpa/commands/assess.md
@@ -8,7 +8,7 @@ Runs a compliance gap assessment against the **Digital Personal Data Protection 
 
 ## Usage
 
-```
+```bash
 /ind-dpdpa:assess [--scope=<scope>] [--sources=<connector-list>] [--role=<fiduciary|processor|consent-manager>]
 ```
 
@@ -68,7 +68,7 @@ Significant Data Fiduciary status carries additional obligations (DPO, DPIA, per
 
 Under the hood:
 
-```
+```bash
 /grc-engineer:gap-assessment "apac-ind-dpdpa-2023" [--sources=<connector-list>]
 ```
 

--- a/plugins/frameworks/ind-dpdpa/commands/breach-process.md
+++ b/plugins/frameworks/ind-dpdpa/commands/breach-process.md
@@ -10,7 +10,7 @@ The single most common DPDPA-era breach failure is **clock collision** — runni
 
 ## Usage
 
-```
+```bash
 /ind-dpdpa:breach-process [--phase=detect|classify|notify|investigate|review] [--sectors=<list>]
 ```
 
@@ -34,7 +34,7 @@ This is broader than a "cyber incident":
 |---|---|---|
 | Ransomware encrypts customer database; production access lost | Yes (availability) | Yes |
 | Unauthorised employee exports customer list to personal cloud | Yes (confidentiality) | Maybe (insider threat) |
-| DDoS causes service unavailability; no data exfil | No (data still confidential, intact, available after the event) | Yes |
+| DDoS causes service unavailability; no data exfil | Context-dependent — likely **Yes** if the unavailability blocks Data Principals from accessing their personal data (loss of access falls within Section 2's availability/loss-of-access limb). Document the determination basis. | Yes |
 | Misconfigured S3 bucket exposes customer records publicly | Yes (confidentiality) | Yes |
 | Bug deletes a Principal's account record without backup | Yes (availability for that Principal) | Possibly |
 | Cross-tenant data leak in SaaS product | Yes | Yes |

--- a/plugins/frameworks/ind-dpdpa/commands/breach-process.md
+++ b/plugins/frameworks/ind-dpdpa/commands/breach-process.md
@@ -1,0 +1,242 @@
+---
+description: India DPDPA personal data breach response — 72-hour clock, parallel sectoral clocks, notification content, post-breach review
+---
+
+# India DPDPA Breach Process
+
+End-to-end personal data breach response under DPDPA Section 8(6) and DPDP Rules 2025 R7, with the parallel sectoral clocks every regulated Fiduciary must run alongside.
+
+The single most common DPDPA-era breach failure is **clock collision** — running only the 72-hour DPDPA clock and missing the 6-hour CERT-In / RBI / SEBI clocks that fire in parallel for the same incident. This command's purpose is to prevent that.
+
+## Usage
+
+```
+/ind-dpdpa:breach-process [--phase=detect|classify|notify|investigate|review] [--sectors=<list>]
+```
+
+Phases:
+
+- `detect` — discovery and confirmation of a personal data breach
+- `classify` — severity, notifiability, scope, sectoral applicability
+- `notify` — DPB, affected Principals, sectoral regulators, internal stakeholders
+- `investigate` — forensic preservation and root-cause analysis
+- `review` — post-incident review and programme improvement
+
+If `--sectors` is passed, the parallel-clock matrix is rendered for those sectors.
+
+## What is a "personal data breach"?
+
+Section 2 defines a personal data breach as any unauthorised processing or accidental disclosure, acquisition, sharing, use, alteration, destruction or loss of access to personal data, that compromises the **confidentiality, integrity, or availability** of personal data.
+
+This is broader than a "cyber incident":
+
+| Event | DPDPA personal data breach? | CERT-In cyber incident? |
+|---|---|---|
+| Ransomware encrypts customer database; production access lost | Yes (availability) | Yes |
+| Unauthorised employee exports customer list to personal cloud | Yes (confidentiality) | Maybe (insider threat) |
+| DDoS causes service unavailability; no data exfil | No (data still confidential, intact, available after the event) | Yes |
+| Misconfigured S3 bucket exposes customer records publicly | Yes (confidentiality) | Yes |
+| Bug deletes a Principal's account record without backup | Yes (availability for that Principal) | Possibly |
+| Cross-tenant data leak in SaaS product | Yes | Yes |
+| Lost laptop with encrypted customer data; key custody intact | Likely No (current interpretation; document the basis) | Maybe (per CERT-In) |
+| Phishing attempt unsuccessful | No | Possibly (per CERT-In) |
+
+When the events overlap, both regulator obligations fire. Both clocks run.
+
+## Parallel-clock matrix
+
+For a regulated Fiduciary, identify which clocks apply to a given incident **before** the first notification goes out. Missing the fastest clock is the typical failure.
+
+| Source | Trigger | Timeline | To whom |
+|---|---|---|---|
+| **CERT-In Direction 20(3)/2022** | Cyber incident (broad scope including unauthorised access, data breach, identity theft, malware, defacement, DDoS, etc.) | **6 hours** from awareness | CERT-In via incident@cert-in.org.in |
+| **RBI Cyber Security Framework** | Cyber incident at scheduled commercial banks, urban cooperative banks, NBFCs, payment system operators | **6 hours** | RBI / IDRBT CSITE Cell |
+| **SEBI CSCRF** | Cyber incident at MIIs, intermediaries, AMCs, depositories | **6 hours** | SEBI / CERT-In / NCIIPC per matrix |
+| **IRDAI Information & Cyber Security Guidelines (2023)** | Cyber incident at insurer / intermediary | Per current direction (typically rapid; check current circular) | IRDAI |
+| **DoT / TRAI Telecom Cyber Security Rules 2024** | Cyber-security incident in a telecom network | Per the Rules' reporting matrix | DoT / TRAI / CERT-In |
+| **NCIIPC** | Incident affecting Critical Information Infrastructure | Immediate | NCIIPC |
+| **DPDPA 8(6) + DPDP Rules 2025 R7** | Personal data breach | **72 hours** from awareness | Data Protection Board of India + each affected Data Principal |
+| **Contractual obligations** | As specified in customer / partner / B2B contracts | Often **24 – 48 hours** | The contractual counterparty |
+
+**Operating principle**: when you can't yet tell whether a clock applies, start the clock anyway and extend if the analysis disconfirms applicability. Stopping a clock you've started costs nothing; missing one is unrecoverable.
+
+## Phase 1: Detect
+
+**Trigger sources**:
+
+- Internal: SIEM alert, EDR alert, anomaly detection, employee report, customer complaint, audit finding.
+- External: regulator inquiry, third-party security researcher disclosure, media report, sub-processor notification, threat-intel feed.
+
+**Detect-phase actions**:
+
+1. **Open a tracked incident record** — unique ID, time of awareness (this is **t-zero** for every clock).
+2. **Activate the on-call structure** — incident commander, scribe, comms lead, legal lead, privacy lead, sectoral compliance lead (where applicable).
+3. **Preserve volatile evidence** — log snapshots, memory captures, configuration baseline, suspect-account session details. Chain-of-custody log starts here.
+4. **Containment** — without destroying evidence: isolate affected systems, rotate credentials, revoke tokens, network segment, remove malicious accounts.
+5. **Initial scope estimate** — which systems, which data categories, which Principals (count or estimate range).
+
+**Output of Phase 1**: an incident record with t-zero, initial scope, on-call activated.
+
+## Phase 2: Classify
+
+**Within 1 – 4 hours of t-zero**, complete the classification before the fastest clock expires.
+
+**Classification axes**:
+
+- **Personal data involved?** Yes / No / Suspected → DPDPA scope.
+- **Cyber incident per CERT-In?** Yes / No → CERT-In 6h.
+- **Sectoral applicability?** Banking / securities / insurance / telecom / health / DPI → sectoral 6h or per direction.
+- **Severity**: Critical / High / Medium / Low (based on data sensitivity, volume, and harm potential).
+- **Affected Principal count**: known / estimated range.
+- **Cross-border component?** Was data transferred to or from India during the incident?
+- **Active exfiltration vs contained event?** Determines pace and content of notification.
+- **Children's data involved?** Adds Section 9 emphasis.
+
+**Severity criteria (illustrative — calibrate to organisation)**:
+
+| Severity | Indicator |
+|---|---|
+| Critical | Confirmed exfil of large-volume personal data; or sensitive categories (financial, health, biometric, child); or active threat actor with persistence |
+| High | Suspected exfil; or unauthorised access to personal-data-bearing systems; or material integrity compromise |
+| Medium | Limited unauthorised access; data plausibly intact; controlled containment |
+| Low | Theoretical exposure; no evidence of access |
+
+**Notifiability decision** — for each clock, document the determination basis. If the determination is "not notifiable," document why. The DPB may inquire later; the determination basis is the defensible record.
+
+**Output of Phase 2**: classification record with severity, applicable clocks, notifiability determination per clock, target notification times.
+
+## Phase 3: Notify
+
+### 3.1 CERT-In (6 hours from awareness)
+
+If the incident qualifies as a cyber incident under Direction 20(3)/2022, file the CERT-In report within 6 hours. Direction-prescribed format; submit to incident@cert-in.org.in (or the current channel CERT-In specifies).
+
+Include: affected systems, attack vector if known, indicators of compromise, initial impact assessment, contact point.
+
+### 3.2 Sectoral regulator (6 hours, where applicable)
+
+Concurrent with CERT-In. Use the sectoral format:
+
+- **RBI**: report via the designated cybersecurity reporting channel; include impact on customer service availability.
+- **SEBI**: per the CSCRF reporting flow.
+- **IRDAI**: per current circular.
+- **DoT / TRAI**: per Telecom Cyber Security Rules 2024 reporting matrix.
+- **NCIIPC**: where the incident affects CII.
+
+The sectoral regulator's expectations on content go beyond CERT-In's — typically including business-continuity status, customer-impact estimate, market-functioning impact (for capital markets).
+
+### 3.3 DPDPA — Data Protection Board of India (72 hours)
+
+The Section 8(6) intimation goes to the **DPB** in the form and manner prescribed under the DPDP Rules 2025. The 72-hour clock is from awareness — the same t-zero used for the sectoral 6-hour clocks.
+
+**Notification content (Rules-aligned baseline)**:
+
+| Field | What to include |
+|---|---|
+| Nature of breach | Confidentiality / integrity / availability compromise; root cause if known. |
+| Date and time of breach | Best-known; range acceptable if exact unknown. |
+| Date and time of awareness | t-zero — drives the 72-hour calculation. |
+| Categories and approximate number of affected Data Principals | Range acceptable if exact unknown; commit to update on confirmation. |
+| Categories and approximate volume of personal data records | E.g. "names, email addresses, phone numbers, partial card numbers — approx 120,000 records." |
+| Likely consequences | What harm Principals may suffer — financial, reputational, identity, safety. |
+| Measures taken or proposed to mitigate | Technical containment, credential rotation, monitoring, customer notifications. |
+| Contact point | Person and channel for the Board to reach. |
+
+If material facts change after submission, **submit an update**. The Board prefers a timely first report with updates over a delayed first report.
+
+### 3.4 DPDPA — affected Data Principals (72 hours)
+
+In parallel with the Board notification, give intimation to each affected Principal. The Rules prescribe form and content. Practical posture:
+
+- Use the channel the Principal would expect: in-app banner + push, registered email, registered SMS / WhatsApp Business message.
+- Plain-language; avoid legalese.
+- State: what happened, what data, what consequences, what the Principal can do (steps to protect themselves), what the Fiduciary is doing, the contact point.
+- Do not under-claim: stating "no harm expected" when harm is plausible is a regulator-trust failure even if technically correct.
+
+For very large affected populations, a **conspicuous public notice** (top of website, in-app top banner, social media, press release where appropriate) is generally considered to constitute reasonable best efforts when individual outreach is impracticable. The Rules-prescribed mechanism for public notice should be followed.
+
+### 3.5 Internal and contractual notifications
+
+- **Board of Directors / Audit Committee** — for Critical / High severity.
+- **Customer / partner contractual counterparties** — per their contracts (often 24 – 48 hours).
+- **Cyber insurance carrier** — per policy terms, typically within 24 – 48 hours.
+- **Investors / acquirers** (for material events at listed entities) — per disclosure obligations.
+
+**Output of Phase 3**: dispatched notifications with timestamps and acknowledgements; updates queued for new material facts.
+
+## Phase 4: Investigate
+
+Forensic and remediation work continues in parallel with notifications.
+
+**Investigation actions**:
+
+- **Forensic preservation** — disk images, memory captures, log archives. Chain of custody.
+- **Root cause analysis** — technical, procedural, and contextual. Don't stop at "phishing"; ask "why was the access this email yielded so wide?"
+- **Lateral-movement scoping** — confirm bounds; don't assume the first-discovered scope is the actual scope.
+- **Affected-Principal census** — refine the count; reconcile with the initial estimate.
+- **Threat-actor analysis** (where relevant) — attribution, motivation, persistence indicators.
+- **Engagement of external assistance** — incident response retainer, regulator-recognised forensic firm, legal counsel.
+- **Remediation tracking** — every remediation item ticketed with owner and SLA.
+- **Update notifications** as material facts firm up — to the Board, to Principals (if scope materially changed), to sectoral regulators.
+
+**Output of Phase 4**: forensic report; root-cause statement; remediation tracker; reconciled affected-population count.
+
+## Phase 5: Review
+
+Within 30 days of incident closure:
+
+- **Post-incident review (PIR)** — chronology, decisions, what worked, what didn't.
+- **Control failure analysis** — which control should have prevented or detected; why it didn't.
+- **Programme improvement actions** — owned, scheduled, measurable.
+- **Tabletop or live drill** of the lesson learned, within 60 days.
+- **Briefing to leadership / Board** — facts, root cause, regulatory posture, programme improvements.
+- **Update breach playbook** — incorporate the learning. Versioned.
+- **Update training** — incorporate the lesson into security and privacy awareness.
+- **Update vendor expectations** — if a Processor / sub-processor was involved, contract or process changes.
+
+**Regulator follow-through**:
+
+- Track DPB inquiry status — written submissions, hearings, orders.
+- Track sectoral regulator follow-through — show-cause notices, penalty proceedings.
+- Maintain a **DPB filing register** — every notification, response, and order.
+
+## Common failure modes
+
+1. **Starting only the 72-hour clock.** The 6-hour clocks fire first; the failure is silent until the 6-hour-clock regulator comes back asking why they weren't told.
+2. **Under-scoping affected Principals.** Initial estimate is too low; subsequent confirmation triggers a "second wave" notification that erodes trust.
+3. **Notifying Principals before regulators.** Most sectoral regulators expect them to be informed first or concurrent. Public statements that beat the regulator filing damage the relationship.
+4. **Drafting the Principal notification in legalese.** Principals can't act on it; Board / regulator views it as evasive.
+5. **No update mechanism.** First filing is filed and forgotten; the Board never receives the confirmation that scope was bounded.
+6. **No tabletop drill in the past 12 months.** Plays out in slow motion at the worst possible time.
+7. **No chain-of-custody on logs.** The forensic finding is challengeable.
+8. **Conflating "encrypted, key custody intact" with "no breach."** Document the determination basis; don't assume.
+9. **Not informing the cyber insurance carrier in time.** Coverage forfeited.
+10. **Treating the breach as IT-only.** Privacy, legal, comms, sectoral-compliance, customer-service have parallel runbooks. Run them concurrently.
+
+## Templates
+
+This command does not vendor regulator-specific templates (they change with each circular). Maintain in your incident response repository:
+
+- DPB-notification template (Rules-aligned content fields)
+- Affected-Principal notification (per channel: email, in-app, SMS)
+- CERT-In incident report (Direction 20(3)/2022 fields)
+- Sectoral regulator template (RBI / SEBI / IRDAI / DoT)
+- Internal Board / Audit Committee briefing
+- Cyber insurance notification
+- Customer contractual notification
+- Public notice (where applicable for large-scale events)
+
+Each template carries a version, an owner, and a "last reviewed" date — reviewed at minimum on regulator circular changes.
+
+## Drill cadence
+
+| Drill | Cadence |
+|---|---|
+| Full clock-collision tabletop (DPDPA + sectoral + CERT-In + contractual) | Annual |
+| Channel-specific drill (DPB filing, Principal notification at scale, sectoral filing) | Twice a year per channel |
+| New-staff onboarding scenario | Within 30 days of role start |
+| Lessons-learned drill | Within 60 days of any actual incident |
+
+## Disclaimer
+
+Engineering and assessment guidance only. **Not legal advice.** The Board, sectoral regulators, and counsel determine what is required in any specific incident. Confirm posture before treating any output as definitive for an active incident.

--- a/plugins/frameworks/ind-dpdpa/commands/breach-process.md
+++ b/plugins/frameworks/ind-dpdpa/commands/breach-process.md
@@ -26,7 +26,7 @@ If `--sectors` is passed, the parallel-clock matrix is rendered for those sector
 
 ## What is a "personal data breach"?
 
-Section 2 defines a personal data breach as any unauthorised processing or accidental disclosure, acquisition, sharing, use, alteration, destruction or loss of access to personal data, that compromises the **confidentiality, integrity, or availability** of personal data.
+Section 2(u) covers any incident that compromises the **confidentiality, integrity, or availability** of personal data — including unauthorised processing, accidental disclosure or sharing, alteration, destruction, and loss of access. Consult the Act for the authoritative wording.
 
 This is broader than a "cyber incident":
 

--- a/plugins/frameworks/ind-dpdpa/commands/evidence-checklist.md
+++ b/plugins/frameworks/ind-dpdpa/commands/evidence-checklist.md
@@ -10,7 +10,7 @@ Run `/ind-dpdpa:scope` first to know which themes apply to your entity.
 
 ## Usage
 
-```
+```bash
 /ind-dpdpa:evidence-checklist [--theme=<theme>] [--role=<fiduciary|processor>] [--sdf]
 ```
 

--- a/plugins/frameworks/ind-dpdpa/commands/evidence-checklist.md
+++ b/plugins/frameworks/ind-dpdpa/commands/evidence-checklist.md
@@ -1,0 +1,338 @@
+---
+description: India DPDPA evidence checklist — what to collect, where it lives, how to verify
+---
+
+# India DPDPA Evidence Checklist
+
+Operational checklist of evidence patterns the Data Protection Board, an independent auditor (for SDFs), or an internal review will expect across the DPDPA obligation themes. Each theme lists **what** to collect, **where** it typically lives, and **what good looks like**.
+
+Run `/ind-dpdpa:scope` first to know which themes apply to your entity.
+
+## Usage
+
+```
+/ind-dpdpa:evidence-checklist [--theme=<theme>] [--role=<fiduciary|processor>] [--sdf]
+```
+
+Themes:
+
+- `notice` — Section 5
+- `consent` — Section 6
+- `legitimate-uses` — Section 7
+- `purpose-limitation` — derived from Sections 5, 6, 7, 8
+- `accuracy` — Section 8(3)
+- `security` — Section 8(5)
+- `breach` — Section 8(6) + DPDP Rules 2025 R7
+- `retention` — Section 8(7)
+- `principal-rights` — Sections 11–14
+- `children` — Section 9
+- `sdf` — Section 10
+- `cross-border` — Section 16
+- `consent-manager` — Consent Manager integration
+- `governance` — overarching programme evidence
+
+Use `--sdf` to include SDF-specific intensification across all themes.
+
+## 1. Notice (Section 5)
+
+**Why**: Notice is the gateway. A defective notice undermines the consent that follows.
+
+**Collect**:
+
+- ☐ Versioned **notice templates** in English plus the languages used to engage the Principal (Eighth Schedule languages where applicable).
+- ☐ **Change log** of notice versions with effective dates.
+- ☐ **Sample as-served notices** — three samples per channel (web, app, in-store, vendor onboarding flow, etc.) showing the notice exactly as a Principal would see it.
+- ☐ **Mapping** of each notice version to the specific processing purpose(s) it covers.
+- ☐ **Accessibility evidence** — screen-reader compatibility, font-size controls, simplified-language version where applicable.
+- ☐ For pre-Act consents, **first-after-Act notice** evidence (Section 5(2)).
+
+**Where to find it**:
+
+- Product CMS, in-app screen catalogue, vendor master with notice attachments, contact-centre script repository.
+- Translation service or in-house language QA system.
+- Accessibility audit report.
+
+**What good looks like**:
+
+- One notice per processing purpose, in the Principal's language at point of choice.
+- Plain-language; no nested cross-references that defeat clarity.
+- Each notice version has a unique identifier and an audit trail of approvals.
+- Samples can be retrieved per-Principal on request: "Show me the notice this user saw on 14 March 2026."
+
+## 2. Consent (Section 6)
+
+**Why**: Consent must be free, specific, informed, unconditional, unambiguous, with clear affirmative action — and withdrawable at parity. Defects are common.
+
+**Collect**:
+
+- ☐ **Consent records** for every Principal × purpose, with timestamp, version of notice shown, mode of capture (clickwrap, in-app toggle, voice with recording, Consent Manager flow), IP / device hash where lawful.
+- ☐ **Consent receipts** issued to the Principal where applicable (the Rules contemplate receipts in some flows).
+- ☐ **Pre-ticked-box / dark-pattern audit** — UI inspection of every consent surface; certification that no pre-ticked, default-on, or coercive flows exist.
+- ☐ **Granularity** — evidence that distinct purposes have distinct consent toggles, not bundled.
+- ☐ **Withdrawal events** with timestamp and downstream action records (purpose ceased, Processor instructed, deletion job triggered).
+- ☐ **Withdrawal-parity test** — same number of clicks / steps to withdraw as to grant.
+- ☐ For onboarding flows, **screen recording or step-by-step screenshot trail** of the consent journey.
+
+**Where to find it**:
+
+- Consent management platform (CMP) database.
+- Application audit logs.
+- Consent Manager reconciliation reports (where integrated).
+- UX team's product copy repository.
+
+**What good looks like**:
+
+- A single query returns the full consent timeline of any Principal: granted → modified → withdrawn → re-granted.
+- Withdrawal events show downstream consequences within the SLA: cessation in primary system, Processor notification, deletion job ticket, sub-processor notification.
+- No consent is "bundled" — the user can refuse one purpose and still consume the core service.
+- The consent receipt format matches the Rules' content requirements.
+
+## 3. Legitimate uses (Section 7)
+
+**Why**: Section 7 is exhaustive. Misclassifying a processing activity here is a common audit finding.
+
+**Collect**:
+
+- ☐ **Per-activity determination memo** — for every processing activity that does not rely on consent, the specific Section 7 clause being relied on, with reasoning.
+- ☐ **Boundary documentation** — what falls outside the Section 7 use; how drift is detected.
+- ☐ **Periodic review** — evidence that legitimate-use determinations are reviewed (at least annually, on material change of processing).
+- ☐ **For employment-related processing under 7(i)**: which employee data, what use, with what safeguard.
+- ☐ **For medical-emergency / disaster-response**: incident logs showing the trigger event and the bounded processing.
+
+**Where to find it**:
+
+- Privacy programme document repository.
+- HR system policy library (for employment-related processing).
+- Incident logs (for emergency-related processing).
+
+**What good looks like**:
+
+- Every processing activity has a documented lawful basis: consent OR a named Section 7 clause.
+- No "legitimate interest" framing imported from GDPR practice.
+- Boundary policing is automated where feasible (e.g. the data store flagged as Section-7-only refuses non-7 reads).
+
+## 4. Purpose limitation
+
+**Why**: A specified purpose constrains downstream processing. Drift is the most common compliance erosion.
+
+**Collect**:
+
+- ☐ **Purpose register** — per system, the registered purposes; data fields used per purpose; retention per purpose.
+- ☐ **Data flow diagrams** — origin, transformations, destinations, sub-processors, deletion.
+- ☐ **Access reviews** — proof that operators only access data they need for a registered purpose.
+- ☐ **Model / analytics governance** — for ML / AI uses, evidence that training data scope matches a registered purpose; no silent re-use of operational data for model training.
+- ☐ **Cross-purpose-use risk register** — list of "almost-drift" cases that were caught and contained.
+
+**Where to find it**:
+
+- GRC platform / privacy register.
+- Architecture documentation, data lineage tooling.
+- IAM / entitlement-review reports.
+- ML / data science governance records.
+
+**What good looks like**:
+
+- Adding a new processing purpose triggers a notice / consent review automatically.
+- Cross-environment data movement (prod → analytics → ML) is gated by purpose review.
+- Data-quality / model-training datasets carry purpose tags propagated from source.
+
+## 5. Accuracy (Section 8(3))
+
+**Collect**:
+
+- ☐ **Correction-request log** with intake, response, outcome, SLA conformance.
+- ☐ **Data quality controls** — validation at intake, periodic reconciliation, source-of-truth designation per data category.
+- ☐ Where data is shared with another Fiduciary, evidence the shared copy is **accurate at point of share**.
+
+**What good looks like**:
+
+- Median correction-request closure within the prescribed SLA.
+- Stale-data detection runs at material cadence; corrections propagate downstream.
+
+## 6. Security safeguards (Section 8(5))
+
+**Why**: Largest single penalty band — up to ₹250 crore. Auditors examine this in depth.
+
+**Collect**:
+
+- ☐ **Information Security Management System (ISMS) evidence** — ISO 27001:2022 Statement of Applicability, internal audit reports, management review minutes, ISMS scope.
+- ☐ **Risk register** — assets, threats, controls, residual risk; reviewed periodically.
+- ☐ **Encryption inventory** — data at rest, data in transit, key management. Algorithms and key lengths conform to current best practice.
+- ☐ **Access control evidence** — RBAC / ABAC design, joiner-mover-leaver process, periodic access recertification, privileged-access management.
+- ☐ **Logging and monitoring** — what is logged, retention period, integrity protection, SIEM alert library, response runbooks. Conform to CERT-In 180-day India-side log retention where applicable.
+- ☐ **Vulnerability management** — scanning cadence, asset coverage, SLA per severity, evidence of closure.
+- ☐ **Penetration test reports** — annual minimum; remediation closure evidence; follow-up retest.
+- ☐ **Secure SDLC** — SAST / DAST / SCA in pipelines; threat-modelling for new features; security review gates.
+- ☐ **Backup and recovery** — backup schedule, restoration tests, integrity protection, encryption.
+- ☐ **Vendor security assessment** — for every Processor and material vendor.
+- ☐ **Cloud configuration baseline** — CIS / cloud-provider best-practice conformance; drift detection.
+- ☐ **Sectoral overlay**: where applicable, RBI Cyber Security Framework, SEBI CSCRF, IRDAI cyber guidelines artefacts.
+
+**Where to find it**:
+
+- ISMS document set; GRC platform; vulnerability scanner / pen-test vendor portals; SIEM; cloud security posture management (CSPM) tooling.
+- For Connectors users: many of these are continuously verified by `aws-inspector`, `gcp-inspector`, `okta-inspector`, `github-inspector`. Run those and feed findings into `/ind-dpdpa:assess`.
+
+**What good looks like**:
+
+- The ISMS scope explicitly covers all processing activities subject to DPDPA.
+- Pen-test findings have a closure SLA tied to severity; HIGH and CRITICAL closed within stated window.
+- A drill in the past 12 months has tested the breach-response capability end-to-end.
+- Cloud accounts have CSPM in place with drift-alerting; access review evidence per quarter.
+- Sectoral overlay artefacts are mapped against the same baseline (not maintained as a separate compliance silo).
+
+## 7. Breach notification (Section 8(6) + DPDP Rules 2025 R7)
+
+**Why**: 72-hour clock to DPB **and** to each affected Principal. Penalty up to ₹50 crore for notification failure (separate from the up-to-₹250-crore security failure that may have caused the breach).
+
+**Collect**:
+
+- ☐ **Personal data breach playbook** that distinguishes a "personal data breach" from a "cyber incident" — they overlap but are not identical. Both clocks may run.
+- ☐ **Parallel-clock matrix** — per regulator and per incident type, what notification is owed, by when, in what format. At minimum: DPDPA 72h, CERT-In 6h, RBI 6h (if banking), SEBI 6h (if SEBI-regulated), IRDAI per direction (if insurer), DoT/TRAI per Telecom Cyber Security Rules (if telecom).
+- ☐ **Notification templates** to the DPB and to affected Principals — content compliant with Rules-prescribed fields (nature, scope, time, consequences, mitigation, contact).
+- ☐ **Receipt/acknowledgement protocol** — proof of submission to DPB; proof of delivery to Principals (where reasonable best efforts demonstrated).
+- ☐ **Tabletop exercise records** — at least one full-clock tabletop in the past 12 months that exercised the parallel-regulator coordination.
+- ☐ **Severity classification matrix** — what counts as a notifiable breach; what doesn't (e.g. encrypted data with intact key custody — paraphrased criterion subject to current interpretation).
+- ☐ **Forensic evidence preservation** — chain-of-custody plan; logs immutable for the retention window.
+- ☐ **Communications register** — every breach (notifiable or not) recorded with the determination basis.
+- ☐ **Post-breach review** — root cause, control failure, remediation, communication to leadership / Audit Committee.
+
+**Where to find it**:
+
+- Incident response repository (Confluence / Notion / equivalent).
+- SIEM and forensics tooling.
+- Tabletop exercise reports.
+
+**What good looks like**:
+
+- Average detection-to-classification time below the fastest applicable regulatory clock.
+- Tabletop drills involve cross-functional teams: security, privacy, legal, comms, sectoral compliance, customer service.
+- The notification template is pre-approved by legal and updated on Rules amendment.
+- Drills report parallel notifications going out within their respective SLAs (CERT-In within 6h, etc.) — not just the DPDPA 72-hour notification.
+
+## 8. Retention and erasure (Section 8(7))
+
+**Collect**:
+
+- ☐ **Retention schedule** by data category × purpose, with statutory minimums (PMLA 5y, RBI sectoral retention rules, tax records, etc.) called out explicitly.
+- ☐ **Deletion job evidence** — periodic execution logs showing data deleted on schedule, with integrity (hash, count) check.
+- ☐ **Withdrawal-triggered deletion** — for every consent withdrawal, the deletion ticket and its closure evidence.
+- ☐ **Legal-hold register** — data preserved beyond default retention with the basis recorded.
+- ☐ **Backup-retention coherence** — deletion propagates to backups within the documented backup-retention window; backups not kept indefinitely.
+- ☐ **Sub-processor deletion** — evidence each Processor / sub-processor performed the deletion they were instructed to perform.
+
+**What good looks like**:
+
+- Retention schedule is current; reviewed when regulation or business model changes.
+- Deletion jobs are automated, audited, and report failures.
+- A request "delete my data" results in evidence of deletion across primary system, backups, sub-processors, log stores (subject to legal retention) within a stated SLA.
+
+## 9. Data Principal rights (Sections 11 – 14)
+
+**Collect**:
+
+- ☐ **Rights-request intake** — channel diversity (web form, app, email, contact centre, postal); accessibility.
+- ☐ **Verification process** — how the entity verifies the requester is the Principal (proportionate to risk; not over-collecting).
+- ☐ **SLA conformance** — per request type, response within the Rules-prescribed window.
+- ☐ **Refusal records** — when rights cannot be fulfilled (e.g. retention required by law), the basis is documented and communicated.
+- ☐ **Sample responses** — at least one of each request type executed end-to-end, redacted of PII, available for audit.
+- ☐ **Grievance redressal** — records of complaints, time-to-resolution, escalation to DPB cases.
+- ☐ **Nomination handling** (Section 14) — process to register nominations, validate them on death/incapacity, and execute requests.
+
+**What good looks like**:
+
+- Rights requests are tracked centrally with status, owner, and SLA dashboard.
+- Verification is proportionate — not requiring more identity proof than the original onboarding.
+- Refusals are rare and well-justified; the Principal is informed of escalation routes (grievance officer → DPB).
+
+## 10. Children's data (Section 9)
+
+**Collect**:
+
+- ☐ **Age-determination mechanism** — design document; conformance test evidence.
+- ☐ **Verifiable parental consent flow** — for Principals identified as children, the verification artefact (KYC-bearing, payment-instrument verified, declaration with ID, Consent Manager flow).
+- ☐ **Targeted-advertising suppression** — configuration evidence in ad-serving systems; periodic test evidence.
+- ☐ **Behavioural-tracking suppression** — analytics / personalisation systems exclude child-flagged accounts; periodic test evidence.
+- ☐ **Default-on protections** — where age is unverified, the more conservative posture applies.
+- ☐ **Educational / health exemption** — where claimed under a Government notification, the gazette reference and operational scope.
+
+**What good looks like**:
+
+- A user identified as under-18 cannot be served behavioural-targeted ads, regardless of which ad partner is in the chain.
+- Child-account flags propagate across system boundaries.
+- The age-determination mechanism's false-negative rate is measured.
+
+## 11. Significant Data Fiduciary (Section 10)
+
+**Collect (in addition to all the above)**:
+
+- ☐ **DPO appointment record** — name, India residency, governance/reporting line to Board, term, replacement plan.
+- ☐ **DPO independence evidence** — no operational conflict; budget and staffing.
+- ☐ **DPIA framework** — trigger criteria; methodology (typically harm × likelihood); template; sign-off authority.
+- ☐ **DPIA register** — all DPIAs performed, with conclusions and residual risks.
+- ☐ **Periodic independent audit** — auditor selection criteria; engagement letter; audit report; management response; remediation tracking.
+- ☐ **Algorithmic / automated-decision risk register** where applicable — model inventory, risk classification, mitigation.
+- ☐ **Board / Audit Committee minutes** showing oversight of privacy programme.
+- ☐ **DPB filing register** — every notification, response, and order from / to the DPB.
+
+**What good looks like**:
+
+- DPO is empowered: budget, staffing, escalation rights.
+- DPIA register has visible cadence; not just paper exercises.
+- Independent auditor is rotated per organisation policy and is genuinely independent.
+
+## 12. Cross-border transfers (Section 16)
+
+**Collect**:
+
+- ☐ **Transfer register** — every cross-border data flow with destination, data category, volume, recipient, basis.
+- ☐ **Restricted-territory check artefact** — evidence the latest gazette notification was checked at posture-determination and at material change.
+- ☐ **Sectoral-localisation conformance** — where applicable, evidence that payment-system data is stored in India per RBI; insurance data per IRDAI; telecom data per the relevant Rules.
+- ☐ **Sub-processor flow-down** — every Processor's cross-border posture is contractually flowed down.
+
+**What good looks like**:
+
+- Transfer register maps cleanly onto the data inventory.
+- Restricted-territory check is a recurring compliance task with an owner and a date.
+- Sectoral localisation is enforced at the storage layer (cloud region selection), not just policy.
+
+## 13. Consent Manager integration (where applicable)
+
+**Collect**:
+
+- ☐ **Integration design** — APIs, message formats, error handling.
+- ☐ **Consent receipt format** — fields conform to Rules-prescribed content.
+- ☐ **Reconciliation reports** — periodic comparison of Consent Manager records with Fiduciary's own consent log.
+- ☐ **Withdrawal-event handling** — evidence of cascading actions on withdrawal events.
+
+**What good looks like**:
+
+- Consents and withdrawals stay in sync between Consent Manager and Fiduciary; discrepancies are alerted and closed within SLA.
+- The Fiduciary maintains its own consent record; the Consent Manager is corroborative, not the only source of truth.
+
+## 14. Governance overlay
+
+**Collect**:
+
+- ☐ **Privacy governance charter** — roles, accountability, approval authority, escalation routes.
+- ☐ **Privacy programme metrics** — consent capture rate, withdrawal rate, rights-request SLA conformance, breach drill cadence, training completion.
+- ☐ **Training records** — engineering, product, support, partner-handling staff trained on DPDPA basics.
+- ☐ **Vendor / Processor inventory** — every Processor; contract has DPDPA clauses (security, deletion, breach cooperation, sub-processor flow-down).
+- ☐ **Risk register** — privacy risks, owners, mitigations, review cadence.
+- ☐ **Programme review cadence** — quarterly internal; annual leadership; external review for SDFs.
+
+**What good looks like**:
+
+- Privacy is part of design, not a bolt-on.
+- The metrics are read at leadership cadence.
+- Vendor inventory is current; new vendors cannot onboard without privacy review.
+
+## Output
+
+Produces a per-theme checklist with status (`Collected` / `Partial` / `Missing` / `Not applicable`), gaps prioritised by penalty exposure (security ₹250cr > children ₹200cr > SDF ₹150cr > breach-notification ₹50cr), and a remediation-effort estimate.
+
+This output feeds into `/ind-dpdpa:assess` (gap-by-control) and `/grc-engineer:generate-implementation` (where automation is feasible).
+
+## Disclaimer
+
+Engineering and assessment guidance only. **Not legal advice.** Confirm artefact adequacy with qualified counsel before relying on this checklist for regulatory submission.

--- a/plugins/frameworks/ind-dpdpa/commands/scope.md
+++ b/plugins/frameworks/ind-dpdpa/commands/scope.md
@@ -10,7 +10,7 @@ Run this **before** `/ind-dpdpa:assess`. The assessment behaves differently depe
 
 ## Usage
 
-```
+```bash
 /ind-dpdpa:scope [--section=applicability|role|sdf|cross-border|sectoral|exemptions]
 ```
 

--- a/plugins/frameworks/ind-dpdpa/commands/scope.md
+++ b/plugins/frameworks/ind-dpdpa/commands/scope.md
@@ -1,0 +1,240 @@
+---
+description: India DPDPA — applicability, role assignment, SDF trigger walkthrough, sectoral overlay
+---
+
+# India DPDPA Scope
+
+Determines whether DPDPA applies, what role the entity holds, whether Significant Data Fiduciary (SDF) thresholds are at risk, and which sectoral regulators overlay obligations on top of DPDPA.
+
+Run this **before** `/ind-dpdpa:assess`. The assessment behaves differently depending on the role and SDF status.
+
+## Usage
+
+```
+/ind-dpdpa:scope [--section=applicability|role|sdf|cross-border|sectoral|exemptions]
+```
+
+If `--section` is omitted, the command walks the full decision tree.
+
+## 1. Territorial and material applicability (Section 3)
+
+Answer in order. The first **No** to a hard requirement breaks scope.
+
+### 1.1 Is processing of digital personal data involved?
+
+DPDPA covers personal data **in digital form**, or **in non-digital form digitised subsequently**. Purely paper-based processing that is never digitised is out of scope.
+
+- ☐ Personal data is collected, stored, processed in digital form, **OR**
+- ☐ Personal data is collected on paper and digitised at some later point.
+
+If neither is true → **out of scope**. Stop here.
+
+### 1.2 Does at least one of the territorial triggers apply?
+
+- ☐ **In-India processing**: any processing within Indian territory, regardless of where the entity is established or headquartered.
+- ☐ **Extra-territorial processing in connection with offering goods or services to Data Principals located in India**.
+
+If neither is true → **out of scope**. Stop here.
+
+The extra-territorial trigger is broader than it appears. Indicators that the trigger is engaged for an entity outside India:
+
+- Pricing in INR
+- Payment methods that include UPI / RuPay / India-only rails
+- Marketing copy targeting Indian users (Hindi or other Indian-language UI; "available in India"; India-specific offers)
+- Customer support hours that include India business hours; phone numbers in +91
+- App store listings released in India
+- T&Cs that include reference to India / Indian law
+- Material number of users with Indian IPs / billing addresses
+
+The **monitoring of behaviour** trigger that GDPR has is **not** a standalone DPDPA trigger — DPDPA hooks on offering goods or services. However, monitoring *as a service offered to Indian users* (e.g. an analytics product whose buyers monitor Indian-resident users) is in scope via the offering-of-services route.
+
+### 1.3 Does any Section 17 exemption fully apply?
+
+- ☐ Personal-or-domestic processing by an individual.
+- ☐ Personal data made publicly available by the Principal themselves, or by another person under a legal obligation to publish.
+- ☐ State processing for sovereign functions (where notified).
+- ☐ Research / archiving / statistical processing (subject to safeguards prescribed under the Rules).
+- ☐ Prevention / detection / investigation of offences (where notified).
+- ☐ Other classes notified under Section 17.
+
+If a full exemption applies, scope ends. Most commercial processing **does not** qualify for any of these exemptions, and the burden is on the Fiduciary to demonstrate it does.
+
+**Output of step 1**: APPLICABLE / NOT APPLICABLE / PARTIALLY EXEMPT (with the exempt subset clearly identified).
+
+## 2. Role assignment
+
+Determine the entity's primary role. Note that an organisation can hold multiple roles for different processing activities.
+
+### 2.1 Data Fiduciary
+
+The entity is a Data Fiduciary if it **decides the purpose and means** of processing — what data, what it's used for, how, with whom shared.
+
+**Indicators**:
+
+- The entity collects personal data directly from Principals or from another Fiduciary.
+- The entity decides retention periods, processing purposes, and disclosure recipients.
+- The entity owns the customer / user / employee relationship.
+
+### 2.2 Data Processor
+
+The entity is a Data Processor if it processes personal data **on behalf of a Fiduciary under contract**, acting on the Fiduciary's instructions.
+
+**Indicators**:
+
+- Processing is governed by a contract with another organisation (the Fiduciary).
+- The entity does not independently decide retention, additional purposes, or disclosure recipients.
+- Examples: cloud hosting providers, payroll processors, KYC vendors, analytics partners that operate on the Fiduciary's data.
+
+A Processor that decides to use the data for its own purpose (analytics on aggregated trends, model training, monetisation) **becomes a Fiduciary** for that processing — irrespective of contract wording.
+
+### 2.3 Consent Manager
+
+A registrable entity that manages consents on behalf of Data Principals. Consent Managers register with the Data Protection Board under the DPDP Rules 2025 conditions and are accountable to the Principal, not the Fiduciary.
+
+**Most organisations are not Consent Managers** — this role is specific.
+
+### 2.4 Mixed roles
+
+Common pattern: an organisation is a Fiduciary for its own customers, a Processor for a partner's data flowing through its systems, and engages many Processors. Each role-relationship is governed independently.
+
+**Output of step 2**: per processing activity, the entity is `Fiduciary` / `Processor` / `Consent Manager` / `Joint`.
+
+## 3. Significant Data Fiduciary (SDF) trigger assessment (Section 10)
+
+The Central Government may notify a Fiduciary as an SDF based on these factors. Even before designation, prudent organisations assess proximity to the triggers and prepare proportionally.
+
+### 3.1 Volume of personal data processed
+
+- ☐ Tens of millions of Indian Data Principals' records processed routinely.
+- ☐ National-scale platforms (e-commerce marketplaces, super-apps, large social platforms, large telecom providers, large banks).
+
+### 3.2 Sensitivity of personal data
+
+- ☐ Health data at scale.
+- ☐ Financial / credit data at scale.
+- ☐ Biometric data (face, fingerprint, voice) processed for identification or unique recognition.
+- ☐ Location data continuously collected.
+- ☐ Children's personal data at scale (independent of Section 9 obligations).
+
+### 3.3 Risk to rights of Data Principals
+
+- ☐ Processing that supports automated decisions materially affecting Principals (credit scoring, hiring, pricing, content amplification, eligibility decisions).
+- ☐ Processing that involves profiling for advertising or recommendation.
+- ☐ Processing that creates risk of identity theft, financial harm, or reputational harm at scale.
+
+### 3.4 Risk to sovereignty, integrity, electoral integrity, public order
+
+- ☐ Operating critical information infrastructure (CII) under NCIIPC.
+- ☐ Operating digital public infrastructure (DPI) at national scale.
+- ☐ Influence on public discourse / elections (large-reach platforms, news aggregators, recommendation systems with national reach).
+- ☐ Aggregating data that could reveal patterns of public order significance.
+
+### 3.5 Likely-SDF candidates today
+
+Organisations in this typical zone start SDF preparation now, not after notification:
+
+- Tier-1 banks, payment systems operators, large NBFCs.
+- National-scale telecom providers.
+- Large consumer internet platforms (e-commerce, social, ride-hailing, food, edtech).
+- National digital health platforms, ABDM custodians.
+- Cloud / hyperscaler infrastructure providers with material Indian data exposure.
+- Identity / KYC / Aadhaar-linked service providers.
+
+### 3.6 SDF additional obligations to plan for
+
+If proximate to SDF triggers, plan for:
+
+- **DPO (Indian-resident, accountable to Board)** — name, role, reporting line, budget, escalation path.
+- **DPIA framework** — when to trigger, methodology, sign-off, register, periodic review.
+- **Periodic independent audit** — auditor selection, scope, cadence, remediation pipeline.
+- **Algorithmic / automated-decision risk assessment** where decisions materially affect Principals.
+
+**Output of step 3**: SDF status `notified` / `likely candidate` / `not proximate` / `unclear — re-assess`.
+
+## 4. Cross-border posture (Section 16)
+
+DPDPA's default is **permissive** — transfer outside India is allowed unless the Central Government has notified the destination as restricted.
+
+### 4.1 Transfer inventory
+
+- ☐ Where do production data flows go? (Cloud regions, SaaS vendor regions, partner regions.)
+- ☐ Where do analytical / backup / DR copies go?
+- ☐ Where does support staff access from?
+
+For each destination, record the destination country and the data category transferred.
+
+### 4.2 Restricted-territory check
+
+- ☐ Has the Central Government notified any of those destinations as restricted under Section 16?
+
+The list is published by the Central Government and updated by gazette notification. **Query the latest gazette / MeitY notification at posture-determination time**. The plugin does not vendor the list.
+
+### 4.3 Sectoral localisation overlay
+
+Even when DPDPA permits the transfer, sectoral rules may require domestic storage:
+
+- **RBI**: Storage of Payment System Data (April 2018) — payment-system data must be stored only in India (offshore copy permitted for certain processing, then must return). Master Direction on IT Governance (2023) overlays additional storage / segregation rules.
+- **SEBI**: CSCRF storage and incident-handling rules for securities-market participants.
+- **IRDAI**: Information and Cyber Security Guidelines (2023) — insurer data handling.
+- **DoT/TRAI**: Indian Telecommunications Act 2023 / Telecom Cyber Security Rules 2024 — traffic and subscriber data retention India-side.
+- **CERT-In Direction 20(3)/2022**: 180-day log retention India-side; 5-year KYC retention for VPN / cloud / data-centre service providers.
+
+The strictest binding rule wins.
+
+**Output of step 4**: per data flow, posture `compliant` / `requires sectoral approval` / `prohibited under sectoral rule` / `prohibited under DPDPA notification`.
+
+## 5. Sectoral overlay assessment
+
+Identify which sectoral regulators apply to the entity. Each adds parallel obligations.
+
+| Sector trigger | Regulator | Add to compliance map |
+|---|---|---|
+| ☐ Operates as a bank, NBFC, payment system operator, account aggregator | RBI | IT Governance MD 2023; Cyber Security Framework; 6-hour incident reporting; payment-system data localisation |
+| ☐ Operates as a stock exchange, broker, investment advisor, MII, mutual fund, AIF | SEBI | CSCRF; 6-hour incident reporting; resilience standards |
+| ☐ Operates as an insurer, broker, web aggregator | IRDAI | Information and Cyber Security Guidelines 2023; incident reporting per current circulars |
+| ☐ Operates a telecom network, ISP, OTT-comms-as-a-service | DoT, TRAI | Indian Telecommunications Act 2023; Telecom Cyber Security Rules 2024; lawful interception; subscriber data |
+| ☐ Operates digital health services, ABDM-linked services, hospital information system at scale | NHA, MoH&FW | ABDM data policy; Health Data Management Policy; ABHA consent flows |
+| ☐ Operates Critical Information Infrastructure | NCIIPC | CII directions; incident reporting to NCIIPC |
+| ☐ Operates VPN, cloud, data centre services at scale | CERT-In, MeitY | Direction 20(3)/2022 — KYC retention 5 years, log retention 180 days India-side, 6-hour incident reporting |
+| ☐ Cross-listed or operates in EU / UK / Singapore / California | GDPR / UK GDPR / PDPA / CCPA | Build the multi-jurisdiction stricter-of matrix |
+
+**Output of step 5**: sectoral matrix listing each regulator that applies and the operating-rule that binds.
+
+## 6. Children's data trigger
+
+- ☐ Does the service or product accept users under 18?
+- ☐ Does the service have any feature that could be used by under-18s in practice (regardless of stated age limit)?
+- ☐ Is there any behavioural tracking, profiling, or recommendation that could reach a child user?
+- ☐ Is there any advertising experience that could target a child user?
+
+If yes to any, Section 9 obligations apply: verifiable parental consent, no behavioural tracking of children, no targeted advertising at children. Penalty exposure up to ₹200 crore.
+
+If the service is "not for children" but in practice reachable by them, design the verifiable-parental-consent flow as a default — not as an edge case.
+
+## 7. Output: scope summary
+
+Produce a structured summary covering:
+
+| Field | Value |
+|---|---|
+| Entity | <name> |
+| Applicability | APPLICABLE / NOT APPLICABLE / PARTIALLY EXEMPT |
+| Role(s) per processing activity | Fiduciary / Processor / Consent Manager / Joint |
+| SDF status | Notified / likely candidate / not proximate / unclear |
+| Children's data exposure | Yes / No (default-assume Yes if reachable) |
+| Cross-border destinations | <list> |
+| Restricted-territory issues | None / <list> |
+| Sectoral regulators in play | None / RBI / SEBI / IRDAI / DoT / NHA / NCIIPC / CERT-In / multi |
+| Highest-stakes obligation theme | Security / Children / SDF / Breach / Cross-border / Notice-Consent |
+| Recommended next command | `/ind-dpdpa:assess --scope=<theme> --role=<role>` |
+
+This summary feeds `/ind-dpdpa:assess` and `/ind-dpdpa:evidence-checklist`. Re-run scope when:
+
+- The Central Government notifies a new restricted territory under Section 16.
+- The entity's user base materially crosses an SDF-proximate threshold.
+- A new sectoral regulator is added to the entity's footprint.
+- A new processing activity is launched that materially changes the data inventory.
+
+## Disclaimer
+
+This is engineering and assessment guidance only. **Not legal advice.** Confirm scope determinations with qualified counsel before treating any output as definitive.

--- a/plugins/frameworks/ind-dpdpa/skills/ind-dpdpa-expert/SKILL.md
+++ b/plugins/frameworks/ind-dpdpa/skills/ind-dpdpa-expert/SKILL.md
@@ -1,0 +1,390 @@
+---
+name: ind-dpdpa-expert
+description: India DPDPA expert for the Digital Personal Data Protection Act 2023 and the DPDP Rules 2025. Covers Data Fiduciary obligations, Data Principal rights, Significant Data Fiduciary regime, Consent Manager, breach notification (72-hour), cross-border transfer regime, children's data, sectoral overlap with RBI / SEBI / IRDAI / TRAI / CERT-In / ABDM, and Data Protection Board enforcement.
+allowed-tools: Read, Glob, Grep, Write
+---
+
+# India DPDPA Expert
+
+Deep working knowledge of the **Digital Personal Data Protection Act, 2023** (DPDPA) and the **Digital Personal Data Protection Rules, 2025** (DPDP Rules), as enforced by the **Data Protection Board of India** (DPB) under the Ministry of Electronics and Information Technology (MeitY).
+
+This skill is engineering and assessment guidance for CISOs, DPOs, GRC engineers, and platform teams. It is **not** legal advice. Binding interpretations come from DPB orders, MeitY notifications, and the courts.
+
+## When to invoke this skill
+
+Invoke when the user is:
+
+- Mapping a system, product, or third-party vendor to DPDPA obligations
+- Determining whether DPDPA applies (territorial, material, role)
+- Assessing Significant Data Fiduciary (SDF) exposure
+- Drafting or auditing privacy notices, consent flows, or rights-fulfilment workflows
+- Building or stress-testing a personal-data-breach playbook (with DPDPA's 72-hour clock and the parallel sectoral clocks)
+- Preparing for a DPB enquiry or compiling penalty-mitigation evidence
+- Deciding cross-border transfer postures or evaluating a Consent Manager partner
+- Comparing DPDPA to GDPR / Singapore PDPA / other regimes for a multi-jurisdictional product
+
+## Framework identity
+
+| Field | Value |
+|---|---|
+| Statute | Digital Personal Data Protection Act, 2023 (Act No. 22 of 2023) |
+| Operational rules | Digital Personal Data Protection Rules, 2025 (notified November 2025) |
+| Regulator | Data Protection Board of India (DPB) under MeitY |
+| Territorial scope | Processing within India; processing outside India in connection with offering goods or services to Data Principals located in India |
+| Material scope | Digital personal data — personal data in digital form, or in non-digital form digitised subsequently |
+| SCF framework ID | `apac-ind-dpdpa-2023` |
+| SCF coverage | 41 SCF controls map to 96 DPDPA control identifiers |
+| Status (as of 2026) | Act in force; Rules notified November 2025 with phased operational dates |
+
+The Act and the Rules **must be read together**. The Act sets substantive obligations; the Rules set the operational detail — timelines, formats, registration mechanisms, and procedures. Gaps in either side are gaps in compliance.
+
+## Roles and definitions
+
+| DPDPA term | Meaning | GDPR analogue |
+|---|---|---|
+| **Data Fiduciary** | Determines the purpose and means of processing personal data. The controller-equivalent. | Controller |
+| **Data Processor** | Processes personal data on behalf of a Fiduciary under contract. | Processor |
+| **Data Principal** | The natural person whose personal data is processed. For a child, the parent or lawful guardian; for a person with a disability, the lawful guardian. | Data Subject |
+| **Significant Data Fiduciary (SDF)** | A class of Data Fiduciary notified by the Central Government as having higher-risk processing. Carries additional obligations. | (Broader and stricter than GDPR's "large-scale" qualifier) |
+| **Consent Manager** | A registrable entity that manages consents on behalf of Data Principals — gives, manages, reviews, withdraws consent across multiple Fiduciaries. | (No direct GDPR analogue) |
+| **Personal data** | Any data about an individual who is identifiable by or in relation to such data. | Personal data (Article 4(1)) |
+| **Processing** | Wholly or partly automated operation/s on personal data — collection, storage, use, sharing, disclosure, erasure, destruction. | Processing |
+| **Personal data breach** | Any unauthorised processing or accidental disclosure, acquisition, sharing, use, alteration, destruction or loss of access to personal data, that compromises its confidentiality, integrity, or availability. | Personal data breach |
+
+DPDPA does **not** define "sensitive personal data" as a separate category (unlike GDPR Article 9 or India's earlier SPDI Rules 2011). All personal data is governed by the same baseline obligations, with intensified obligations for children's data (Section 9) and SDF processing (Section 10).
+
+## Territorial and material applicability (Section 3)
+
+DPDPA applies to processing of **digital personal data**:
+
+1. **Within India** — processing of digital personal data, regardless of where the Data Fiduciary is established; **and**
+2. **Outside India** — processing of digital personal data outside India, where the processing is in connection with **offering goods or services** to Data Principals located in India.
+
+Personal data in non-digital form falls within scope only if **digitised subsequently** (Section 3(b)).
+
+DPDPA does **not** apply to:
+
+- Personal data processed by an individual for **personal or domestic purposes**.
+- Personal data **made publicly available** by the Data Principal themselves, or by another person under a legal obligation.
+- Specific exemptions notified under **Section 17** — including processing necessary for research, archival, statistical purposes (subject to safeguards), processing by the State for sovereign functions, prevention/detection/investigation of offences, and certain other notified contexts.
+
+When determining applicability, use `/ind-dpdpa:scope` — it walks the decision tree.
+
+## Data Fiduciary obligations (Section 8)
+
+Every Data Fiduciary, whether SDF or not, owes the following baseline obligations:
+
+| Obligation | Section | What it requires |
+|---|---|---|
+| Accuracy | 8(3) | Make reasonable efforts to ensure personal data is accurate and complete when used to make a decision affecting the Principal or shared with another Fiduciary. |
+| Security safeguards | 8(5) | Protect personal data in possession or control by taking **reasonable security safeguards** to prevent personal data breaches. (The Schedule attaches up to ₹250 crore penalty for failure here — the largest band.) |
+| Breach notification | 8(6) | On becoming aware of a personal data breach, give intimation in such form and manner as may be prescribed to (a) the Board and (b) each affected Data Principal. The DPDP Rules 2025 (R7) prescribe the timeline (72 hours) and content. |
+| Erasure on completion | 8(7) | Erase personal data when the Principal withdraws consent, or as soon as it is reasonable to assume the specified purpose is no longer being served — unless retention is required by law. Cause processors to do the same. |
+| Cause of processor compliance | 8(2) | Engage a Processor only under a valid contract; remain accountable for processing the Processor performs. |
+| Grievance and Principal-rights operation | 8(10), 13 | Publish business contact information of a person able to answer questions about processing; respond to Principals exercising their rights within prescribed timelines. |
+
+**"Reasonable security safeguards"** is not a checklist in the Act. The DPDP Rules 2025 elaborate technical and organisational measures — encryption, access control, logging and monitoring, backup and recovery, incident response capability, periodic review. In practice, alignment with ISO 27001 / NIST CSF / SCF baseline plus the relevant sectoral overlay (e.g. RBI Cyber Security Framework for banks) is what regulators expect of mature Fiduciaries.
+
+## Notice, consent, legitimate uses (Sections 5 – 7)
+
+### Notice (Section 5)
+
+Before processing, the Data Fiduciary gives the Principal a notice that:
+
+- Describes the personal data and the **purpose of processing**.
+- States the **manner** in which the Principal may exercise rights (Section 11–14).
+- States the **manner** of making a complaint to the DPB.
+- Is in **English or any of the languages specified in the Eighth Schedule** of the Constitution, at the option of the Principal.
+- For consents already obtained before the Act, requires the Fiduciary to give the notice **as soon as reasonably practicable**.
+
+### Consent (Section 6)
+
+Consent must be:
+
+- **Free** — no coercion, no leverage of power asymmetry.
+- **Specific** — limited to the purpose described in the notice.
+- **Informed** — preceded by the Section 5 notice.
+- **Unconditional** — not bundled with services where the data is not necessary for the service.
+- **Unambiguous, with clear affirmative action** — opt-in. Pre-ticked boxes, default-on toggles, and inferred consent do not satisfy.
+- **Withdrawable** — with the same ease as it was given. On withdrawal, processing for the purpose ceases, and the Fiduciary causes its Processors to cease likewise (Section 6(6)).
+
+The validity of consent does not depend on the Fiduciary's business model — bundling unrelated processing into the consent flow invalidates the consent for those unrelated purposes.
+
+### Legitimate uses (Section 7)
+
+Section 7 enumerates uses for which consent is **not required**. These are narrow and exhaustive — they do not create general "legitimate interest" latitude as GDPR does. The categories include:
+
+- Where the Principal has voluntarily provided personal data and has not indicated objection to its use for a specified purpose.
+- Performance of any function of the State authorised by law (subject to conditions).
+- Compliance with any judgment, decree, or order of a court / tribunal.
+- Responding to a medical emergency involving threat to life or immediate threat to the health of the Principal or any other person.
+- Taking measures to provide medical treatment or health services during an epidemic, outbreak, or threat to public health.
+- Disaster response and ensuring safety / providing assistance during disaster, breakdown of public order.
+- Employment-related purposes, including prevention of corporate espionage, maintenance of confidentiality of trade secrets, intellectual property, classified information, services / benefits sought by employee, verifications.
+
+When relying on Section 7 instead of consent, the burden is on the Fiduciary to fit the processing strictly within the named legitimate use. Drift outside the named purpose collapses the lawful basis.
+
+## Data Principal rights (Sections 11 – 14)
+
+| Right | Section | What the Principal can ask |
+|---|---|---|
+| Right to access information | 11 | A summary of personal data processed, the processing activities, the identities of other Fiduciaries / Processors with whom the data has been shared, and any other information prescribed. |
+| Right to correction, completion, updation, erasure | 12 | Correct inaccurate or misleading data, complete incomplete data, update outdated data, or erase data no longer necessary for the specified purpose (subject to retention exceptions). |
+| Right of grievance redressal | 13 | Use a readily available means of grievance redressal provided by the Fiduciary or Consent Manager. The Principal must exhaust this before approaching the DPB. |
+| Right to nominate | 14 | Nominate another individual to exercise the rights of the Principal in the event of death or incapacity. |
+
+The Fiduciary must respond within timelines prescribed under the DPDP Rules 2025. Free of charge for first request; reasonable fees may apply for repeated, manifestly unfounded, or excessive requests.
+
+The right to **erasure** is qualified — retention required by law (e.g. tax records, audit trails, KYC records under PMLA / RBI rules) overrides the request. The Fiduciary should document the retention basis when refusing erasure.
+
+DPDPA does **not** include a portability right (unlike GDPR Article 20) or an explicit right to object to automated decision-making (unlike GDPR Article 22). However, the obligation to respond to grievances and the Section 11 access right indirectly cover much of the same territory.
+
+## Children's data (Section 9)
+
+For Data Principals who are **children** (under 18, per DPDPA's reading) or **persons with disability who have a lawful guardian**:
+
+- Processing requires **verifiable parental consent / guardian consent**.
+- The Fiduciary must **not undertake any tracking or behavioural monitoring of children**.
+- The Fiduciary must **not target advertising directed at children**.
+- These prohibitions apply to all Fiduciaries — not just SDFs. Penalty exposure is up to **₹200 crore** for failure to fulfil obligations relating to children.
+
+The Central Government may exempt classes of Fiduciary or notify a lower threshold age for specific purposes (e.g. educational platforms, health services). Until exempted, the default 18-year threshold applies.
+
+"Verifiable parental consent" is not yet operationally specified by the Rules in granular detail. In practice, Fiduciaries rely on a combination of: (a) credit-card or banking-instrument transaction by an adult, (b) Aadhaar-based parent verification (where applicable and lawful), (c) signed declaration with identification, (d) Consent Manager flow where the Consent Manager performs the parent verification.
+
+## Significant Data Fiduciary regime (Section 10)
+
+The Central Government may notify any Data Fiduciary or class as an SDF, considering:
+
+- Volume and sensitivity of personal data processed.
+- Risk to the rights of Data Principals.
+- Potential impact on the sovereignty and integrity of India.
+- Risk to electoral democracy.
+- Security of the State.
+- Public order.
+
+An SDF has the baseline obligations **plus** the following:
+
+| Obligation | Detail |
+|---|---|
+| Data Protection Officer (DPO) | An individual based in India, accountable to the Board of Directors, the point of contact for grievances and DPB communications. |
+| Independent data auditor | A qualified, independent auditor must perform periodic audits of the SDF's compliance posture. |
+| Periodic Data Protection Impact Assessment (DPIA) | Conducted at the cadence and form prescribed under the Rules. Records risk assessment, mitigation measures, and consultation outcomes. |
+| Periodic compliance audit | Independent audit of compliance with DPDPA — separate from the SDF's own internal audit programme. |
+| Other measures | Such other measures as may be prescribed (e.g. specific algorithmic transparency or risk-mitigation measures for AI / profiling). |
+
+SDF designation is by notification and not automatic. However, prudent organisations that exceed implicit volume thresholds (typically very large consumer platforms, financial sector players with national reach, telecom / digital infrastructure providers) prepare for SDF posture in advance — designation can come at short notice.
+
+Penalty exposure for SDF-specific failures: up to **₹150 crore**.
+
+## Cross-border transfers (Section 16)
+
+DPDPA's cross-border posture is the **inverse** of GDPR:
+
+- The **default is permissive**: a Data Fiduciary may transfer personal data outside India.
+- The Central Government may, by notification, **restrict transfer to specified territories**. Until a territory is notified as restricted, transfer is allowed.
+
+Important interactions:
+
+- Section 16 does **not displace sectoral data localisation rules**. Where RBI Master Directions require payment-system data to be stored only in India, that requirement applies independent of DPDPA. Same for SEBI's CSCRF storage requirements, IRDAI guidance on insurance data, and any sector-specific localisation directive.
+- The list of restricted territories is published by the Central Government and changes over time. **This plugin does not vendor the list**; query the latest gazette notification at posture-determination time.
+- Cross-border processing also remains subject to the underlying lawfulness — purpose, consent, security — at every step.
+
+The practical posture for most Data Fiduciaries today is: transfer is allowed; the friction is sectoral localisation rules and contractual obligations to data principals (e.g. retention, deletion-on-withdrawal cascading across sub-processors).
+
+## Personal data breach response (Section 8(6) + DPDP Rules 2025 R7)
+
+A **personal data breach** under DPDPA is broader than a security incident — any compromise of confidentiality, integrity, or availability of personal data, including accidental disclosure, loss of access, or unauthorised processing.
+
+The Section 8(6) obligation requires the Fiduciary to give **intimation of such breach** to:
+
+1. The **Data Protection Board of India**, **and**
+2. **Each affected Data Principal**.
+
+The DPDP Rules 2025 prescribe the timeline (72 hours from awareness, with extensions on application showing reasonable cause) and the form/content of the notification.
+
+**Notification content (Rules 2025-aligned baseline)**:
+
+- Description of the breach — nature, timing, geographical extent.
+- Categories and approximate number of Principals affected.
+- Categories and approximate volume of personal data records affected.
+- Likely consequences for affected Principals.
+- Measures taken or proposed to mitigate adverse effects.
+- Contact point for follow-up.
+
+**Sectoral parallel clocks** — these run in addition to, not in place of, the DPDPA clock:
+
+| Source | Trigger | Timeline |
+|---|---|---|
+| **CERT-In Direction 20(3)/2022** | Cyber incidents (broader scope than personal-data breach) | **6 hours** |
+| **RBI Cyber Security Framework** | Cyber incidents at scheduled commercial banks, urban cooperative banks, NBFCs | **6 hours** to RBI / IDRBT CSITE Cell |
+| **SEBI CSCRF** | Cyber incidents at MIIs and SEBI-regulated intermediaries | **6 hours** to SEBI / NCIIPC |
+| **IRDAI cyber-security guidelines** | Cyber incidents at insurers and intermediaries | Per IRDAI direction (typically rapid; check current circulars) |
+| **DoT / TRAI Telecom Cyber Security Rules 2024** | Cyber-security incidents in telecom networks | Per the Rules' reporting matrix |
+| **DPDPA 8(6) + DPDP Rules 2025 R7** | Personal data breach | **72 hours** to DPB and affected Principals |
+
+The **first thing the breach playbook does** is identify which clocks are running. A bank suffering a ransomware incident affecting customer data has at least three clocks: CERT-In 6-hour, RBI 6-hour, DPDPA 72-hour. Missing the fastest clock is the typical failure mode.
+
+Penalty exposure for failure to notify: up to **₹50 crore** for the notification failure itself; the underlying security failure continues to expose up to ₹250 crore separately.
+
+## Consent Manager
+
+A Consent Manager is a Board-registered entity that:
+
+- Is **accountable to the Data Principal** (not to the Fiduciary).
+- Provides Principals an interoperable platform to **give, manage, review, and withdraw consents** across multiple Fiduciaries.
+- Is registered with the DPB under conditions prescribed in the DPDP Rules 2025.
+- Cannot itself process the personal data for any purpose other than consent management.
+
+Consent Managers are still emerging as of 2026; their role is critical for high-volume sectors where Principals deal with many Fiduciaries (financial services, healthcare). Account Aggregators in the financial sector are an early Consent Manager analogue regulated by RBI.
+
+For a Fiduciary that integrates a Consent Manager:
+
+- Consent provenance (who, when, what scope, what version of notice) flows from the Consent Manager into the Fiduciary's system.
+- Withdrawal events flow back from the Consent Manager and trigger deletion / processing-cessation cascade.
+- Record-keeping obligations remain with the Fiduciary; the Consent Manager's records are corroborative, not substitutive.
+
+## Sectoral overlay
+
+DPDPA does **not displace** sectoral data and security rules. They stack. A Fiduciary that is also a regulated entity must comply with both — and the stricter or earlier-deadline rule binds.
+
+| Sector | Regulator | Key rules that interact with DPDPA |
+|---|---|---|
+| Banking / NBFC / Payment systems | RBI | Master Direction on IT Governance, Risk, Controls and Assurance Practices (Nov 2023); Cyber Security Framework for Banks; Storage of Payment System Data (April 2018); Account Aggregator framework. 6-hour incident reporting. |
+| Capital markets | SEBI | Cyber Security and Cyber Resilience Framework (CSCRF) for SEBI-regulated entities; 6-hour incident reporting; MII-grade resilience standards. |
+| Insurance | IRDAI | Information and Cyber Security Guidelines (2023); incident reporting timelines per current IRDAI directives. |
+| Telecom / DPI | DoT, TRAI | Indian Telecommunications Act 2023 user-data provisions; Telecom Cyber Security Rules 2024 incident reporting and traffic-data retention. |
+| Digital health | NHA, MoH&FW | Ayushman Bharat Digital Mission (ABDM) data policy; Health Data Management Policy; consent flows tied to ABHA accounts. |
+| All sectors (cyber) | CERT-In | Direction No. 20(3)/2022 — 6-hour reporting of cyber incidents (broader than personal-data breach); log retention obligations (180 days India-side); KYC retention for VPN / cloud / data-centre service providers. |
+| All sectors (information security) | MeitY | IT Act 2000 + SPDI Rules 2011 (still in force for issues outside DPDPA's digital-personal-data scope); CERT-In and NCIIPC directives for critical information infrastructure. |
+
+When assessing a regulated Fiduciary, **build a regulator matrix first**. For each obligation theme (notice, consent, retention, breach, cross-border, audit), record (a) DPDPA position, (b) sectoral position, (c) which is stricter, (d) which clock starts first. The strictest binding rule is the operating obligation.
+
+## GDPR comparison (most-asked)
+
+| Theme | GDPR | DPDPA |
+|---|---|---|
+| Lawful bases | 6 (consent, contract, legal obligation, vital interests, public task, legitimate interests) — Article 6 | Consent (Sec 6) + enumerated **legitimate uses** (Sec 7). No general "legitimate interest" basis. |
+| Sensitive / special data | Article 9 — separate stricter regime | Not separately defined; children's data and SDF have intensified obligations. |
+| Right to portability | Article 20 — explicit | Not provided. |
+| Right to object to automated decision-making | Article 22 — explicit | Not provided as a standalone right. |
+| Cross-border default | Restrict-by-default; need adequacy / SCCs / BCRs | Allow-by-default; restrict only to notified territories. |
+| DPO requirement | When core activities require regular and systematic monitoring on a large scale, or processing of special categories on a large scale | Only for SDFs. |
+| Breach notification | 72 hours to supervisory authority; high-risk breaches to data subjects | 72 hours (per Rules 2025) to DPB **and** to each affected Principal. |
+| Penalty bands | Up to €20m or 4% global turnover | Up to ₹250 crore per breach class (no turnover-percentage formulation). |
+| Children threshold | 16 (with member-state derogation to 13) | 18 (with potential Government notification of lower thresholds for specified purposes). |
+| Record-keeping | Article 30 ROPA | Records of processing implied by Section 8 obligations + Rules; SDF audit obligations. |
+
+Most multi-jurisdictional product programs converge on **the stricter of GDPR and DPDPA per theme** as the operating posture, except for cross-border (where the regimes don't overlap — both must be satisfied independently for the relevant data flows).
+
+## Common implementation pitfalls
+
+1. **Treating Rules 2025 as advisory.** The Rules give the Act its operational teeth (timelines, formats, registration). Compliance posture without reference to the Rules is incomplete.
+2. **Confusing notice with consent.** A privacy policy posted on a website is not consent. Consent requires a **clear affirmative action** by the Principal, post-notice.
+3. **Bundling unrelated processing into one consent.** Section 6 invalidates consent for any processing beyond what is necessary for the service the Principal sought. Granular per-purpose consent is the safe posture.
+4. **Missing the withdrawal cascade.** When consent is withdrawn, processing must cease and Processors must be caused to cease. Many implementations stop at the Fiduciary's own systems and forget the sub-processor / vendor chain.
+5. **Applying GDPR's "legitimate interest" framing to DPDPA.** DPDPA has no equivalent. Section 7 legitimate uses are exhaustive.
+6. **Children-by-default missing.** Sites that don't ask age, or ask but don't enforce verifiable parental consent on positive-age signals, fail Section 9.
+7. **Breach clock collision.** Running only DPDPA's 72-hour clock and missing the parallel CERT-In / RBI / SEBI 6-hour clocks. This is the single most common breach-response failure for regulated Fiduciaries.
+8. **Cross-border misreading.** Assuming Section 16 has a GDPR-style restrictive default; or assuming sectoral localisation rules disappear under DPDPA. Both are wrong.
+9. **SDF posture only after notification.** SDF designation can come fast; preparing only after notification leaves a 90-day scramble.
+10. **Vendor compliance gaps.** Processors operating without DPDPA-aligned contracts. The Fiduciary remains accountable.
+11. **Consent vintage.** Treating pre-Act consents as automatically valid under DPDPA. Section 5(2) requires fresh notice, and consents must satisfy Section 6 going forward.
+
+## Evidence patterns by obligation
+
+For each Section 8 obligation theme, the typical evidence the DPB or an independent auditor will expect:
+
+| Theme | Evidence |
+|---|---|
+| Notice (Sec 5) | Versioned notice templates per language, change log, samples of as-served notices, evidence of language coverage. |
+| Consent (Sec 6) | Consent records with timestamp, purpose, scope, version of notice, mode (clickwrap, in-app, Consent Manager). Withdrawal events and downstream cessation records. |
+| Legitimate use (Sec 7) | Documented determination per processing activity, mapping each processing activity to the specific legitimate use category. |
+| Purpose limitation | Purpose register; data flow diagrams; system entitlement reviews showing data accessed only for the registered purpose. |
+| Accuracy (Sec 8(3)) | Correction-request logs with response timelines; data quality controls. |
+| Security safeguards (Sec 8(5)) | ISMS evidence (ISO 27001, NIST CSF, sectoral framework); risk register; pen-test reports; vulnerability management records; access-control reviews; encryption inventory; logging and monitoring evidence. |
+| Breach notification (Sec 8(6)) | Incident response plan with DPDPA-specific clauses; tabletop exercise records; sample DPB notification template; sample Principal notification template; clock matrix per applicable regulator. |
+| Retention / erasure (Sec 8(7)) | Retention schedule by data category and purpose; deletion job logs; legal-hold register for data preserved beyond default retention. |
+| Principal-rights (Sec 11–14) | Rights-request intake records; SLA evidence; refusal records with documented retention basis. |
+| Children (Sec 9) | Age-gating mechanism design; parental-consent verification artefacts; targeted-advertising suppression configuration; behavioural-tracking suppression configuration. |
+| SDF (Sec 10) | DPO appointment record; DPIA report; independent audit report; algorithmic / model risk register where applicable. |
+| Cross-border (Sec 16) | Transfer register (where data flows); restricted-territories check at posture-determination time; sectoral-localisation conformance evidence. |
+| Consent Manager integration | Integration design; consent receipt format; withdrawal-event handling; reconciliation reports. |
+
+The `/ind-dpdpa:evidence-checklist` command renders the live checklist with collection guidance per evidence type.
+
+## DPDP Rules 2025 — operational themes
+
+The Rules notified in November 2025 give DPDPA its day-to-day shape. Headline themes:
+
+| Theme | Rule cluster (paraphrased) |
+|---|---|
+| Notice content and language | Detailed content requirements, language coverage, accessibility for the visually impaired. |
+| Consent format and management | Specifications for consent receipts; record retention; integration with Consent Managers. |
+| Consent Manager registration | Capital and governance criteria, technical interoperability standards, supervisory expectations. |
+| Breach notification | 72-hour timeline; format and content of notice to the DPB and affected Principals; mechanism for receipt; extension procedures on reasonable cause. |
+| Children's data | Operational means of verifiable parental consent; mechanisms for age determination; permissible exemptions for educational and health services. |
+| SDF obligations | DPIA cadence and form; periodic audit cadence and qualification of auditors; DPO scope. |
+| Exemptions | Procedures for invoking research / archival / statistical exemptions; safeguards required. |
+| DPB procedure | Inquiry process; timelines; written statements; orders; appeal route to the Telecom Disputes Settlement and Appellate Tribunal (TDSAT). |
+| Cross-border restrictions | Mechanism for the Central Government to notify restricted territories. |
+
+When a precise Rule number is needed for an assessment artefact, **read the gazette notification of the DPDP Rules 2025 directly** — that is the authoritative numbering.
+
+## Penalty exposure (Schedule)
+
+Penalties are imposed by the DPB after inquiry. Bands (per breach class):
+
+- Up to **₹250 crore** — failure to take reasonable security safeguards (Section 8(5)) leading to a personal data breach
+- Up to **₹200 crore** — failure to fulfil obligations relating to children (Section 9)
+- Up to **₹150 crore** — failure to fulfil additional obligations of an SDF (Section 10)
+- Up to **₹50 crore** — failure to inform the Board / affected Principal of a breach (Section 8(6))
+- Up to **₹50 crore** — failure of a Data Principal to comply with Section 15 duties
+
+The DPB considers nature, gravity, duration, type and nature of personal data, repetitive conduct, mitigation, and benefit gained / loss avoided in determining the actual penalty. Recidivism is treated as an aggravating factor.
+
+## Implementation roadmap (mature programme)
+
+For a Fiduciary starting an end-to-end DPDPA programme:
+
+**Day 0 — Determine**
+- Run `/ind-dpdpa:scope` for territorial / material applicability and role assignment.
+- Build the regulator matrix (DPDPA + sectoral overlays).
+- Inventory in-scope systems and data flows. Identify Processors.
+
+**Phase 1 — Foundations (0–90 days)**
+- Notice templates per language, per processing activity. Versioned.
+- Consent capture redesign: opt-in, granular, withdrawable, recorded.
+- Rights workflow: intake, triage, response SLAs, refusal logging.
+- Breach playbook: parallel-clock matrix, notification templates (DPB + Principals), tabletop drill.
+- Vendor / processor contract uplift: DPDPA addendum, security safeguards, breach-cooperation, deletion cascade.
+
+**Phase 2 — SDF preparation (where applicable, 90–180 days)**
+- DPO appointment (India-resident, accountable to Board).
+- DPIA framework: trigger criteria, methodology, register.
+- Independent auditor selection and first audit.
+- Algorithmic risk inventory for model-driven decisions affecting Principals.
+
+**Phase 3 — Continuous compliance (180+ days)**
+- Evidence automation: consent receipts, deletion jobs, audit logs flow into the GRC platform automatically.
+- Quarterly internal reviews; annual independent review.
+- Regulator matrix maintenance: sectoral rule changes, restricted-territory list checks.
+- DPB filing register (any inquiry, notice, or order).
+- Lessons-learned from sector incidents fed back into the breach playbook.
+
+## Plugin commands
+
+When the user invokes any of these, this skill provides the framework knowledge:
+
+- `/ind-dpdpa:scope` — applicability and SDF-trigger walkthrough
+- `/ind-dpdpa:assess` — gap assessment via SCF crosswalk
+- `/ind-dpdpa:evidence-checklist` — evidence-by-theme list
+- `/ind-dpdpa:breach-process` — 72-hour timeline and parallel sectoral clocks
+
+## Caveats
+
+- This skill paraphrases statutory obligations; the gazette text of the Act and Rules is authoritative.
+- Rule numbering for the DPDP Rules 2025 referenced here is illustrative — confirm specific rule numbers against the gazette notification when authoring compliance artefacts.
+- Sectoral references (RBI, SEBI, IRDAI, TRAI, NHA, CERT-In) are provided so the engineering posture accounts for parallel obligations; the authoritative source for each is the regulator's own circulars and directions, not this skill.
+- Penalty bands are from the Schedule attached to the Act. Actual penalty in any matter is determined by the DPB on the merits.
+- This is engineering and assessment guidance, **not legal advice**. Confirm postures with qualified counsel before treating any output as compliant.

--- a/plugins/frameworks/ind-dpdpa/skills/ind-dpdpa-expert/SKILL.md
+++ b/plugins/frameworks/ind-dpdpa/skills/ind-dpdpa-expert/SKILL.md
@@ -49,7 +49,7 @@ The Act and the Rules **must be read together**. The Act sets substantive obliga
 | **Consent Manager** | A registrable entity that manages consents on behalf of Data Principals — gives, manages, reviews, withdraws consent across multiple Fiduciaries. | (No direct GDPR analogue) |
 | **Personal data** | Any data about an individual who is identifiable by or in relation to such data. | Personal data (Article 4(1)) |
 | **Processing** | Wholly or partly automated operation/s on personal data — collection, storage, use, sharing, disclosure, erasure, destruction. | Processing |
-| **Personal data breach** | Any unauthorised processing or accidental disclosure, acquisition, sharing, use, alteration, destruction or loss of access to personal data, that compromises its confidentiality, integrity, or availability. | Personal data breach |
+| **Personal data breach** | Any incident that compromises the confidentiality, integrity, or availability of personal data — covering unauthorised processing, accidental disclosure or sharing, alteration, destruction, and loss of access (see Section 2(u) of the Act for the authoritative wording). | Personal data breach |
 
 DPDPA does **not** define "sensitive personal data" as a separate category (unlike GDPR Article 9 or India's earlier SPDI Rules 2011). All personal data is governed by the same baseline obligations, with intensified obligations for children's data (Section 9) and SDF processing (Section 10).
 
@@ -339,7 +339,7 @@ Penalties are imposed by the DPB after inquiry. Bands (per breach class):
 - Up to **₹200 crore** — failure to fulfil obligations relating to children (Section 9)
 - Up to **₹150 crore** — failure to fulfil additional obligations of an SDF (Section 10)
 - Up to **₹50 crore** — failure to inform the Board / affected Principal of a breach (Section 8(6))
-- Up to **₹50 crore** — failure of a Data Principal to comply with Section 15 duties
+- Up to **₹10,000** — failure of a Data Principal to comply with Section 15 duties (this is a Principal-side penalty under the Schedule, distinct from the crore-scale Fiduciary penalties above)
 
 The DPB considers nature, gravity, duration, type and nature of personal data, repetitive conduct, mitigation, and benefit gained / loss avoided in determining the actual penalty. Recidivism is treated as an aggravating factor.
 


### PR DESCRIPTION
## Summary

Adds a **Reference-depth** framework plugin for India's **Digital Personal Data Protection Act, 2023** (DPDPA) and the **DPDP Rules, 2025**, built for CISOs, DPOs, GRC engineers, and platform teams operating in India or offering goods or services to Data Principals located in India.

| Field | Value |
|---|---|
| Slug | `ind-dpdpa` |
| Path | `plugins/frameworks/ind-dpdpa/` |
| SCF framework ID | `apac-ind-dpdpa-2023` (41 SCF → 96 framework controls) |
| Region / Country | APAC / IN |
| Depth | `reference` |
| Regulator | Data Protection Board of India (DPB) under MeitY |
| Authored by | [Devam Shah](https://github.com/DevamShah), personally |

## Coordination with #66

[#66](https://github.com/GRCEngClub/claude-grc-engineering/pull/66) (@AnandSundar) proposes a **Stub-depth** plugin for the same framework. Per [`docs/FRAMEWORK-PLUGIN-GUIDE.md`](https://github.com/GRCEngClub/claude-grc-engineering/blob/main/docs/FRAMEWORK-PLUGIN-GUIDE.md) ("*Level-ups are separate PRs. Don't try to go Stub → Full in one PR.*"), the natural sequence is:

1. **#66 lands first** as the Stub.
2. **This PR rebases** as a clean Stub → Reference upgrade.

Happy to invert that order or coordinate directly with @AnandSundar — whichever the maintainers prefer. The work credits @AnandSundar's stub framing in spirit; this PR builds the Reference content the level-up checklist calls for.

## What's in the box

| File | Lines | Purpose |
|---|---|---|
| `plugins/frameworks/ind-dpdpa/.claude-plugin/plugin.json` | 22 | Reference manifest (depth, regulator, framework_metadata) |
| `plugins/frameworks/ind-dpdpa/README.md` | 99 | Roles table, command index, sectoral-overlay matrix, penalty bands |
| `plugins/frameworks/ind-dpdpa/commands/assess.md` | 88 | `/ind-dpdpa:assess` — scope / role / sources args; SCF crosswalk delegation |
| `plugins/frameworks/ind-dpdpa/commands/scope.md` | 240 | 7-step applicability + role + SDF-trigger + cross-border + sectoral walkthrough |
| `plugins/frameworks/ind-dpdpa/commands/evidence-checklist.md` | 338 | 14 obligation themes — what to collect, where it lives, what good looks like |
| `plugins/frameworks/ind-dpdpa/commands/breach-process.md` | 242 | DPDPA 72h + parallel sectoral clocks (CERT-In 6h, RBI 6h, SEBI 6h, IRDAI, DoT/TRAI), 5 phases |
| `plugins/frameworks/ind-dpdpa/skills/ind-dpdpa-expert/SKILL.md` | 390 | Reference-grade expert knowledge with no `TODO:` markers |
| `.claude-plugin/marketplace.json` | +6 | Registration entry |

**Total: 1,425 lines of authored Markdown + JSON.**

## Reference-depth differentiators

Per the level-up checklist in `docs/FRAMEWORK-PLUGIN-GUIDE.md`:

- [x] `framework_metadata.depth` = `"reference"`
- [x] `commands/scope.md` — framework-specific (not generic) applicability + SDF triggers + sectoral overlap detection
- [x] `commands/evidence-checklist.md` — evidence patterns organised by DPDPA's own obligation themes
- [x] `SKILL.md` substantive in every section; no `TODO:` markers in body
- [x] Regulator named (DPB under MeitY); SCF crosswalk metadata correct
- [x] `README.md` reflects Reference depth and install/usage
- [x] No verbatim Act / Rules text

**Reference-plus:** `commands/breach-process.md` is a substantive bonus command — the **clock-collision** problem (DPDPA 72h vs CERT-In 6h vs RBI 6h vs SEBI 6h running concurrently) is the most common DPDPA-era breach failure for regulated Indian Fiduciaries, and the Reference checklist alone wouldn't cover it well.

## Sectoral overlay

DPDPA stacks on top of sectoral data and security rules — it does not displace them. The plugin flags overlap with:

- **RBI** — Master Direction on IT Governance (2023), Cyber Security Framework, payment-system data localisation, 6-hour incident reporting
- **SEBI** — Cyber Security and Cyber Resilience Framework (CSCRF), 6-hour incident reporting
- **IRDAI** — Information & Cyber Security Guidelines (2023)
- **DoT / TRAI** — Indian Telecommunications Act 2023, Telecom Cyber Security Rules 2024
- **NHA / MoH&FW** — Ayushman Bharat Digital Mission data policy, Health Data Management Policy
- **NCIIPC** — Critical Information Infrastructure
- **CERT-In** — Direction No. 20(3)/2022 (6-hour cyber-incident reporting; 180-day log retention India-side)

The plugin **does not enforce** sectoral rules — those remain for sector-specific plugins or org-internal playbooks. It only flags overlap so engineering teams don't miss parallel clocks.

## Constraints honoured

- **No verbatim Act or Rules text.** Paraphrase only; references by section / rule number.
- **No PII, no real org context, no credentials.**
- **No legal-advice phrasing.** "Engineering and assessment guidance only" disclaimer in every user-facing file.
- **Cloud-agnostic.** No hard vendor dependencies in implementation guidance.
- **No hand-maintained crosswalks.** Defers to SCF for control mapping (`apac-ind-dpdpa-2023`).
- **No vendored restricted-territories list.** Section 16's blocklist is published by the Central Government and updates over time; the plugin tells users to consult the latest gazette notification at posture-determination time.

## Validation

- [x] `plugin.json` passes the Reference manifest schema (the one proposed in [#71](https://github.com/GRCEngClub/claude-grc-engineering/pull/71))
- [x] `marketplace.json` passes the marketplace schema
- [x] `claude plugin install` install-time validation: passes (the `framework_metadata` extension key is permitted)
- [x] Audit grep clean for: long verbatim quotes, real-org context, PII patterns, credentials, "legal advice" misuse phrasing
- [x] Disclaimer present in every user-facing file (README + 4 commands + SKILL)

## Test plan

- [ ] Install: `/plugin install ind-dpdpa@grc-engineering-suite`
- [ ] `/ind-dpdpa:scope` walks through applicability + role + SDF + cross-border + sectoral
- [ ] `/ind-dpdpa:assess SOC2 --sources=github-inspector` (or any connector) routes via SCF crosswalk and produces a DPDPA-flavoured gap report
- [ ] `/ind-dpdpa:evidence-checklist --theme=breach` renders the breach-evidence list
- [ ] `/ind-dpdpa:breach-process --sectors=banking` renders the parallel-clock matrix with RBI included
- [ ] SKILL is invoked when the user asks Claude any DPDPA question in a workspace where this plugin is installed

## Disclaimer

This plugin is **engineering and assessment guidance only**. It is **not legal advice**. DPDPA enforcement and binding interpretation come from the Data Protection Board of India, MeitY notifications, and the courts. Confirm postures with qualified counsel before treating any output as compliant.

🤖 Authored personally by [Devam Shah](https://github.com/DevamShah), with [Claude Code](https://claude.com/claude-code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds India DPDPA 2023 + DPDP Rules 2025 compliance framework plugin in marketplace (v0.1.0)
  * Enables end-to-end compliance gap assessments with role- and scope-driven obligation filtering
  * Provides structured evidence checklist, assessment outputs (scores, control gaps, remediation roadmap) and SDF guidance

* **Documentation**
  * Adds detailed breach notification & response workflows with parallel regulator timing and templates
  * Introduces applicability scoping, sectoral overlays, and Significant Data Fiduciary determination guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->