### PR TITLE
feat(teach-me): /teach-me primer + drill plugin (closes #61)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,6 +41,12 @@
       "version": "0.1.0"
     },
     {
+      "name": "teach-me",
+      "source": "./plugins/teach-me",
+      "description": "Socratic primer + drill plugin for new-to-GRC practitioners. Get up to speed on a framework, control, or role without already knowing it.",
+      "version": "0.1.0"
+    },
+    {
       "name": "soc2",
       "source": "./plugins/frameworks/soc2",
       "description": "SOC 2 Trust Service Criteria expertise and Type I/II assessment support",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes follow the format from [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Added
+
+- **`teach-me` plugin (v0.1.0).** Socratic primer + drill plugin for new-to-GRC practitioners and career transitioners — the on-ramp the toolkit was missing for people who don't already know the framework. Four commands: `/teach-me:framework <name>` produces a paraphrased primer (purpose, scope, artifacts, cadence, regulator, control families), `/teach-me:control <id>` explains one control across every framework it maps to via the SCF crosswalk, `/teach-me:role <persona>` outputs a first-90-days onboarding for the four GRC personas, and `/teach-me:quiz <framework>` runs a Socratic drill loop (inspired by [`mattpocock/skills/grill-me`](https://github.com/mattpocock/skills/tree/main/grill-me)) that tracks coverage in-session. Reuses `/grc-engineer:map-controls-unified` and `/grc-engineer:frameworks` rather than duplicating the SCF client. No normative standard text is reproduced. Closes [#61](https://github.com/GRCEngClub/claude-grc-engineering/issues/61).
+
 ### Removed
 
 - **`markdown-lint` CI workflow and `markdownlint-cli2` devDependency.** The lint gate was rejecting valid `<picture>`/`<source>` HTML in the README's star-history block (and similar legitimate HTML) faster than it was catching real prose problems. Removed `.github/workflows/markdown-lint.yml`, `.markdownlint-cli2.jsonc`, the `lint:md` package script, and the `markdownlint-cli2` devDependency.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Full walkthrough: [`docs/QUICKSTART.md`](docs/QUICKSTART.md).
 | Analyze a vendor security questionnaire (SIG, CAIQ, Yardstick) | `/grc-tprm:analyze-questionnaire` |
 | Discover which of the 249 SCF-mapped frameworks have dedicated plugins | `/grc-engineer:frameworks` |
 | Scaffold a new framework plugin from the SCF crosswalk | `/grc-engineer:scaffold-framework` |
+| Get a primer on a framework, drill yourself on it, or onboard into a GRC role | `/teach-me:framework`, `/teach-me:control`, `/teach-me:role`, `/teach-me:quiz` |
 
 Every command's reference page lives in its plugin's `commands/` directory with full input and output documentation.
 
@@ -87,6 +88,12 @@ Every command's reference page lives in its plugin's `commands/` directory with 
 | **grc-internal** | `/grc-internal:` | Internal GRC teams: risk registers, policy lifecycle, cert portfolio tracking |
 | **grc-reporter** | `/report:` | GRC practitioners communicating up: exec summaries, board briefs, program-health, automation ROI |
 | **grc-tprm** | `/grc-tprm:` | Third-party risk: vendor assessments, questionnaire analysis, risk scoring |
+
+### Learning
+
+| Plugin | Namespace | Who it's for |
+|---|---|---|
+| **teach-me** | `/teach-me:` | Career transitioners and new-to-GRC practitioners: paraphrased framework primers, single-control deep-dives, role onboarding, Socratic drills |
 
 ### Framework plugins
 

--- a/plugins/teach-me/.claude-plugin/plugin.json
+++ b/plugins/teach-me/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "teach-me",
+  "description": "Teach-me - get up to speed on a framework, control, or GRC role. Socratic primer + drill plugin built for new-to-GRC practitioners and career transitioners. Closes #61.",
+  "version": "0.1.0",
+  "author": {
+    "name": "GRC Engineering Club Contributors"
+  },
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT"
+}

--- a/plugins/teach-me/README.md
+++ b/plugins/teach-me/README.md
@@ -1,0 +1,35 @@
+# teach-me
+
+Get up to speed on a framework, control, or GRC role. Built for the practitioner who **doesn't already know the framework** — career transitioners, new hires, engineers asked to own a control they've never touched.
+
+```bash
+/plugin install teach-me@grc-engineering-suite
+
+/teach-me:framework SOC2          # primer on a framework
+/teach-me:control SCF-IAC-01      # one control across every framework it maps to
+/teach-me:role grc-engineer       # "I just got hired as X — what now?"
+/teach-me:quiz FedRAMP            # Socratic drill, asks until you've got it
+```
+
+## What this plugin is
+
+Every other framework plugin in this toolkit assumes you already know the framework. `teach-me` is the on-ramp that gets you there.
+
+- `/teach-me:framework` — paraphrased primer on a framework's purpose, scope, mandatory artifacts, cadence, and regulator. Names control families and points at the framework's own plugin (`/soc2:scope`, `/fedramp-rev5:assess`, etc.) for the next step. Does not reproduce copyrighted standard text.
+- `/teach-me:control` — pulls a control from the [SCF crosswalk](https://grcengclub.github.io/scf-api/) and explains it once, with the mapped framework controls listed below. Useful when "what does CHG-02 mean and where does it show up?" is the actual question.
+- `/teach-me:role` — what a `grc-engineer`, `grc-auditor`, `grc-internal`, or `grc-tprm` practitioner does day-to-day, what they touch in this toolkit, and where to start.
+- `/teach-me:quiz` — Socratic drill (inspired by [`mattpocock/skills/grill-me`](https://github.com/mattpocock/skills/tree/main/grill-me)). Asks you a control-application question, evaluates your answer, asks another. Tracks which control families you've covered. Stops when you say so.
+
+## What this plugin is not
+
+- Not a substitute for reading the framework. The user's licensed copy of SOC 2, FedRAMP Rev 5, ISO 27001, etc. is still the source of truth. This plugin paraphrases and points; it does not reproduce normative text.
+- Not an exam-prep tool. The quiz drills application, not memorization.
+- Not stateful. v0.1 holds quiz coverage in the current CLI session only. No history, no scoring, no leaderboard.
+
+## Reuse, not rebuild
+
+`/teach-me:control` delegates to `/grc-engineer:map-controls-unified` for crosswalk lookups. `/teach-me:framework` delegates to `/grc-engineer:frameworks` for coverage and depth metadata. The tutor doesn't duplicate the SCF client.
+
+## Status
+
+v0.1.0 — first cut. Feedback welcome on issue [#61](https://github.com/GRCEngClub/claude-grc-engineering/issues/61).

--- a/plugins/teach-me/commands/control.md
+++ b/plugins/teach-me/commands/control.md
@@ -1,0 +1,47 @@
+---
+description: Explain a single control once and show every framework it maps to via the SCF crosswalk
+---
+
+# /teach-me:control
+
+Take one control — by SCF ID, framework-specific ID, or plain English — and explain what it means, why it exists, what evidence proves it, and every other framework that maps to it. Designed for the question "I have to implement CC6.1 / IA-2 / 8.3 / CHG-02 — what is this and where else does it show up?"
+
+## Usage
+
+```
+/teach-me:control <control-id> [--lens=<framework>]
+```
+
+## Arguments
+
+- `<control-id>` (required) — accepts:
+  - SCF ID (e.g. `IAC-01`, `CHG-02`)
+  - Framework-specific ID (e.g. `CC6.1` for SOC 2, `IA-2` for NIST 800-53, `8.3` for ISO 27001)
+  - Plain-English description (e.g. "MFA on root accounts") — the `control-explainer` skill resolves to the closest match and lists alternatives if ambiguous.
+- `--lens=<framework>` (optional) — explain the control through one framework's vocabulary. Default is SCF.
+
+## What this produces
+
+1. **In plain English** — what this control requires, paraphrased. No normative quoting.
+2. **Why it exists** — the threat or failure mode the control addresses.
+3. **What good looks like** — 2–3 evidence patterns that demonstrate the control is in place.
+4. **Common implementation gaps** — where teams typically half-implement this control.
+5. **Cross-framework view** — every framework in the SCF crosswalk that maps this SCF control, with their local IDs. Lets the reader see "the same control shows up as CC6.1, IA-2, and 8.3."
+6. **Where this shows up in the toolkit** — relevant connector that detects it (e.g. `/aws-inspector:setup` for IAM controls), framework plugins that include it, and `/grc-engineer:test-control` to validate end-to-end.
+
+## Delegation
+
+The `control-explainer` skill calls:
+
+- `/grc-engineer:map-controls-unified` for the cross-framework view.
+- The SCF API for the canonical control vocabulary.
+- Reads the relevant framework plugins' `skills/<framework>-expert/SKILL.md` for any framework-specific notes the plugin author left.
+
+## Examples
+
+```
+/teach-me:control IAC-01
+/teach-me:control CC6.1 --lens=SOC2
+/teach-me:control "MFA on root accounts"
+/teach-me:control IA-2 --lens="NIST 800-53"
+```

--- a/plugins/teach-me/commands/framework.md
+++ b/plugins/teach-me/commands/framework.md
@@ -1,0 +1,55 @@
+---
+description: Get a working primer on a GRC framework — purpose, scope, artifacts, cadence, and where to start
+---
+
+# /teach-me:framework
+
+Produce a working primer on a framework for someone who doesn't know it yet. The output is a paraphrased explainer the reader can act on — not a regurgitation of the standard.
+
+## Usage
+
+```
+/teach-me:framework <framework-name> [--background=<level>]
+```
+
+## Arguments
+
+- `<framework-name>` (required) — common name (`SOC2`, `FedRAMP`, `ISO 27001`, `PCI DSS`) or SCF framework ID (`apac-sgp-pdpa-2012`). The `framework-tutor` skill resolves aliases.
+- `--background=<level>` (optional) — `none` | `adjacent` | `practitioner`. Adjusts depth. Defaults to `none` (career-transitioner audience).
+
+## What this produces
+
+A primer covering, in order:
+
+1. **In one paragraph** — what this framework exists to do and who it affects.
+2. **Who must comply** — territorial scope, entity types, common triggers.
+3. **What you have to produce** — the named artifacts (e.g. SOC 2 SOC report, FedRAMP SSP/SAP/SAR/POA&M, ISO 27001 SoA, PCI ROC/SAQ).
+4. **Cadence** — assessment frequency, recertification windows, breach-notification clocks.
+5. **Who enforces it** — regulator or accrediting body, recent enforcement patterns worth knowing.
+6. **Control families at a glance** — names + count, no normative text.
+7. **Common misinterpretations** — 2–3 things people new to this framework get wrong.
+8. **Where to go next in this toolkit** — the framework's own plugin (`/<framework>:scope`, `/<framework>:assess`) plus `/teach-me:control <id>` for any control the user wants to drill on.
+
+## Delegation
+
+The `framework-tutor` skill is invoked. It calls:
+
+- `/grc-engineer:frameworks` to confirm the framework has a plugin and to fetch its `framework_metadata` (depth, region, SCF ID, control counts).
+- The SCF API at [`grcengclub.github.io/scf-api`](https://grcengclub.github.io/scf-api/) for the framework's mapped control list (control IDs and families only).
+
+If the requested framework has no plugin in this toolkit, the primer still produces output but flags it: "This framework has no dedicated plugin. SCF crosswalk gives you the control set; ask `/teach-me:framework SOC2` (or similar) for a flow that has full plugin support."
+
+## What this command will not do
+
+- **Not reproduce normative standard text.** PCI DSS, ISO 27001, HITRUST text is copyrighted. This primer paraphrases and references control IDs only. The reader's licensed copy of the standard is the source of truth.
+- **Not give legal advice.** Frameworks like ITAR/EAR have legal exposure; the primer flags that and points at the framework plugin's own disclaimer.
+- **Not invent control IDs.** Every control reference comes from SCF or the framework plugin's own metadata.
+
+## Examples
+
+```
+/teach-me:framework SOC2
+/teach-me:framework FedRAMP --background=adjacent
+/teach-me:framework apac-sgp-pdpa-2012 --background=practitioner
+/teach-me:framework "ISO 27001"
+```

--- a/plugins/teach-me/commands/quiz.md
+++ b/plugins/teach-me/commands/quiz.md
@@ -1,0 +1,55 @@
+---
+description: Socratic drill on a framework — asks application-level questions and grades your answers until you say stop
+---
+
+# /teach-me:quiz
+
+Drill yourself on a framework with application-level questions. Ask, evaluate, ask again. Inspired by [`mattpocock/skills/grill-me`](https://github.com/mattpocock/skills/tree/main/grill-me).
+
+## Usage
+
+```
+/teach-me:quiz <framework> [--focus=<area>] [--difficulty=<level>]
+```
+
+## Arguments
+
+- `<framework>` (required) — common name or SCF framework ID. Same resolution as `/teach-me:framework`.
+- `--focus=<area>` (optional) — narrow the quiz to a control family or domain (e.g. `--focus=access-control` for IAM-heavy questions, `--focus=incident-response`). Skill resolves the area against the framework's control families.
+- `--difficulty=<level>` (optional) — `apprentice` (definitions and scope), `practitioner` (application and edge cases), `audit-defense` (the hard ones — explaining decisions to an assessor). Default `practitioner`.
+
+## How a session goes
+
+1. The skill picks a control or scenario from the framework's mapped SCF controls.
+2. It poses an **application-level question** — "your IAM admin enabled MFA for human users but not for service accounts. Which control fails and why?" — not a definition lookup.
+3. The user answers in plain language.
+4. The skill evaluates: correct, partially correct (with what's missing), or incorrect (with what to look up). It cites the control ID being tested.
+5. The skill picks the next question — biased toward control families the user hasn't covered yet in this session.
+6. After every 5 questions, the skill summarizes: which families covered, which still untouched, recurring weak spots.
+7. User says `stop`, `enough`, or `done` to end. Final summary printed.
+
+## What this produces
+
+A back-and-forth Q&A loop in the terminal. No file output, no scoring history persisted. State is the current CLI session only.
+
+## Delegation
+
+The `socratic-drill` skill drives the loop. It calls:
+
+- `/grc-engineer:frameworks` to validate the framework target.
+- The SCF API to enumerate the framework's mapped controls.
+- The framework plugin's `<framework>-expert` skill for application context that goes beyond the control text.
+
+## What the quiz will not do
+
+- **Not reproduce normative standard text** in either questions or evaluations. Paraphrased application scenarios only.
+- **Not certify the user** for anything. This is a study aid, not an exam-prep platform.
+- **Not persist results** in v0.1. A future version may write a coverage map under `grc-data/learning/` if the user opts in.
+
+## Examples
+
+```
+/teach-me:quiz SOC2
+/teach-me:quiz FedRAMP --focus=access-control --difficulty=audit-defense
+/teach-me:quiz "ISO 27001" --difficulty=apprentice
+```

--- a/plugins/teach-me/commands/role.md
+++ b/plugins/teach-me/commands/role.md
@@ -1,0 +1,42 @@
+---
+description: Onboarding primer for a GRC role — what you'll do, what you'll touch in this toolkit, and where to start
+---
+
+# /teach-me:role
+
+For someone who just got hired into (or pivoted to) a GRC role. Outputs a practical "your first 90 days" primer for the role, mapped to commands in this toolkit.
+
+## Usage
+
+```
+/teach-me:role <persona> [--background=<level>]
+```
+
+## Arguments
+
+- `<persona>` (required) — `grc-engineer`, `grc-auditor`, `grc-internal`, `grc-tprm`. Aliases (`engineer`, `auditor`, `internal`, `tprm`, `vendor-risk`) resolve to the canonical name.
+- `--background=<level>` (optional) — `none` (career transitioner), `adjacent` (security or platform-engineering background), `practitioner` (already in GRC, switching specialties). Default `none`.
+
+## What this produces
+
+1. **What this role does** — paraphrased role definition; what they own, what they don't, who they report into.
+2. **Day in the life** — concrete activities the role performs weekly and quarterly.
+3. **What you'll touch in this toolkit** — the persona's plugin (`grc-engineer`, `grc-auditor`, `grc-internal`, `grc-tprm`) plus the framework and connector plugins they'll lean on. Names actual commands.
+4. **Common mistakes new-to-role practitioners make** — 2–3, with the toolkit feature that prevents each.
+5. **First-week, first-month, first-quarter recommendations** — concrete commands to run, things to read, people to meet.
+6. **Adjacent roles you'll work with** — and how their toolkit footprint intersects with yours.
+
+## Delegation
+
+The `framework-tutor` skill is invoked. It reads:
+
+- The persona plugin's commands directory for the actual command surface.
+- `MAINTAINERS.md` and `CONTRIBUTORS.md` to point new practitioners at people active in that role.
+
+## Examples
+
+```
+/teach-me:role grc-engineer
+/teach-me:role auditor --background=adjacent
+/teach-me:role grc-tprm --background=practitioner
+```

--- a/plugins/teach-me/skills/control-explainer/SKILL.md
+++ b/plugins/teach-me/skills/control-explainer/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: control-explainer
+description: Explains a single control once and shows every framework it maps to via the SCF crosswalk. Resolves SCF IDs, framework-specific IDs, and plain-English descriptions. Never reproduces normative text.
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Control Explainer
+
+You are the skill invoked by `/teach-me:control <control-id>`. Your job is to take any reasonable reference to a control — SCF ID, framework-specific ID, or English description — and produce a single explanation that is useful across every framework that maps to it.
+
+## Operating principles
+
+1. **One control, many vocabularies.** SCF is the canonical vocabulary in this toolkit. SOC 2 calls it `CC6.1`; NIST 800-53 calls it `IA-2`; ISO 27001 calls it `8.3`. Show the learner that *the underlying requirement is shared* — that's the point of the SCF crosswalk.
+2. **Paraphrase the control.** Do not quote the standard's text. Explain what good implementation looks like in operational terms.
+3. **Show the failure mode, not just the requirement.** A control without its threat model is just a checkbox. Explain why the control exists.
+4. **Always end with a "where this lands in the toolkit" pointer.** Connector that detects it, framework plugin that includes it, and `/grc-engineer:test-control` to validate end-to-end.
+
+## Steps
+
+1. **Resolve the control reference.**
+   - If the input matches an SCF ID pattern (e.g. `IAC-01`, `CHG-02`), use it directly.
+   - If the input matches a framework-specific ID (e.g. `CC6.1`, `IA-2`, `8.3`, `Req 7.2`), call `/grc-engineer:map-controls-unified --framework=<best-guess>` to map it to SCF first. If `--lens=<framework>` is provided, use that as the lens.
+   - If the input is plain English (e.g. "MFA on root accounts"), search SCF control names and descriptions for the closest match. If multiple matches are plausible, list the top 3 and ask the user to pick.
+2. **Pull the cross-framework view.** Call `/grc-engineer:map-controls-unified <scf-id>` to get every framework that maps this SCF control, with their local IDs.
+3. **Read framework-specific notes.** For each mapped framework that has a dedicated plugin in `plugins/frameworks/`, read `skills/<framework>-expert/SKILL.md` for any framework-specific notes the plugin author left about this control.
+4. **Compose the explanation** in this order:
+   - **In plain English** — what this control requires (paraphrased).
+   - **Why it exists** — the threat or failure mode.
+   - **What good looks like** — 2–3 evidence patterns.
+   - **Common implementation gaps** — where teams typically half-implement.
+   - **Cross-framework view** — table of frameworks → local control IDs.
+   - **Where this lands in the toolkit** — connector(s), framework plugin(s), `/grc-engineer:test-control`.
+5. **If the control is unmapped or doesn't exist**, say so plainly. Do not invent a mapping.
+
+## Output format
+
+Markdown. Use a small table for the cross-framework view. Keep prose paragraphs short. Bold the section headings.
+
+## What you will not do
+
+- Do not quote control text from any framework. Paraphrase only.
+- Do not claim a mapping that the SCF crosswalk does not contain.
+- Do not invent framework-specific IDs. If a framework maps to the SCF control but the local ID isn't in the crosswalk data, say "mapped — local ID not present in crosswalk" rather than guessing.
+- Do not give implementation code. The reader can follow up with `/grc-engineer:generate-implementation` for that.

--- a/plugins/teach-me/skills/framework-tutor/SKILL.md
+++ b/plugins/teach-me/skills/framework-tutor/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: framework-tutor
+description: Tutor that produces working primers on GRC frameworks and roles. Adapts depth to the learner's background. Never reproduces copyrighted standard text — paraphrases and references control IDs.
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Framework Tutor
+
+You are the tutor invoked by `/teach-me:framework` and `/teach-me:role`. Your job is to get a learner who **does not know the framework** to a working understanding fast — without dumping the standard on them.
+
+## Operating principles
+
+1. **Paraphrase, never quote.** ISO 27001, PCI DSS, HITRUST, FedRAMP, and most national-data-protection-law text is copyrighted. Reference control IDs and section numbers; explain in your own words. The learner's licensed copy of the standard is the authoritative source — say so.
+2. **Adapt to background.** If `--background=none` (default), assume the learner has not seen the framework before and may be in a career transition. If `--background=adjacent`, assume security or platform-engineering literacy but no GRC role experience. If `--background=practitioner`, the learner is in GRC and switching specialties — be terse.
+3. **Point, don't lecture.** After every section, name the next command to run in this toolkit (`/<framework>:scope`, `/teach-me:control <id>`, `/grc-engineer:gap-assessment`). The primer is an on-ramp; the framework-specific plugin is where they go next.
+4. **Cite control IDs, not control text.** "FedRAMP Rev 5 has the AC family covering access control" — yes. "AC-2 says...[verbatim]" — no.
+5. **Flag legal exposure.** ITAR / EAR / national export controls / GDPR / breach-notification rules can have legal consequences. When the framework has any of these dimensions, point at the framework plugin's disclaimer rather than giving advice.
+
+## Steps for `/teach-me:framework <framework>`
+
+1. **Resolve the framework name.** Accept common names (`SOC2`, `SOC 2`, `FedRAMP`, `FedRAMP Rev 5`, `ISO 27001`, `ISO/IEC 27001:2022`), SCF framework IDs (`apac-sgp-pdpa-2012`, `us-fedramp-rev5`), and reasonable typos. If ambiguous, list the matches and ask. Use the `/grc-engineer:frameworks` discovery command for the canonical list and SCF IDs.
+2. **Check plugin coverage.** If a dedicated plugin exists in `plugins/frameworks/<name>/`, read its `skills/<name>-expert/SKILL.md` for the framework-specific context the plugin author left. If no plugin exists, use SCF crosswalk data from [`grcengclub.github.io/scf-api`](https://grcengclub.github.io/scf-api/) and tell the learner the toolkit's plugin coverage is at "Stub" or "Crosswalk-only" depth.
+3. **Produce the primer in this order**: one-paragraph purpose → who must comply → mandatory artifacts → cadence → regulator → control families at a glance → common misinterpretations → next commands.
+4. **End with three concrete next commands.** At minimum: `/<framework>:scope` (or its closest equivalent), `/teach-me:control <id>` for the most central control of the framework, and `/grc-engineer:gap-assessment <framework>` once the learner has a connector configured.
+
+## Steps for `/teach-me:role <persona>`
+
+1. **Resolve the persona.** `grc-engineer`, `grc-auditor`, `grc-internal`, `grc-tprm`. Reject unknown persona names rather than inventing one — `grc-ciso` is explicitly not a persona in this toolkit (it's an audience served by `/report:*`).
+2. **Read the persona plugin's command directory** at `plugins/<persona>/commands/` to get the actual command surface. Don't invent commands.
+3. **Produce the role primer** in this order: what the role owns → day in the life → first-week / first-month / first-quarter command sequence → common mistakes new practitioners make → adjacent roles.
+4. **Reference real maintainers.** Read `MAINTAINERS.md` and `CONTRIBUTORS.md`. If a maintainer is active in the role, name them as a person to follow.
+
+## What you will not do
+
+- Do not produce certification exam questions or claim to prepare anyone for an exam. The quiz skill is for application drills, not memorization.
+- Do not invent control IDs. Every control reference must come from SCF or a framework plugin's metadata.
+- Do not give legal opinions. Frameworks with legal exposure get a one-line disclaimer pointing at the framework plugin and the user's legal counsel.
+- Do not fabricate plugin coverage. If `/grc-engineer:frameworks` shows a framework as Crosswalk-only, say so plainly.
+
+## Output format
+
+Markdown. Use H2 (`##`) for the seven-section primer. Use fenced code blocks for any command examples. Keep paragraphs tight — under five sentences. The learner is reading this on a terminal, not in a textbook.

--- a/plugins/teach-me/skills/socratic-drill/SKILL.md
+++ b/plugins/teach-me/skills/socratic-drill/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: socratic-drill
+description: Drills the user on a framework with application-level scenario questions. Inspired by mattpocock/skills/grill-me. Tracks coverage in-session, evaluates answers against framework guidance, never reproduces normative standard text.
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Socratic Drill
+
+You are the skill invoked by `/teach-me:quiz <framework>`. Your job is to drill the learner on **applying** a framework's controls, not memorizing them. You ask scenario questions, evaluate answers, and adapt difficulty to keep them in the productive-struggle zone.
+
+## Operating principles
+
+1. **Application questions, not definitions.** "What does CC6.1 say?" is a definition question — do not ask it. "Your IAM admin enabled MFA for human users but missed service accounts. Which control fails and why?" is an application question — ask that.
+2. **Cover the framework, not your favorites.** Track which control families have been touched in this session. Bias the next question toward families not yet covered.
+3. **Honest evaluation.** If the user is wrong, say so and explain. If they're partially right, say what's missing. If they're right, say so and pick a harder angle next time. Don't sandbag and don't pile on.
+4. **Cite the control ID being tested.** After each evaluation, name the SCF or framework-specific control the question targeted. The user should leave the session knowing which controls they're shaky on.
+5. **No normative text.** Questions and evaluations paraphrase. Never quote the standard's control text.
+
+## Session flow
+
+1. **Initialize.** Resolve the framework name. Pull its SCF-mapped control list. Build a coverage map keyed by control family. If `--focus=<area>` was passed, restrict the control pool to that area.
+2. **Set difficulty.** `apprentice` — definitions, scope, who-does-what. `practitioner` (default) — application and edge cases. `audit-defense` — the hard ones, where the user has to defend a decision to a hypothetical assessor.
+3. **Loop:**
+   - Pick a control from the uncovered families (or weakest covered families if all touched).
+   - Pose a scenario question grounded in that control's domain. The question should be specific enough that there's a right and wrong answer.
+   - Wait for the user's answer.
+   - Evaluate honestly. State: correct / partially correct / incorrect, what's right, what's missing. Cite the control ID.
+   - Mark the family as covered (or noted-weak if the answer was off).
+   - **After every 5 questions**, output a short summary: families covered, families still uncovered, recurring weak spots.
+   - Pick the next question.
+4. **Stop conditions:** user types `stop`, `enough`, `done`, `quit`, `exit`, or anything similar. Print the final coverage summary on exit.
+
+## Question design rules
+
+- **Concrete scenarios.** "Your team just rotated AWS access keys and the rotation script forgot to revoke the old keys" beats "What does access key rotation require?"
+- **Use real-world artifacts.** A misconfigured S3 bucket, a Terraform module, a vendor questionnaire response, a SOC 2 SOC report finding.
+- **One control per question.** If your scenario implicates several controls, that's fine — but the question should target the one you're asking about. The user can volunteer the others.
+- **Avoid yes/no questions.** Force the user to articulate the why.
+
+## Evaluation rules
+
+- **Lead with the verdict.** "Correct," "Partially correct," "Incorrect." Then explain.
+- **Reference the control ID.** Always cite the SCF ID and the framework-specific ID for the lens framework.
+- **Name what the user missed.** If they got the control right but missed the threat model, say "you identified the right control — the threat model you missed is..." and explain.
+- **Do not reveal the answer before the user attempts it.** This is a drill, not a lecture.
+
+## Coverage summary format
+
+After every 5 questions and at the end of the session:
+
+```
+Coverage so far:
+  Covered (n): <list of control families touched>
+  Uncovered (n): <list of control families not yet touched>
+  Weak spots (n): <list of families where answers were partial or wrong>
+
+Suggested next focus: <family the skill recommends>
+```
+
+## What you will not do
+
+- Do not quote standard text in questions or evaluations.
+- Do not claim the user passed or failed a "test." This is a study aid, not an exam.
+- Do not write a coverage file to disk in v0.1. State is the current CLI session only. (A future version may opt-in write to `grc-data/learning/`.)
+- Do not invent control IDs. If you don't have crosswalk data for the framework, say so and switch to a framework you do.


### PR DESCRIPTION
## Summary

Adds the on-ramp the toolkit was missing for new-to-GRC practitioners and career transitioners. Every other framework plugin assumes the reader already knows the framework — `/teach-me` gets them there.

Four commands:
- `/teach-me:framework <name>` — paraphrased primer (purpose, scope, mandatory artifacts, cadence, regulator, control families). No normative text.
- `/teach-me:control <id>` — one control across every framework it maps to via the SCF crosswalk. Resolves SCF IDs, framework-specific IDs, and plain-English descriptions.
- `/teach-me:role <persona>` — first-90-days onboarding for the four GRC personas (`grc-engineer`, `grc-auditor`, `grc-internal`, `grc-tprm`).
- `/teach-me:quiz <framework>` — Socratic drill loop tracking coverage in-session, inspired by [`mattpocock/skills/grill-me`](https://github.com/mattpocock/skills/tree/main/grill-me). Application questions, not definition lookups.

Three skills back the commands: `framework-tutor`, `control-explainer`, `socratic-drill`. The plugin reuses `/grc-engineer:map-controls-unified` and `/grc-engineer:frameworks` rather than duplicating the SCF client.

The plugin lives at `plugins/teach-me/` as a top-level cross-cutting plugin (not under `personas/` or `frameworks/`) — it serves an audience that cuts across both. A new "Learning" subsection in the README's plugin-categories area makes the placement explicit.

Closes #61.

## Type of change

- [ ] Connector
- [ ] Framework plugin
- [ ] Persona plugin
- [ ] Documentation
- [ ] Community / governance
- [ ] CI / automation
- [x] Other — new top-level plugin (Learning category, cross-cutting)

## Schema impact

- [x] No schema changes
- [ ] `schemas/finding.schema.json` changed
- [ ] Another schema or contract surface changed

The plugin consumes Findings as references and emits no Findings of its own. No contract surface touched.

## Test plan

```text
$ bash tests/validate-plugin-manifests.sh
…
── plugins/teach-me/.claude-plugin/plugin.json
plugins/teach-me/.claude-plugin/plugin.json valid
  ✓ plugins/teach-me/.claude-plugin/plugin.json

Validated 35 manifest(s).
All manifests valid.
```

Functional dogfood is on the reviewer / merge — install the plugin and run:

- `/teach-me:framework SOC2` — should produce a primer that names the five TSCs, points at `/soc2:scope` and `/soc2:assess`, and does not reproduce TSP-100 text.
- `/teach-me:control IAC-01` — pulls the SCF crosswalk, lists mapped framework controls.
- `/teach-me:quiz FedRAMP` — runs at least 3 Socratic Q&A turns, prints a coverage summary.
- `/teach-me:role grc-engineer` — produces a first-90-days narrative referencing real `grc-engineer` commands.

## CHANGELOG

- [ ] No CHANGELOG entry needed
- [x] I added a CHANGELOG entry
- [ ] A maintainer should add the CHANGELOG entry during merge

Entry under `[Unreleased] → Added`.

## Notes for reviewers

- **Legal posture**: same as framework plugins — paraphrase, never quote. Every command file and skill prompt restates this rule. Worth scanning the four command files for any accidental verbatim phrasing.
- **No new schema, no scripts, no Findings emission**. The plugin is self-contained Markdown commands + skill prompts, structured like `plugins/frameworks/singapore-pdpa/` (the `scaffold-framework` reference shape).
- **Quiz state is in-session only** for v0.1. A future version may opt-in write a coverage map to `grc-data/learning/`; flagged in the skill prompt and command doc.
- **Discoverability**: registered in `.claude-plugin/marketplace.json` after `grc-reporter`; new "Learning" subsection added to the README plugin-categories area; workflow-table row added.
- **Closes #61** (Ethan's original "/teach-me" -ish skill or plugin to help get up to speed on frameworks faster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `teach-me` plugin (v0.1.0) with four learning-focused commands: framework primers, control explanations with implementation guidance, GRC role onboarding resources, and interactive Socratic quizzes.

* **Documentation**
  * Added complete documentation for teach-me commands with usage examples, installation instructions, and detailed feature descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->