### PR TITLE
docs: explain the issue → vouch → PR contributor flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ This toolkit is developed openly by the [GRC Engineering Club](https://grcengclu
 - **Issues**: Use a template when opening. Security-sensitive issues go to a private advisory; see `SECURITY.md`.
 - **Recognition**: contributors are credited via the [all-contributors](https://allcontributors.org) bot on every PR. Comment `@all-contributors please add @you for code,doc` after your PR merges, or ask a maintainer.
 
+### How to contribute (issue → vouch → PR)
+
+We get a steady stream of AI-scaffolded drive-by PRs, so contributions go through a small trust-gate that lets maintainers spend review time on real people:
+
+1. **Open an issue or [Discussion](https://github.com/GRCEngClub/claude-grc-engineering/discussions)** with your idea before writing code — even two lines is fine ("I'd like to add a connector for X"). It tells maintainers what you want to build and confirms you're a human, not an agent on a PR-spamming spree.
+2. **A maintainer comments `!vouch`** on the issue, adding you to [`.github/VOUCHED.td`](.github/VOUCHED.td). This is a one-time step — once you're vouched, you stay vouched.
+3. **Open the PR.** Normal review applies. PRs from unvouched authors are auto-closed with a pointer back here. Bots (Dependabot etc.) and maintainers with write access are exempt.
+
+Full mechanics in [`GOVERNANCE.md`](GOVERNANCE.md#vouching-new-contributors). The contributor walkthrough lives in [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md#first-time-contributors).
+
 ### Maintainers
 
 This project is co-led by members of the [GRC Engineering Club leadership team](https://github.com/orgs/GRCEngClub/teams/grc-eng-leadership-team). Current co-leads:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,11 +6,13 @@ The most valuable contributions are **new connectors** and **improvements to exi
 
 ## First-time contributors
 
-If this is your first PR here:
+If this is your first contribution here, the path is **issue → vouch → PR**:
 
-1. Browse [`good-first-issue`](https://github.com/GRCEngClub/claude-grc-engineering/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) labels for a self-contained starting task (typically 2–4 hours of work).
-2. Open a **draft PR** early — even with a skeleton commit. A maintainer will review direction before you sink time into it.
-3. Stuck? Start a thread in [Discussions](https://github.com/GRCEngClub/claude-grc-engineering/discussions) and tag the area (`connector`, `framework`, `docs`). "How would I add a connector for X?" is a welcome question.
+1. **Open an issue or Discussion** with your idea — even a two-line "I'd like to add a connector for X" works. Browse [`good-first-issue`](https://github.com/GRCEngClub/claude-grc-engineering/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) labels for a self-contained starting task (typically 2–4 hours). The issue also signals you're a real person — we get a steady stream of AI-scaffolded drive-by PRs and triage time matters.
+2. **Wait for a vouch.** A maintainer will comment `!vouch` on the issue (or on your profile, if we already know you). This adds you to [`.github/VOUCHED.td`](../.github/VOUCHED.td); see [`GOVERNANCE.md`](../GOVERNANCE.md#vouching-new-contributors) for the mechanics and why we do this.
+3. **Open the PR.** Once you're vouched, normal review applies. PRs from unvouched authors are auto-closed with a pointer back here. Bots (Dependabot etc.) and maintainers with write access are exempt.
+
+Stuck on direction? Tag your issue or Discussion with the area (`connector`, `framework`, `docs`). "How would I add a connector for X?" is a welcome question.
 
 ## Ground rules
 


### PR DESCRIPTION
## Summary

Adds a short "How to contribute" subsection in the README's Community section walking new contributors through the gate we just shipped: open an issue first, get a \`!vouch\`, then open the PR. Updates the matching First-time contributors section in \`docs/CONTRIBUTING.md\` so it leads with the same flow (the old "open a draft PR early" advice now gets auto-closed for unvouched authors).

Both blocks point to \`GOVERNANCE.md#vouching-new-contributors\` for full mechanics.

## Test plan

- [ ] Render the README on the merged branch and skim the Community section for clarity
- [ ] Verify the relative anchor links (\`GOVERNANCE.md#vouching-new-contributors\`, \`docs/CONTRIBUTING.md#first-time-contributors\`) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)