### PR TITLE
feat(governance): migrate vouch to grc-eng-vouch-bot GitHub App

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -6,8 +6,9 @@
 #  - Denounce by prefixing with `-`. Optional reason after the handle.
 #
 # Maintainers (write/admin role) are auto-allowed and don't need to be listed.
-# Vouch a new contributor by commenting `vouch` on their issue/PR.
+# Vouch a new contributor by commenting `!vouch` on their issue/PR.
 # Only @ajy0127 and @ethanolivertroy can vouch — see VOUCHED-MANAGERS.td.
+-github:carycooper777 spam
 AnandSundar
 DevamShah
 ajy0127

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -12,11 +12,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: mitchellh/vouch/action/check-pr@v1
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.VOUCH_APP_ID }}
+          private-key: ${{ secrets.VOUCH_APP_PRIVATE_KEY }}
+
+      - uses: mitchellh/vouch/action/check-pr@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
         with:
           pr-number: ${{ github.event.pull_request.number }}
           require-vouch: "true"
-          auto-close: "false"
-          dry-run: "true"
+          auto-close: "true"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/vouch-manage.yml
+++ b/.github/workflows/vouch-manage.yml
@@ -11,20 +11,33 @@ concurrency:
 permissions:
   contents: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   manage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.VOUCH_APP_ID }}
+          private-key: ${{ secrets.VOUCH_APP_PRIVATE_KEY }}
 
-      - uses: mitchellh/vouch/action/manage-by-issue@v1
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: mitchellh/vouch/action/manage-by-issue@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
         with:
           repo: ${{ github.repository }}
           issue-id: ${{ github.event.issue.number }}
           comment-id: ${{ github.event.comment.id }}
           vouched-managers-file: .github/VOUCHED-MANAGERS.td
           roles: admin,maintain
+          vouch-keyword: "!vouch"
+          denounce-keyword: "!denounce"
+          unvouch-keyword: "!unvouch"
+          pull-request: "true"
+          merge-immediately: "true"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -61,20 +61,23 @@ contributors are listed in `.github/VOUCHED.td`; users with `write` or `admin`
 role on the repository (including the leadership team) are auto-allowed and do
 not need to be listed.
 
-The gate currently runs in **dry-run mode**: unvouched authors get a comment
-on their PR but the PR is not closed. After we tune the seed list, we will
-flip enforcement on.
+The gate runs in **enforcement mode**: PRs from unvouched authors are
+auto-closed with a templated comment. Bots and write/admin users are exempt.
 
 Only **AJ Yawn (`@ajy0127`) and Ethan Troy (`@ethanolivertroy`)** are
 authorized to manage the vouch list — see `.github/VOUCHED-MANAGERS.td`. They
-manage it by commenting on any issue or PR:
+manage it by commenting on any issue or PR (the keyword must be the **first
+line** of the comment):
 
-- `vouch` — vouch for the issue/PR author
-- `vouch @user` — vouch for a specific user
-- `denounce @user [reason]` — block a user
-- `unvouch @user` — remove a user from the list
+- `!vouch` — vouch for the issue/PR author
+- `!vouch @user` — vouch for a specific user
+- `!denounce @user [reason]` — block a user
+- `!unvouch @user` — remove a user from the list
 
-Comments from anyone outside the managers file are ignored.
+Each command opens a small auto-PR editing `.github/VOUCHED.td` and
+auto-merges it via the `grc-eng-vouch-bot` GitHub App, which holds bypass
+permission on the main branch. Comments from anyone outside the managers
+file are ignored.
 
 ## History
 


### PR DESCRIPTION
## Summary

- Moves the vouch system off the default `GITHUB_TOKEN` onto the new `grc-eng-vouch-bot` GitHub App (App ID `3513268`). The default token couldn't get past branch protection on `main`; the App is now in the bypass list so it can self-merge vouch-PRs.
- Mirrors the [ghostty-org](https://github.com/ghostty-org/ghostty/tree/main/.github/workflows) setup: SHA-pinned action (`v1.4.2` / `c6d80ead`), `!vouch`/`!denounce`/`!unvouch` keyword prefixes (so prose mentions don't trigger), `pull-request: true` + `merge-immediately: true`.
- Drops dry-run and flips `auto-close: true` on `vouch-check-pr.yml` — unvouched external PRs now get auto-closed.
- Records `-github:carycooper777 spam` in `VOUCHED.td` (the original `denounce` comment lost a push race; this lands the change directly).
- Updates `GOVERNANCE.md` to reflect the new keyword prefix and enforcement mode.

## Setup already completed (pre-merge)

- [x] `grc-eng-vouch-bot` GitHub App created and installed on this repo
- [x] `VOUCH_APP_ID` + `VOUCH_APP_PRIVATE_KEY` secrets set
- [x] App added to branch-protection bypass list on `main` (verified via API)

## Test plan

- [ ] After merge, post `!vouch @some-test-user` on a throwaway issue as @ethanolivertroy → vouch-bot opens a small PR editing `VOUCHED.td` and auto-merges it
- [ ] Post `!vouch @user` from a non-manager account → workflow runs but exits `unchanged`, no PR opened
- [ ] Open a PR from a fresh GitHub account not in `VOUCHED.td` → `Vouch — check PR author` auto-closes it with the templated comment
- [ ] Verify `VOUCHED.td` contains `-github:carycooper777 spam` immediately after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor vouching system documentation with new command syntax and enforcement behavior.

* **Chores**
  * Changed vouch command keyword from `vouch` to `!vouch` with updated syntax.
  * Activated automatic enforcement for unvouched pull requests.
  * Updated GitHub workflow configurations to support new vouch system behavior.
  * Removed a contributor from the vouched list due to spam.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->