### PR TITLE
fix(vouch): switch to direct push (legacy bypass doesn't honor merge API)

### DIFF
--- a/.github/workflows/vouch-manage.yml
+++ b/.github/workflows/vouch-manage.yml
@@ -37,7 +37,5 @@ jobs:
           vouch-keyword: "!vouch"
           denounce-keyword: "!denounce"
           unvouch-keyword: "!unvouch"
-          pull-request: "true"
-          merge-immediately: "true"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

The previous PR's auto-PR + auto-merge flow hit `405 Method Not Allowed` on `PUT /pulls/{N}/merge`. Root cause: legacy branch protection's `bypass_pull_request_allowances` lets bypass actors push directly to protected branches, but it does **not** honor bypass on the merge API endpoint. The endpoint refused to merge because GitHub still saw `reviewDecision: REVIEW_REQUIRED`.

Ghostty's working setup uses `pull-request: true` + `merge-immediately: true` because they're on **Rulesets** (the merge API honors ruleset bypass). We're on legacy branch protection.

Drops both options from `vouch-manage.yml` so the action defaults to direct push. The `grc-eng-vouch-bot` App is in the bypass list, so direct push to `main` should succeed.

## Test plan

- [ ] After merge, post `!vouch @some-test-user` on a throwaway issue → action commits directly to main, no auto-PR
- [ ] Verify VOUCHED.td updates without an intermediate PR

If direct push also fails, the next step is migrating from legacy branch protection to a Repository Ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to use default behavior settings.

---

**Note:** This release contains no user-facing changes. The modification adjusts internal development processes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->