### PR TITLE
feat(governance): add vouch-based PR contributor gate (dry-run)

### DIFF
--- a/.github/VOUCHED-MANAGERS.td
+++ b/.github/VOUCHED-MANAGERS.td
@@ -1,0 +1,4 @@
+# Users authorized to vouch/denounce/unvouch contributors.
+# See .github/workflows/vouch-manage.yml.
+ajy0127
+ethanolivertroy

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,15 @@
+# The list of vouched contributors for this repository.
+#
+# Syntax (see https://github.com/mitchellh/vouch):
+#  - One handle per line (no `@`), sorted alphabetically.
+#  - Optional platform prefix: `github:username`.
+#  - Denounce by prefixing with `-`. Optional reason after the handle.
+#
+# Maintainers (write/admin role) are auto-allowed and don't need to be listed.
+# Vouch a new contributor by commenting `vouch` on their issue/PR.
+# Only @ajy0127 and @ethanolivertroy can vouch — see VOUCHED-MANAGERS.td.
+AnandSundar
+DevamShah
+ajy0127
+ethanolivertroy
+jeftekhari

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,22 @@
+name: Vouch — check PR author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@v1
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          require-vouch: "true"
+          auto-close: "false"
+          dry-run: "true"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage.yml
+++ b/.github/workflows/vouch-manage.yml
@@ -1,0 +1,30 @@
+name: Vouch — manage by comment
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mitchellh/vouch/action/manage-by-issue@v1
+        with:
+          repo: ${{ github.repository }}
+          issue-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+          vouched-managers-file: .github/VOUCHED-MANAGERS.td
+          roles: admin,maintain
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -53,6 +53,29 @@ high-quality participation. Our default bar is:
 
 Maintainership is a stewardship role, not just a merge permission.
 
+## Vouching new contributors
+
+To manage the volume of automated and AI-scaffolded pull requests, this repo
+uses [mitchellh/vouch](https://github.com/mitchellh/vouch). Vouched
+contributors are listed in `.github/VOUCHED.td`; users with `write` or `admin`
+role on the repository (including the leadership team) are auto-allowed and do
+not need to be listed.
+
+The gate currently runs in **dry-run mode**: unvouched authors get a comment
+on their PR but the PR is not closed. After we tune the seed list, we will
+flip enforcement on.
+
+Only **AJ Yawn (`@ajy0127`) and Ethan Troy (`@ethanolivertroy`)** are
+authorized to manage the vouch list — see `.github/VOUCHED-MANAGERS.td`. They
+manage it by commenting on any issue or PR:
+
+- `vouch` — vouch for the issue/PR author
+- `vouch @user` — vouch for a specific user
+- `denounce @user [reason]` — block a user
+- `unvouch @user` — remove a user from the list
+
+Comments from anyone outside the managers file are ignored.
+
 ## History
 
 The toolkit was founded by Ethan Troy in 2025 and contributed to the GRC


### PR DESCRIPTION
## Summary

- Adopts [mitchellh/vouch](https://github.com/mitchellh/vouch) to manage the volume of automated and AI-scaffolded PRs we've been seeing. New contributors must be vouched for before their PRs get fast-tracked; bots and users with `write`/`admin` role are auto-allowed.
- Ships in **dry-run + comment-only mode** so we can tune the seed list (`VOUCHED.td`) before flipping enforcement on. Unvouched PRs get a comment from the action but aren't closed.
- Vouching authority is **restricted to @ajy0127 and @ethanolivertroy** via `VOUCHED-MANAGERS.td` — deliberately narrower than the leadership team since vouching is a trust-anchoring decision.

## Files

- `.github/VOUCHED.td` — seeded with 5 prior merged-PR authors (AnandSundar, DevamShah, ajy0127, ethanolivertroy, jeftekhari)
- `.github/VOUCHED-MANAGERS.td` — ajy0127, ethanolivertroy
- `.github/workflows/vouch-check-pr.yml` — runs `mitchellh/vouch/action/check-pr` on `pull_request_target` (open/reopen) with `auto-close: false` + `dry-run: true`
- `.github/workflows/vouch-manage.yml` — runs `mitchellh/vouch/action/manage-by-issue` on `issue_comment` so AJ/Ethan can comment `vouch` / `denounce` / `unvouch`
- `GOVERNANCE.md` — new "Vouching new contributors" section

## Test plan

- [ ] Both workflows show up under the Actions tab after merge (`gh workflow list`)
- [ ] Next external PR triggers `Vouch — check PR author`; verify it posts a "needs vouch" comment and exits with `status=allowed` (no close, because dry-run)
- [ ] Comment `vouch` on that PR as @ethanolivertroy; verify `Vouch — manage by comment` runs, commits a line to `.github/VOUCHED.td`, and pushes to main
- [ ] On a test issue, comment `vouch` from a non-manager account; verify the workflow exits with `status=unchanged` and VOUCHED.td is unmodified
- [ ] After ~1–2 weeks of clean dry-run runs, open a follow-up PR flipping `dry-run: "false"` + `auto-close: "true"`

## Out of scope

- Gating issues (`check-issue` action). Decided against — keeps the support channel low-friction.
- Branch protection rules. Pre-existing gap; vouch works without them.
- Custom unvouched-PR response template (`template-file` input). Default message is fine for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a contributor vouching system with automated PR author verification.
  * Enabled automated checks on pull requests to verify vouched contributor status (currently in dry-run mode, posting comments only).

* **Documentation**
  * Added governance documentation explaining the vouching process, authorized managers, and management procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->