### PR TITLE
chore: add project-scoped Linear MCP for GRC Engineering Club

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "linear-grc-club": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -729,6 +729,18 @@ The grc-engineer plugin supports evidence collection across:
 - **GCP**: google-cloud-* SDKs, gcloud CLI (IAM, Storage, Logging)
 - **Kubernetes**: kubectl, kubernetes SDK
 
+## Issue tracking (Linear)
+
+This repo ships a **project-scoped** Linear MCP server in `.mcp.json` named `linear-grc-club`, pointing at `https://mcp.linear.app/mcp`. It loads only when Claude Code starts in this directory and does not affect MCP configuration in any other repo.
+
+**First-time setup per machine:**
+
+1. Start a Claude Code session in this directory.
+2. Run `/mcp` and authenticate `linear-grc-club` via OAuth.
+3. **Select the GRC Engineering Club workspace** at the consent screen (not a personal Linear). OAuth tokens are stored in the user's Claude config, not in the repo.
+
+Linear operations from this repo should target the GRC Engineering Club workspace through the `linear-grc-club` MCP. If a global `claude.ai Linear` MCP is also active in the session (authenticated to a different workspace), prefer the project-scoped tools so issues land in the right workspace. The team/project IDs for the club workspace will be recorded here once an authenticated maintainer captures them via `linear-grc-club`'s `list_teams` / `list_projects`.
+
 ## Important Notes
 
 - All plugins use MIT license


### PR DESCRIPTION
## Summary

- Adds `.mcp.json` with a project-scoped Linear MCP server (`linear-grc-club`) at `https://mcp.linear.app/mcp`. Only loads when Claude Code starts in this directory — doesn't touch any other repo's MCP config.
- Each maintainer authenticates via `/mcp` on first run per machine; OAuth consent screen lets them pick the **GRC Engineering Club workspace** specifically (no shared API key in the repo).
- CLAUDE.md gains an "Issue tracking (Linear)" section with the setup steps and a note to prefer the project-scoped MCP over any globally-active Linear MCP that might be authenticated to a personal workspace.

## Test plan

- [ ] After merge, start a fresh Claude Code session in the repo. Run `/mcp`. Confirm `linear-grc-club` is listed and offers to authenticate.
- [ ] OAuth via the GRC Engineering Club workspace. Confirm tokens land in user's Claude config (not committed).
- [ ] List teams via `mcp__linear-grc-club__list_teams` and confirm they're the GRC Eng Club teams (not personal workspace teams).
- [ ] Open this repo in another Claude Code session on a different machine — confirm `.mcp.json` ships, MCP loads, separate OAuth flow needed.
- [ ] Capture team/project IDs and add them to the placeholder line in CLAUDE.md as a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup guide for Linear integration, including authentication flow and workspace configuration instructions.

* **Chores**
  * Added configuration file for project-scoped Linear server integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->