### PR TITLE
Add compliance posture dashboard demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "collect-evidence": "node plugins/grc-engineer/scripts/collect-evidence.js",
     "record-automation-metrics": "node plugins/grc-engineer/scripts/record-automation-metrics.js",
     "monitor-continuous": "node plugins/grc-engineer/scripts/monitor-continuous.js",
+    "dashboard:compliance-posture": "node plugins/dashboards/compliance-posture/scripts/serve.js",
     "transform-risk": "node plugins/grc-engineer/scripts/transform-risk.js",
     "frameworks": "node plugins/grc-engineer/scripts/frameworks.js",
     "scaffold-framework": "node plugins/grc-engineer/scripts/scaffold-framework.js",

--- a/plugins/dashboards/compliance-posture/.claude-plugin/plugin.json
+++ b/plugins/dashboards/compliance-posture/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "compliance-posture-dashboard",
+  "description": "Localhost compliance posture dashboard for monitor-continuous JSON output. Reference implementation of the Dashboards category from RFC #38.",
+  "version": "0.1.0",
+  "author": {
+    "name": "GRC Engineering Club Contributors"
+  },
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT"
+}

--- a/plugins/dashboards/compliance-posture/README.md
+++ b/plugins/dashboards/compliance-posture/README.md
@@ -1,0 +1,54 @@
+# Compliance Posture Dashboard
+
+Localhost dashboard for the `/dashboard:` category proposed in
+[RFC #38](https://github.com/GRCEngClub/claude-grc-engineering/issues/38).
+
+This first pass intentionally avoids deployment infrastructure. It reads saved
+JSON output from `/grc-engineer:monitor-continuous`, serves a local web UI, and
+derives current posture, framework health, alerts, and run-over-run deltas
+outside Claude's context window.
+
+## Run It
+
+Generate one or more monitor runs:
+
+```bash
+node plugins/grc-engineer/scripts/monitor-continuous.js SOC2,NIST-800-53 \
+  --cache-dir=tests/fixtures/findings \
+  --no-exit-code \
+  --output=grc-data/dashboard/monitor-continuous/latest.json
+```
+
+Serve the dashboard:
+
+```bash
+npm run dashboard:compliance-posture -- \
+  --data=grc-data/dashboard/monitor-continuous \
+  --port=8787
+```
+
+Open `http://127.0.0.1:8787`.
+
+If you only want to see the UI shape before collecting real data:
+
+```bash
+npm run dashboard:compliance-posture -- --demo
+```
+
+## Data Contract
+
+The server accepts either a single JSON file or a directory tree containing
+JSON files. Each file can be one `monitor_continuous_run` document or an array
+of those documents.
+
+The dashboard uses:
+
+- `generated_at`, `run_id`, `schedule`, `frameworks`, and `sources`
+- `summary.overall_status`, `summary.overall_pass_rate`, and tier totals
+- `framework_results[]` with pass rates, evaluated controls, coverage, and
+  per-framework status
+- `alerts[]` for the operational queue
+- `artifacts.gap_report_dir` for traceability back to the report bundle
+
+Historical comparison is deliberately a dashboard concern. Claude generates the
+run manifest; the viewer compares saved manifests over time.

--- a/plugins/dashboards/compliance-posture/README.md
+++ b/plugins/dashboards/compliance-posture/README.md
@@ -32,7 +32,7 @@ Open `http://127.0.0.1:8787`.
 If you only want to see the UI shape before collecting real data:
 
 ```bash
-npm run dashboard:compliance-posture -- --demo
+npm run dashboard:compliance-posture -- --demo --port=8788
 ```
 
 ## Data Contract

--- a/plugins/dashboards/compliance-posture/commands/compliance-posture.md
+++ b/plugins/dashboards/compliance-posture/commands/compliance-posture.md
@@ -1,0 +1,47 @@
+---
+description: Serve a localhost compliance posture dashboard from monitor-continuous JSON
+---
+
+# Compliance Posture Dashboard
+
+Serves a local HTML dashboard from saved
+`/grc-engineer:monitor-continuous` JSON output.
+
+Implementation:
+[`scripts/serve.js`](../scripts/serve.js).
+
+## Usage
+
+```bash
+/dashboard:compliance-posture --data=<path> [--port=8787]
+```
+
+Local script form:
+
+```bash
+node plugins/dashboards/compliance-posture/scripts/serve.js \
+  --data=grc-data/dashboard/monitor-continuous \
+  --port=8787
+```
+
+## Options
+
+- `--data=<path>` - JSON file or directory tree to read. Repeat as
+  comma-separated paths.
+- `--host=<host>` - Bind host. Defaults to `127.0.0.1`.
+- `--port=<port>` - Bind port. Defaults to `8787`.
+- `--demo` - Serve built-in demo monitor runs and ignore local JSON.
+- `--help` - Show CLI help.
+
+## Monitor Output
+
+Generate dashboard input with:
+
+```bash
+node plugins/grc-engineer/scripts/monitor-continuous.js SOC2,NIST-800-53 \
+  --output=grc-data/dashboard/monitor-continuous/$(date +%Y%m%dT%H%M%S).json \
+  --no-exit-code
+```
+
+The dashboard reads the saved JSON manifests and computes latest state, trends,
+and deltas at view time. It does not require Claude to retain historical state.

--- a/plugins/dashboards/compliance-posture/public/app.js
+++ b/plugins/dashboards/compliance-posture/public/app.js
@@ -28,6 +28,10 @@ function percent(value) {
   return `${Math.round(Number(value) * 100)}%`;
 }
 
+function coverage(value) {
+  return value === null || value === undefined ? 'n/a' : `${value}%`;
+}
+
 function number(value) {
   return new Intl.NumberFormat().format(value || 0);
 }
@@ -52,7 +56,8 @@ function dateLabel(value) {
 }
 
 function statusClass(status) {
-  return `status-${status || 'no_data'}`;
+  const known = ['ok', 'no_data', 'warning', 'critical'];
+  return `status-${known.includes(status) ? status : 'no_data'}`;
 }
 
 function latestFrameworks() {
@@ -166,7 +171,7 @@ function renderOverall() {
     ['Tier 1 blockers', number(summary.tier1_blockers)],
     ['Report bundle', state.latest.artifacts?.gap_report_dir || 'not recorded']
   ].map(([label, value]) => `
-    <div class="breakdown-row"><span>${label}</span><strong>${value}</strong></div>
+    <div class="breakdown-row"><span>${label}</span><strong>${escapeHtml(value)}</strong></div>
   `).join('');
 }
 
@@ -276,12 +281,12 @@ function renderFrameworks() {
     return `
       <div class="framework-row">
         <div>
-          <div class="framework-title">${item.framework}</div>
-          <div class="framework-subtitle">${item.display_name || 'Monitor result'}</div>
+          <div class="framework-title">${escapeHtml(item.framework)}</div>
+          <div class="framework-subtitle">${escapeHtml(item.display_name || 'Monitor result')}</div>
         </div>
         <div>
           <div class="bar" title="${percent(item.pass_rate)} pass rate"><span style="--value: ${Math.round((item.pass_rate || 0) * 100)}"></span></div>
-          <div class="framework-subtitle">${deltaCopy} since previous run</div>
+          <div class="framework-subtitle">${escapeHtml(deltaCopy)} since previous run</div>
         </div>
         <div>
           <div class="cell-label">Pass rate</div>
@@ -289,9 +294,9 @@ function renderFrameworks() {
         </div>
         <div>
           <div class="cell-label">Coverage</div>
-          <div class="cell-value">${item.coverage_pct ?? 'n/a'}%</div>
+          <div class="cell-value">${coverage(item.coverage_pct)}</div>
         </div>
-        <span class="status-pill ${statusClass(item.status)}">${statusCopy[item.status] || item.status}</span>
+        <span class="status-pill ${statusClass(item.status)}">${escapeHtml(statusCopy[item.status] || item.status)}</span>
       </div>
     `;
   }).join('');
@@ -311,16 +316,16 @@ function renderAlerts() {
 
   const alertCards = alerts.map(alert => `
     <div class="alert-card">
-      <span class="status-pill ${statusClass(alert.severity)}">${alert.severity}</span>
-      <strong>${alert.framework || 'Run alert'}</strong>
-      <p>${alert.message}</p>
+      <span class="status-pill ${statusClass(alert.severity)}">${escapeHtml(alert.severity)}</span>
+      <strong>${escapeHtml(alert.framework || 'Run alert')}</strong>
+      <p>${escapeHtml(alert.message)}</p>
     </div>
   `);
 
   const deltaCards = deltas.map(item => `
     <div class="alert-card">
       <span class="status-pill ${item.delta >= 0 ? 'status-ok' : 'status-warning'}">${item.delta >= 0 ? 'improved' : 'changed'}</span>
-      <strong>${item.framework}</strong>
+      <strong>${escapeHtml(item.framework)}</strong>
       <p>${item.delta >= 0 ? '+' : ''}${Math.round(item.delta * 100)} percentage points since the previous saved run.</p>
     </div>
   `);
@@ -337,10 +342,10 @@ function renderAlerts() {
 function renderHistory() {
   $('#run-list').innerHTML = state.runs.slice(-8).reverse().map(run => `
     <div class="run-item">
-      <div><strong>${run.run_id || 'unknown run'}</strong>${dateLabel(run.generated_at)}</div>
+      <div><strong>${escapeHtml(run.run_id || 'unknown run')}</strong>${dateLabel(run.generated_at)}</div>
       <div><strong>${percent(run.summary?.overall_pass_rate)}</strong>pass rate</div>
-      <div><span class="status-pill ${statusClass(run.summary?.overall_status)}">${run.summary?.overall_status || 'no_data'}</span></div>
-      <div>${run.source_file || 'unknown source'}</div>
+      <div><span class="status-pill ${statusClass(run.summary?.overall_status)}">${escapeHtml(run.summary?.overall_status || 'no_data')}</span></div>
+      <div>${escapeHtml(run.source_file || 'unknown source')}</div>
     </div>
   `).join('');
 }

--- a/plugins/dashboards/compliance-posture/public/app.js
+++ b/plugins/dashboards/compliance-posture/public/app.js
@@ -1,0 +1,352 @@
+const $ = (selector) => document.querySelector(selector);
+
+const statusRank = { ok: 0, no_data: 1, warning: 1, critical: 2 };
+const statusCopy = {
+  ok: 'On track',
+  warning: 'Watch',
+  critical: 'Critical',
+  no_data: 'No data'
+};
+
+let state = { runs: [], latest: null, previous: null, meta: null };
+
+async function refresh() {
+  const response = await fetch('/api/runs', { cache: 'no-store' });
+  const payload = await response.json();
+  const runs = (payload.runs || []).filter(run => run.generated_at);
+  state = {
+    runs,
+    latest: runs.at(-1) || null,
+    previous: runs.at(-2) || null,
+    meta: payload
+  };
+  render();
+}
+
+function percent(value) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) return 'n/a';
+  return `${Math.round(Number(value) * 100)}%`;
+}
+
+function number(value) {
+  return new Intl.NumberFormat().format(value || 0);
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function dateLabel(value) {
+  if (!value) return 'Unknown';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(new Date(value));
+}
+
+function statusClass(status) {
+  return `status-${status || 'no_data'}`;
+}
+
+function latestFrameworks() {
+  return state.latest?.framework_results || [];
+}
+
+function frameworkPrevious(framework) {
+  return (state.previous?.framework_results || []).find(item => item.framework === framework);
+}
+
+function trendDelta(current, previous) {
+  if (current === null || current === undefined || previous === null || previous === undefined) return null;
+  return current - previous;
+}
+
+function render() {
+  renderChrome();
+  if (!state.latest) {
+    $('#empty-state').classList.remove('hidden');
+    $('#posture').innerHTML = '';
+    $('#trend-chart').innerHTML = '';
+    $('#chart-legend').innerHTML = '';
+    $('#framework-table').innerHTML = '';
+    $('#alert-list').innerHTML = '';
+    $('#run-list').innerHTML = '';
+    return;
+  }
+
+  $('#empty-state').classList.add('hidden');
+  renderMetrics();
+  renderTrend();
+  renderOverall();
+  renderFrameworks();
+  renderAlerts();
+  renderHistory();
+}
+
+function renderChrome() {
+  const paths = state.meta?.data_paths?.join(', ') || 'No data path reported';
+  $('#data-source').textContent = paths;
+
+  if (!state.latest) {
+    $('#run-subtitle').textContent = 'No saved monitor-continuous JSON found.';
+    return;
+  }
+
+  const frameworks = latestFrameworks().map(f => f.framework).join(', ');
+  $('#run-subtitle').textContent = `${dateLabel(state.latest.generated_at)} - ${frameworks || 'no frameworks'} - ${state.runs.length} saved run${state.runs.length === 1 ? '' : 's'}`;
+}
+
+function renderMetrics() {
+  const latest = state.latest;
+  const currentRate = latest.summary?.overall_pass_rate;
+  const previousRate = state.previous?.summary?.overall_pass_rate;
+  const delta = trendDelta(currentRate, previousRate);
+  const frameworkCount = latestFrameworks().length;
+  const criticalCount = latestFrameworks().filter(f => f.status === 'critical').length;
+
+  const cards = [
+    {
+      label: 'Overall pass rate',
+      value: percent(currentRate),
+      caption: delta === null ? 'First saved run' : `${delta >= 0 ? '+' : ''}${Math.round(delta * 100)} pts since previous`,
+      icon: 'OK'
+    },
+    {
+      label: 'Frameworks in scope',
+      value: number(frameworkCount),
+      caption: `${criticalCount} critical, ${latestFrameworks().filter(f => f.status === 'warning').length} warning`,
+      icon: 'FW'
+    },
+    {
+      label: 'Tier 1 blockers',
+      value: number(latest.summary?.tier1_blockers),
+      caption: `${number(latest.summary?.tier2_findings)} tier 2 findings`,
+      icon: 'T1'
+    },
+    {
+      label: 'Open alerts',
+      value: number(latest.alerts?.length),
+      caption: `${number(latest.sources?.length)} evidence sources`,
+      icon: 'AL'
+    }
+  ];
+
+  $('#posture').innerHTML = cards.map(card => `
+    <article class="metric-card">
+      <div class="metric-top">
+        <div>
+          <p class="eyebrow">${card.label}</p>
+          <div class="metric-value">${card.value}</div>
+        </div>
+        <div class="metric-icon">${card.icon}</div>
+      </div>
+      <div class="metric-caption">${card.caption}</div>
+    </article>
+  `).join('');
+}
+
+function renderOverall() {
+  const status = state.latest.summary?.overall_status || 'no_data';
+  const rate = state.latest.summary?.overall_pass_rate || 0;
+  const summary = state.latest.summary || {};
+  $('#overall-status').textContent = statusCopy[status] || status;
+  $('#overall-status').className = `status-pill ${statusClass(status)}`;
+  $('#overall-donut').style.setProperty('--value', Math.round(rate * 100));
+  $('#overall-rate').textContent = percent(rate);
+  $('#overall-breakdown').innerHTML = [
+    ['Passing checks', number(summary.passes)],
+    ['Inconclusive', number(summary.inconclusive)],
+    ['Tier 1 blockers', number(summary.tier1_blockers)],
+    ['Report bundle', state.latest.artifacts?.gap_report_dir || 'not recorded']
+  ].map(([label, value]) => `
+    <div class="breakdown-row"><span>${label}</span><strong>${value}</strong></div>
+  `).join('');
+}
+
+function renderTrend() {
+  const runs = state.runs.slice(-14);
+  $('#trend-caption').textContent = `${runs.length} run${runs.length === 1 ? '' : 's'}`;
+  $('#chart-legend').innerHTML = '<span>Overall pass rate</span><span>Warning threshold</span>';
+
+  if (runs.length < 2) {
+    $('#trend-chart').innerHTML = '<div class="empty-state"><p class="muted">Save at least two monitor runs to see a trend.</p></div>';
+    return;
+  }
+
+  const width = 860;
+  const height = 300;
+  const pad = 34;
+  const values = runs.map(run => run.summary?.overall_pass_rate ?? 0);
+  const x = (index) => pad + (index / Math.max(1, runs.length - 1)) * (width - pad * 2);
+  const y = (value) => pad + (1 - value) * (height - pad * 2);
+  const points = values.map((value, index) => [x(index), y(value)]);
+  const path = points.map(([px, py], index) => `${index === 0 ? 'M' : 'L'} ${px} ${py}`).join(' ');
+  const area = `${path} L ${x(points.length - 1)} ${height - pad} L ${x(0)} ${height - pad} Z`;
+  const warn = state.latest.thresholds?.warning ?? 0.9;
+
+  $('#trend-chart').innerHTML = `
+    <svg viewBox="0 0 ${width} ${height}" role="img" aria-label="Overall pass-rate trend">
+      <defs>
+        <linearGradient id="areaGradient" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stop-color="#356f64" stop-opacity="0.22"></stop>
+          <stop offset="100%" stop-color="#356f64" stop-opacity="0.02"></stop>
+        </linearGradient>
+      </defs>
+      ${[0.25, 0.5, 0.75, 1].map(v => `<line class="grid-line" x1="${pad}" x2="${width - pad}" y1="${y(v)}" y2="${y(v)}"></line>`).join('')}
+      <line class="threshold-line" x1="${pad}" x2="${width - pad}" y1="${y(warn)}" y2="${y(warn)}"></line>
+      <path class="trend-area" d="${area}"></path>
+      <path class="trend-line" d="${path}"></path>
+      ${points.map(([px, py], index) => {
+        const run = runs[index];
+        const summary = run.summary || {};
+        const tooltip = [
+          dateLabel(run.generated_at),
+          `Run: ${run.run_id || 'unknown'}`,
+          `Pass rate: ${percent(summary.overall_pass_rate)}`,
+          `Status: ${summary.overall_status || 'no_data'}`,
+          `Tier 1 blockers: ${number(summary.tier1_blockers)}`,
+          `Alerts: ${number(run.alerts?.length)}`
+        ].join('|');
+        return `
+          <g>
+            <circle
+              class="point-hit"
+              cx="${px}"
+              cy="${py}"
+              r="16"
+              tabindex="0"
+              data-x="${(px / width) * 100}"
+              data-y="${(py / height) * 100}"
+              data-tooltip="${escapeHtml(tooltip)}"></circle>
+            <circle class="point" cx="${px}" cy="${py}" r="${index === points.length - 1 ? 6 : 4}"></circle>
+          </g>
+        `;
+      }).join('')}
+      <text x="${pad}" y="${height - 4}" fill="#657077" font-size="13">${dateLabel(runs[0].generated_at)}</text>
+      <text x="${width - pad}" y="${height - 4}" fill="#657077" font-size="13" text-anchor="end">${dateLabel(runs.at(-1).generated_at)}</text>
+      <text x="${width - pad}" y="${y(warn) - 8}" fill="#8a9296" font-size="12" text-anchor="end">warning ${percent(warn)}</text>
+    </svg>
+    <div id="trend-tooltip" class="trend-tooltip hidden" role="status"></div>
+  `;
+  bindTrendTooltip();
+}
+
+function bindTrendTooltip() {
+  const tooltip = $('#trend-tooltip');
+  if (!tooltip) return;
+
+  const show = (target) => {
+    const rows = (target.dataset.tooltip || '').split('|');
+    tooltip.innerHTML = `
+      <strong>${escapeHtml(rows[0] || 'Monitor run')}</strong>
+      ${rows.slice(1).map(row => `<span>${escapeHtml(row)}</span>`).join('')}
+    `;
+    tooltip.style.left = `${target.dataset.x}%`;
+    tooltip.style.top = `${target.dataset.y}%`;
+    tooltip.classList.remove('hidden');
+  };
+
+  const hide = () => tooltip.classList.add('hidden');
+
+  document.querySelectorAll('.point-hit').forEach(point => {
+    point.addEventListener('mouseenter', () => show(point));
+    point.addEventListener('focus', () => show(point));
+    point.addEventListener('mouseleave', hide);
+    point.addEventListener('blur', hide);
+  });
+}
+
+function renderFrameworks() {
+  const frameworks = latestFrameworks()
+    .slice()
+    .sort((a, b) => (statusRank[b.status] ?? 0) - (statusRank[a.status] ?? 0) || (a.pass_rate ?? 0) - (b.pass_rate ?? 0));
+
+  $('#framework-count').textContent = `${frameworks.length} framework${frameworks.length === 1 ? '' : 's'}`;
+  $('#framework-table').innerHTML = frameworks.map(item => {
+    const previous = frameworkPrevious(item.framework);
+    const delta = trendDelta(item.pass_rate, previous?.pass_rate);
+    const deltaCopy = delta === null ? 'new' : `${delta >= 0 ? '+' : ''}${Math.round(delta * 100)} pts`;
+    return `
+      <div class="framework-row">
+        <div>
+          <div class="framework-title">${item.framework}</div>
+          <div class="framework-subtitle">${item.display_name || 'Monitor result'}</div>
+        </div>
+        <div>
+          <div class="bar" title="${percent(item.pass_rate)} pass rate"><span style="--value: ${Math.round((item.pass_rate || 0) * 100)}"></span></div>
+          <div class="framework-subtitle">${deltaCopy} since previous run</div>
+        </div>
+        <div>
+          <div class="cell-label">Pass rate</div>
+          <div class="cell-value">${percent(item.pass_rate)}</div>
+        </div>
+        <div>
+          <div class="cell-label">Coverage</div>
+          <div class="cell-value">${item.coverage_pct ?? 'n/a'}%</div>
+        </div>
+        <span class="status-pill ${statusClass(item.status)}">${statusCopy[item.status] || item.status}</span>
+      </div>
+    `;
+  }).join('');
+}
+
+function renderAlerts() {
+  const alerts = [...(state.latest.alerts || [])];
+  const deltas = latestFrameworks()
+    .map(item => {
+      const previous = frameworkPrevious(item.framework);
+      const delta = trendDelta(item.pass_rate, previous?.pass_rate);
+      return { framework: item.framework, delta };
+    })
+    .filter(item => item.delta !== null)
+    .sort((a, b) => a.delta - b.delta)
+    .slice(0, 3);
+
+  const alertCards = alerts.map(alert => `
+    <div class="alert-card">
+      <span class="status-pill ${statusClass(alert.severity)}">${alert.severity}</span>
+      <strong>${alert.framework || 'Run alert'}</strong>
+      <p>${alert.message}</p>
+    </div>
+  `);
+
+  const deltaCards = deltas.map(item => `
+    <div class="alert-card">
+      <span class="status-pill ${item.delta >= 0 ? 'status-ok' : 'status-warning'}">${item.delta >= 0 ? 'improved' : 'changed'}</span>
+      <strong>${item.framework}</strong>
+      <p>${item.delta >= 0 ? '+' : ''}${Math.round(item.delta * 100)} percentage points since the previous saved run.</p>
+    </div>
+  `);
+
+  $('#alert-list').innerHTML = [...alertCards, ...deltaCards].join('') || `
+    <div class="alert-card">
+      <span class="status-pill status-ok">clear</span>
+      <strong>No open alerts</strong>
+      <p>All frameworks are at or above their warning thresholds in the latest run.</p>
+    </div>
+  `;
+}
+
+function renderHistory() {
+  $('#run-list').innerHTML = state.runs.slice(-8).reverse().map(run => `
+    <div class="run-item">
+      <div><strong>${run.run_id || 'unknown run'}</strong>${dateLabel(run.generated_at)}</div>
+      <div><strong>${percent(run.summary?.overall_pass_rate)}</strong>pass rate</div>
+      <div><span class="status-pill ${statusClass(run.summary?.overall_status)}">${run.summary?.overall_status || 'no_data'}</span></div>
+      <div>${run.source_file || 'unknown source'}</div>
+    </div>
+  `).join('');
+}
+
+$('#refresh').addEventListener('click', refresh);
+refresh().catch(err => {
+  $('#run-subtitle').textContent = `Dashboard failed to load: ${err.message}`;
+  $('#empty-state').classList.remove('hidden');
+});

--- a/plugins/dashboards/compliance-posture/public/index.html
+++ b/plugins/dashboards/compliance-posture/public/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Compliance Posture Dashboard</title>
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <div class="shell">
+      <aside class="sidebar" aria-label="Dashboard navigation">
+        <div class="brand">
+          <div class="brand-mark">G</div>
+          <div>
+            <p class="eyebrow">GRC Engineering</p>
+            <h1>Control Room</h1>
+          </div>
+        </div>
+
+        <nav class="nav-list">
+          <a class="active" href="#posture">Posture</a>
+          <a href="#frameworks">Frameworks</a>
+          <a href="#alerts">Alert queue</a>
+          <a href="#history">History</a>
+        </nav>
+
+        <div class="sidebar-card">
+          <p class="eyebrow">Data source</p>
+          <p id="data-source">Loading...</p>
+        </div>
+      </aside>
+
+      <main class="main">
+        <header class="topbar">
+          <div>
+            <h2>Compliance posture</h2>
+            <p id="run-subtitle" class="muted">Reading monitor-continuous JSON...</p>
+          </div>
+          <div class="top-actions">
+            <button id="refresh" class="ghost-button" type="button">Refresh</button>
+            <a class="primary-button" href="/api/runs">View JSON</a>
+          </div>
+        </header>
+
+        <section id="empty-state" class="empty-state hidden">
+          <p class="eyebrow">No monitor runs found</p>
+          <h3>Point the dashboard at saved `monitor-continuous` JSON.</h3>
+          <pre><code>node plugins/grc-engineer/scripts/monitor-continuous.js SOC2,NIST-800-53 \
+  --output=grc-data/dashboard/monitor-continuous/latest.json \
+  --no-exit-code</code></pre>
+        </section>
+
+        <section id="posture" class="metric-grid" aria-label="Posture summary"></section>
+
+        <section class="dashboard-grid">
+          <article class="panel span-2">
+            <div class="panel-heading">
+              <div>
+                <p class="eyebrow">Historical signal</p>
+                <h3>Compliance trend</h3>
+              </div>
+              <span id="trend-caption" class="pill">Awaiting data</span>
+            </div>
+            <div id="trend-chart" class="chart">
+              <div id="trend-tooltip" class="trend-tooltip hidden" role="status"></div>
+            </div>
+            <div id="chart-legend" class="legend"></div>
+          </article>
+
+          <article class="panel" id="overall-panel">
+            <div class="panel-heading">
+              <div>
+                <p class="eyebrow">Current run</p>
+                <h3>Overall status</h3>
+              </div>
+              <span id="overall-status" class="status-pill">Loading</span>
+            </div>
+            <div class="donut-wrap">
+              <div id="overall-donut" class="donut" style="--value: 0">
+                <span id="overall-rate">0%</span>
+                <small>pass rate</small>
+              </div>
+            </div>
+            <div id="overall-breakdown" class="breakdown"></div>
+          </article>
+        </section>
+
+        <section class="dashboard-grid lower">
+          <article id="frameworks" class="panel span-2">
+            <div class="panel-heading">
+              <div>
+                <p class="eyebrow">Framework-by-framework</p>
+                <h3>Control health</h3>
+              </div>
+              <span id="framework-count" class="pill">0 frameworks</span>
+            </div>
+            <div id="framework-table" class="framework-table"></div>
+          </article>
+
+          <article id="alerts" class="panel">
+            <div class="panel-heading">
+              <div>
+                <p class="eyebrow">Operational queue</p>
+                <h3>Alerts and deltas</h3>
+              </div>
+            </div>
+            <div id="alert-list" class="alert-list"></div>
+          </article>
+        </section>
+
+        <section id="history" class="panel run-history">
+          <div class="panel-heading">
+            <div>
+              <p class="eyebrow">Saved manifests</p>
+              <h3>Recent monitor runs</h3>
+            </div>
+          </div>
+          <div id="run-list" class="run-list"></div>
+        </section>
+      </main>
+    </div>
+
+    <script type="module" src="/app.js"></script>
+  </body>
+</html>

--- a/plugins/dashboards/compliance-posture/public/index.html
+++ b/plugins/dashboards/compliance-posture/public/index.html
@@ -61,9 +61,7 @@
               </div>
               <span id="trend-caption" class="pill">Awaiting data</span>
             </div>
-            <div id="trend-chart" class="chart">
-              <div id="trend-tooltip" class="trend-tooltip hidden" role="status"></div>
-            </div>
+            <div id="trend-chart" class="chart"></div>
             <div id="chart-legend" class="legend"></div>
           </article>
 

--- a/plugins/dashboards/compliance-posture/public/styles.css
+++ b/plugins/dashboards/compliance-posture/public/styles.css
@@ -1,0 +1,633 @@
+:root {
+  --bg: #dfe6e7;
+  --paper: #fbfaf7;
+  --paper-strong: #ffffff;
+  --ink: #1b2429;
+  --muted: #657077;
+  --line: #d9dfdf;
+  --line-strong: #c6cdce;
+  --green: #1d7a55;
+  --green-soft: #e1f3e8;
+  --amber: #d98b24;
+  --amber-soft: #fff0d8;
+  --red: #c94e57;
+  --red-soft: #ffe3e7;
+  --blue: #2f75bd;
+  --blue-soft: #dfeeff;
+  --teal: #356f64;
+  --shadow: 0 24px 70px rgb(28 42 46 / 16%);
+  --radius-lg: 22px;
+  --radius-md: 14px;
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 18% 12%, rgb(255 255 255 / 70%), transparent 28rem),
+    linear-gradient(135deg, #d8e1e1 0%, #e6eceb 46%, #d4dedf 100%);
+  color: var(--ink);
+  font-family: Aptos, "Avenir Next", "Trebuchet MS", sans-serif;
+}
+
+a {
+  color: inherit;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+.shell {
+  display: grid;
+  grid-template-columns: 290px minmax(0, 1fr);
+  width: calc(100vw - 40px);
+  min-height: calc(100vh - 40px);
+  margin: 20px auto;
+  border: 1px solid rgb(119 132 137 / 42%);
+  border-radius: 26px;
+  background: var(--paper);
+  box-shadow: var(--shadow);
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 22px 16px;
+  border-right: 1px solid var(--line);
+  background: linear-gradient(180deg, #f2f5f4 0%, #edf1f1 100%);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 6px;
+}
+
+.brand-mark {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border: 2px solid #111c24;
+  border-radius: 12px;
+  background: #eaf3ff;
+  font-weight: 800;
+}
+
+.brand h1,
+.topbar h2,
+.panel h3,
+.empty-state h3 {
+  margin: 0;
+  letter-spacing: -0.04em;
+}
+
+.brand h1 {
+  font-size: 18px;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: #7a8388;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.new-run,
+.ghost-button,
+.primary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  border-radius: 10px;
+  font: inherit;
+  font-weight: 800;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.new-run {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  background: #ffffff;
+  box-shadow: 0 4px 12px rgb(20 30 35 / 10%);
+}
+
+.nav-list {
+  display: grid;
+  gap: 7px;
+}
+
+.nav-list a {
+  padding: 12px 14px;
+  border-radius: 11px;
+  color: #576167;
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.nav-list a.active,
+.nav-list a:hover {
+  background: #dfe5e6;
+  color: var(--ink);
+}
+
+.sidebar-card {
+  margin-top: auto;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgb(255 255 255 / 58%);
+}
+
+.sidebar-card p:last-child {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.main {
+  padding: 28px 30px 48px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 28px;
+}
+
+.topbar h2 {
+  font-size: clamp(30px, 4vw, 46px);
+}
+
+.muted {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+
+.top-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.ghost-button {
+  border: 1px solid var(--line-strong);
+  background: #fff;
+  color: var(--ink);
+  padding: 0 18px;
+}
+
+.primary-button {
+  border: 1px solid #12613f;
+  background: linear-gradient(180deg, #238f5d, #157245);
+  color: white;
+  padding: 0 20px;
+  box-shadow: 0 8px 20px rgb(21 114 69 / 24%);
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+  margin-bottom: 24px;
+}
+
+.metric-card,
+.panel,
+.empty-state {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: rgb(255 255 255 / 78%);
+  box-shadow: 0 8px 28px rgb(25 35 40 / 6%);
+}
+
+.metric-card {
+  min-height: 138px;
+  padding: 22px;
+}
+
+.metric-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.metric-icon {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 50%;
+  background: #fff;
+}
+
+.metric-value {
+  font-size: 30px;
+  font-weight: 900;
+  letter-spacing: -0.05em;
+}
+
+.metric-caption {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(360px, 1fr);
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.dashboard-grid.lower {
+  align-items: start;
+}
+
+.span-2 {
+  min-width: 0;
+}
+
+.panel {
+  padding: 22px;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.panel h3 {
+  font-size: 24px;
+}
+
+.pill,
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: #f0f3f3;
+  color: #58636a;
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.status-ok {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.status-warning,
+.status-no_data {
+  background: var(--amber-soft);
+  color: #9d5f12;
+}
+
+.status-critical {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.chart {
+  position: relative;
+  height: 360px;
+  padding: 14px 8px 0;
+}
+
+.chart svg {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.grid-line {
+  stroke: #dfe4e4;
+  stroke-dasharray: 6 7;
+}
+
+.trend-line {
+  fill: none;
+  stroke: var(--teal);
+  stroke-linecap: round;
+  stroke-width: 4;
+}
+
+.trend-area {
+  fill: url(#areaGradient);
+}
+
+.threshold-line {
+  stroke: #b6bdbe;
+  stroke-dasharray: 7 7;
+  stroke-width: 2;
+}
+
+.point {
+  fill: #fff;
+  stroke: var(--teal);
+  stroke-width: 3;
+}
+
+.point-hit {
+  fill: transparent;
+  cursor: crosshair;
+}
+
+.point-hit:hover + .point,
+.point-hit:focus + .point {
+  fill: var(--teal);
+  stroke-width: 4;
+}
+
+.trend-tooltip {
+  position: absolute;
+  z-index: 3;
+  min-width: 210px;
+  padding: 12px 13px;
+  border: 1px solid var(--line-strong);
+  border-radius: 14px;
+  background: rgb(255 255 255 / 95%);
+  box-shadow: 0 16px 38px rgb(25 35 40 / 16%);
+  color: var(--ink);
+  font-size: 13px;
+  line-height: 1.4;
+  pointer-events: none;
+  transform: translate(-50%, calc(-100% - 14px));
+}
+
+.trend-tooltip strong {
+  display: block;
+  margin-bottom: 5px;
+}
+
+.trend-tooltip span {
+  display: block;
+  color: var(--muted);
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.legend span::before {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 7px;
+  border-radius: 50%;
+  background: var(--teal);
+  content: "";
+}
+
+.donut-wrap {
+  display: grid;
+  place-items: center;
+  padding: 26px 0 16px;
+}
+
+.donut {
+  display: grid;
+  width: 236px;
+  height: 236px;
+  place-items: center;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at center, white 0 58%, transparent 59%),
+    conic-gradient(var(--teal) calc(var(--value) * 1%), #edf0ef 0);
+}
+
+.donut span {
+  margin-top: 48px;
+  font-size: 42px;
+  font-weight: 950;
+  letter-spacing: -0.06em;
+}
+
+.donut small {
+  margin-top: -56px;
+  color: var(--muted);
+  font-weight: 750;
+}
+
+.breakdown {
+  display: grid;
+  gap: 9px;
+}
+
+.breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.breakdown-row strong {
+  color: var(--ink);
+}
+
+.framework-table {
+  display: grid;
+  gap: 12px;
+}
+
+.framework-row {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 110px 110px 120px;
+  align-items: center;
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid #e2e6e6;
+  border-radius: 16px;
+  background: #fff;
+}
+
+.framework-title {
+  font-weight: 900;
+}
+
+.framework-subtitle {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.bar {
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #edf0ef;
+}
+
+.bar span {
+  display: block;
+  width: calc(var(--value) * 1%);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #2f75bd, #2d8068);
+}
+
+.cell-label {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.cell-value {
+  margin-top: 4px;
+  font-weight: 900;
+}
+
+.alert-list {
+  display: grid;
+  gap: 12px;
+}
+
+.alert-card {
+  padding: 14px;
+  border-radius: 16px;
+  background: #fff;
+  border: 1px solid #e2e6e6;
+}
+
+.alert-card strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.alert-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.run-history {
+  margin-bottom: 10px;
+}
+
+.run-list {
+  display: grid;
+  gap: 10px;
+}
+
+.run-item {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) 130px 120px 1.8fr;
+  gap: 14px;
+  padding: 12px 14px;
+  border: 1px solid #e2e6e6;
+  border-radius: 14px;
+  background: #fff;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.run-item strong {
+  display: block;
+  color: var(--ink);
+  font-size: 14px;
+}
+
+.empty-state {
+  margin-bottom: 24px;
+  padding: 26px;
+}
+
+.empty-state h3 {
+  font-size: 26px;
+}
+
+pre {
+  overflow: auto;
+  padding: 16px;
+  border-radius: 14px;
+  background: #162126;
+  color: #edf6ef;
+  font-size: 13px;
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 1180px) {
+  .shell {
+    grid-template-columns: 1fr;
+    width: min(100vw - 24px, 980px);
+    min-height: calc(100vh - 24px);
+    margin: 12px auto;
+  }
+
+  .sidebar {
+    display: none;
+  }
+
+  .metric-grid,
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar,
+  .framework-row,
+  .run-item {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    display: grid;
+  }
+
+  .top-actions {
+    padding-top: 0;
+  }
+}
+
+@media (max-width: 680px) {
+  .main {
+    padding: 20px 16px 32px;
+  }
+
+  .top-actions {
+    display: grid;
+  }
+
+  .metric-grid {
+    gap: 12px;
+  }
+
+  .framework-row,
+  .run-item {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .chart {
+    height: 260px;
+  }
+}

--- a/plugins/dashboards/compliance-posture/scripts/serve.js
+++ b/plugins/dashboards/compliance-posture/scripts/serve.js
@@ -12,6 +12,7 @@ const PUBLIC_DIR = path.join(PLUGIN_ROOT, 'public');
 const REPO_ROOT = path.resolve(PLUGIN_ROOT, '../../..');
 
 const DEFAULT_DATA_PATH = path.join(REPO_ROOT, 'grc-data/dashboard/monitor-continuous');
+const MAX_SCAN_DEPTH = 8;
 const MIME_TYPES = {
   '.html': 'text/html; charset=utf-8',
   '.css': 'text/css; charset=utf-8',
@@ -76,20 +77,25 @@ function parseArgs(argv) {
   return out;
 }
 
-async function listJsonFiles(inputPath) {
+async function listJsonFiles(inputPath, depth = 0, seen = new Set()) {
   const files = [];
-  const stat = await fs.stat(inputPath);
+  const realPath = await fs.realpath(inputPath);
+  if (seen.has(realPath) || depth > MAX_SCAN_DEPTH) return files;
+  seen.add(realPath);
+
+  const stat = await fs.lstat(realPath);
+  if (stat.isSymbolicLink()) return files;
   if (stat.isFile()) {
-    if (inputPath.endsWith('.json')) files.push(inputPath);
+    if (realPath.endsWith('.json')) files.push(realPath);
     return files;
   }
   if (!stat.isDirectory()) return files;
 
-  const entries = await fs.readdir(inputPath, { withFileTypes: true });
+  const entries = await fs.readdir(realPath, { withFileTypes: true });
   for (const entry of entries) {
-    const full = path.join(inputPath, entry.name);
+    const full = path.join(realPath, entry.name);
     if (entry.isDirectory()) {
-      files.push(...await listJsonFiles(full));
+      files.push(...await listJsonFiles(full, depth + 1, seen));
     } else if (entry.isFile() && entry.name.endsWith('.json')) {
       files.push(full);
     }
@@ -217,6 +223,7 @@ function demoRuns() {
 }
 
 function sendJson(res, status, payload) {
+  if (res.writableEnded) return;
   res.writeHead(status, {
     'content-type': MIME_TYPES['.json'],
     'cache-control': 'no-store'
@@ -228,13 +235,15 @@ async function sendStatic(req, res) {
   const url = new URL(req.url, 'http://localhost');
   const requested = url.pathname === '/' ? '/index.html' : decodeURIComponent(url.pathname);
   const full = path.resolve(PUBLIC_DIR, `.${requested}`);
-  if (!full.startsWith(PUBLIC_DIR)) {
+  if (full !== PUBLIC_DIR && !full.startsWith(`${PUBLIC_DIR}${path.sep}`)) {
+    if (res.writableEnded) return;
     res.writeHead(403);
     res.end('Forbidden');
     return;
   }
   try {
     const body = await fs.readFile(full);
+    if (res.writableEnded) return;
     res.writeHead(200, {
       'content-type': MIME_TYPES[path.extname(full)] || 'application/octet-stream',
       'cache-control': 'no-store'
@@ -242,6 +251,7 @@ async function sendStatic(req, res) {
     res.end(body);
   } catch (err) {
     if (err.code === 'ENOENT') {
+      if (res.writableEnded) return;
       res.writeHead(404);
       res.end('Not found');
       return;
@@ -265,6 +275,12 @@ async function main() {
   }
 
   const server = http.createServer(async (req, res) => {
+    const timeout = setTimeout(() => {
+      if (!res.writableEnded) {
+        sendJson(res, 504, { error: 'Request timeout' });
+      }
+    }, 30000);
+
     try {
       if (req.url.startsWith('/api/runs')) {
         sendJson(res, 200, await loadRuns(opts.dataPaths, opts.demo));
@@ -272,7 +288,9 @@ async function main() {
       }
       await sendStatic(req, res);
     } catch (err) {
-      sendJson(res, 500, { error: err.message });
+      if (!res.writableEnded) sendJson(res, 500, { error: err.message });
+    } finally {
+      clearTimeout(timeout);
     }
   });
 

--- a/plugins/dashboards/compliance-posture/scripts/serve.js
+++ b/plugins/dashboards/compliance-posture/scripts/serve.js
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PLUGIN_ROOT = path.resolve(__dirname, '..');
+const PUBLIC_DIR = path.join(PLUGIN_ROOT, 'public');
+const REPO_ROOT = path.resolve(PLUGIN_ROOT, '../../..');
+
+const DEFAULT_DATA_PATH = path.join(REPO_ROOT, 'grc-data/dashboard/monitor-continuous');
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml; charset=utf-8'
+};
+
+function usage() {
+  return `Usage:
+  node plugins/dashboards/compliance-posture/scripts/serve.js [options]
+
+Options:
+  --data=<path[,path]>   Monitor JSON file or directory (default: grc-data/dashboard/monitor-continuous)
+  --host=<host>          Bind host (default: 127.0.0.1)
+  --port=<port>          Bind port (default: 8787)
+  --demo                 Serve built-in demo runs and ignore local JSON
+  --help                 Show this help
+`;
+}
+
+function parseArgs(argv) {
+  const out = {
+    dataPaths: [DEFAULT_DATA_PATH],
+    host: '127.0.0.1',
+    port: 8787,
+    demo: false,
+    help: false
+  };
+
+  for (const token of argv) {
+    if (!token.startsWith('--')) {
+      out.dataPaths = [path.resolve(token)];
+      continue;
+    }
+    const [rawKey, rawValue] = token.slice(2).split('=');
+    const value = rawValue ?? true;
+    switch (rawKey) {
+      case 'data':
+        out.dataPaths = String(value).split(',').map(p => path.resolve(p.trim())).filter(Boolean);
+        break;
+      case 'host':
+        out.host = String(value);
+        break;
+      case 'port':
+        out.port = Number(value);
+        if (!Number.isInteger(out.port) || out.port <= 0 || out.port > 65535) {
+          throw new Error(`--port must be a valid TCP port (got ${value})`);
+        }
+        break;
+      case 'demo':
+        out.demo = true;
+        break;
+      case 'help':
+      case 'h':
+        out.help = true;
+        break;
+      default:
+        throw new Error(`Unknown flag: --${rawKey}`);
+    }
+  }
+  return out;
+}
+
+async function listJsonFiles(inputPath) {
+  const files = [];
+  const stat = await fs.stat(inputPath);
+  if (stat.isFile()) {
+    if (inputPath.endsWith('.json')) files.push(inputPath);
+    return files;
+  }
+  if (!stat.isDirectory()) return files;
+
+  const entries = await fs.readdir(inputPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(inputPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listJsonFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function asMonitorRuns(parsed, file) {
+  const docs = Array.isArray(parsed) ? parsed : [parsed];
+  return docs
+    .filter(doc => doc && typeof doc === 'object')
+    .filter(doc => doc.kind === 'monitor_continuous_run' || (doc.summary && Array.isArray(doc.framework_results)))
+    .map(doc => ({
+      ...doc,
+      source_file: path.relative(REPO_ROOT, file)
+    }));
+}
+
+async function loadRuns(dataPaths, demo) {
+  if (demo) {
+    return {
+      loaded_at: new Date().toISOString(),
+      data_paths: ['demo-data'],
+      files: [],
+      errors: [],
+      runs: demoRuns()
+    };
+  }
+
+  const runs = [];
+  const errors = [];
+  const files = [];
+
+  for (const dataPath of dataPaths) {
+    try {
+      files.push(...await listJsonFiles(dataPath));
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        errors.push({ path: path.relative(REPO_ROOT, dataPath), message: 'path does not exist' });
+        continue;
+      }
+      errors.push({ path: path.relative(REPO_ROOT, dataPath), message: err.message });
+    }
+  }
+
+  for (const file of files) {
+    try {
+      const parsed = JSON.parse(await fs.readFile(file, 'utf8'));
+      runs.push(...asMonitorRuns(parsed, file));
+    } catch (err) {
+      errors.push({ path: path.relative(REPO_ROOT, file), message: err.message });
+    }
+  }
+
+  runs.sort((a, b) => new Date(a.generated_at || 0) - new Date(b.generated_at || 0));
+  return {
+    loaded_at: new Date().toISOString(),
+    data_paths: dataPaths.map(p => path.relative(REPO_ROOT, p) || '.'),
+    files: files.map(f => path.relative(REPO_ROOT, f)),
+    errors,
+    runs
+  };
+}
+
+function demoRuns() {
+  const base = Date.now();
+  const frameworks = ['SOC2', 'NIST-800-53', 'PCI-DSS'];
+  return [0, 1, 2, 3, 4].map(i => {
+    const rates = [0.74 + i * 0.035, 0.66 + i * 0.025, 0.82 - i * 0.01];
+    const generated = new Date(base - (4 - i) * 86400000).toISOString();
+    const frameworkResults = frameworks.map((framework, idx) => {
+      const passRate = Math.max(0, Math.min(1, rates[idx]));
+      const evaluated = [64, 92, 48][idx];
+      const passing = Math.round(evaluated * passRate);
+      const status = passRate < 0.8 ? 'critical' : passRate < 0.9 ? 'warning' : 'ok';
+      return {
+        framework,
+        display_name: framework === 'SOC2' ? 'Trust Services Criteria' : framework,
+        evaluated,
+        passing,
+        failing: evaluated - passing,
+        inconclusive: idx + i,
+        total_controls: [399, 810, 288][idx],
+        pass_rate: passRate,
+        pass_rate_pct: Math.round(passRate * 100),
+        coverage_pct: [42 + i * 3, 35 + i * 2, 58 - i][idx],
+        status
+      };
+    });
+    const totalPassing = frameworkResults.reduce((sum, f) => sum + f.passing, 0);
+    const totalEvaluated = frameworkResults.reduce((sum, f) => sum + f.evaluated, 0);
+    const alerts = frameworkResults
+      .filter(f => f.status !== 'ok')
+      .map(f => ({
+        severity: f.status,
+        framework: f.framework,
+        pass_rate: f.pass_rate,
+        threshold: f.status === 'critical' ? 0.8 : 0.9,
+        message: `${f.framework} pass rate ${(f.pass_rate * 100).toFixed(1)}% below ${f.status} floor`
+      }));
+    return {
+      schema_version: '1.0.0',
+      kind: 'monitor_continuous_run',
+      run_id: `demo-${i + 1}`,
+      generated_at: generated,
+      schedule: 'daily',
+      frameworks,
+      sources: ['aws-inspector', 'github-inspector', 'poam-automation'],
+      thresholds: { warning: 0.9, critical: 0.8 },
+      framework_results: frameworkResults,
+      summary: {
+        overall_status: alerts.some(a => a.severity === 'critical') ? 'critical' : alerts.length ? 'warning' : 'ok',
+        overall_pass_rate: totalPassing / totalEvaluated,
+        tier1_blockers: Math.max(0, 7 - i),
+        tier2_findings: 10 + i,
+        tier3_recommendations: 14 - i,
+        passes: totalPassing,
+        inconclusive: 6 + i
+      },
+      alerts,
+      artifacts: { gap_report_dir: './monitor-reports', metrics: { skipped: true, reason: 'demo' } },
+      source_file: 'demo-data'
+    };
+  });
+}
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, {
+    'content-type': MIME_TYPES['.json'],
+    'cache-control': 'no-store'
+  });
+  res.end(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+async function sendStatic(req, res) {
+  const url = new URL(req.url, 'http://localhost');
+  const requested = url.pathname === '/' ? '/index.html' : decodeURIComponent(url.pathname);
+  const full = path.resolve(PUBLIC_DIR, `.${requested}`);
+  if (!full.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+  try {
+    const body = await fs.readFile(full);
+    res.writeHead(200, {
+      'content-type': MIME_TYPES[path.extname(full)] || 'application/octet-stream',
+      'cache-control': 'no-store'
+    });
+    res.end(body);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    throw err;
+  }
+}
+
+async function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`dashboard: ${err.message}\n\n${usage()}`);
+    process.exit(1);
+  }
+
+  if (opts.help) {
+    process.stdout.write(usage());
+    return;
+  }
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      if (req.url.startsWith('/api/runs')) {
+        sendJson(res, 200, await loadRuns(opts.dataPaths, opts.demo));
+        return;
+      }
+      await sendStatic(req, res);
+    } catch (err) {
+      sendJson(res, 500, { error: err.message });
+    }
+  });
+
+  server.on('error', err => {
+    process.stderr.write(`dashboard: failed to listen on ${opts.host}:${opts.port}: ${err.message}\n`);
+    process.exit(1);
+  });
+
+  server.listen(opts.port, opts.host, () => {
+    const data = opts.demo ? 'demo data' : opts.dataPaths.map(p => path.relative(REPO_ROOT, p) || '.').join(', ');
+    process.stderr.write(`compliance-posture dashboard: http://${opts.host}:${opts.port}\n`);
+    process.stderr.write(`data: ${data}\n`);
+  });
+}
+
+main().catch(err => {
+  process.stderr.write(`dashboard: ${err.stack || err.message}\n`);
+  process.exit(1);
+});

--- a/plugins/grc-engineer/scripts/monitor-continuous.js
+++ b/plugins/grc-engineer/scripts/monitor-continuous.js
@@ -28,6 +28,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import os from 'node:os';
 import crypto from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -309,14 +310,27 @@ function log(resolved, message) {
   process.stderr.write(`[monitor-continuous] ${message}\n`);
 }
 
-function runProcess(script, args, { quiet }) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [script, ...args], { stdio: ['ignore', 'pipe', quiet ? 'ignore' : 'inherit'] });
-    let stdout = '';
-    child.stdout.on('data', chunk => { stdout += chunk.toString(); });
-    child.on('error', reject);
-    child.on('close', code => resolve({ code, stdout }));
-  });
+async function runProcess(script, args, { quiet }) {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'monitor-continuous-'));
+  const stdoutPath = path.join(tmpDir, 'stdout');
+  let stdoutHandle;
+  try {
+    stdoutHandle = await fs.open(stdoutPath, 'w');
+    const code = await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [script, ...args], {
+        stdio: ['ignore', stdoutHandle.fd, quiet ? 'ignore' : 'inherit']
+      });
+      child.on('error', reject);
+      child.on('close', resolve);
+    });
+    await stdoutHandle.close();
+    stdoutHandle = null;
+    const stdout = await fs.readFile(stdoutPath, 'utf8').catch(() => '');
+    return { code, stdout };
+  } finally {
+    if (stdoutHandle) await stdoutHandle.close().catch(() => {});
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
 }
 
 async function runGapAssessment(resolved, runId) {


### PR DESCRIPTION
## Summary

Thanks for approving #68. I wanted to build on that JSON output contract and
show a concrete demo of what the `/dashboard:` category from #38 could look
like.

This PR adds a local-first compliance posture dashboard that reads saved
`monitor-continuous` JSON files, renders current posture, trend, framework
health, alert queue, and recent run history, and keeps historical comparison
outside Claude's context window.

cc @ethanolivertroy @Robert-Wiley since this follows the thread in #38 about
saving comparable run state without turning Claude into a memory system.

## What changed

- Adds `plugins/dashboards/compliance-posture/` as a reference dashboard plugin.
- Adds a dependency-free localhost server and static UI for saved monitor manifests.
- Adds `npm run dashboard:compliance-posture`.
- Makes `--demo` force built-in demo data, so local generated JSON does not
  override the demo view.
- Updates `monitor-continuous.js` child-process output capture so saved JSON
  works reliably as the dashboard input.

## How to try it

Demo mode:

```bash
npm run dashboard:compliance-posture -- --demo --port=8788
```

Saved run mode:

```bash
mkdir -p grc-data/dashboard/monitor-continuous

node plugins/grc-engineer/scripts/monitor-continuous.js SOC2,NIST-800-53 \
  --cache-dir=tests/fixtures/findings \
  --no-exit-code \
  --output=grc-data/dashboard/monitor-continuous/run-1.json

npm run dashboard:compliance-posture -- \
  --data=grc-data/dashboard/monitor-continuous
```

Then open the port printed by the server.

## Notes

This is intentionally not a deployment proposal yet. It is a localhost prototype
meant to pressure-test the data shape and UX before deciding whether the
longer-term dashboard backend should be Worker/KV, SQLite, static files, or
something else.

## Validation

- `node --check plugins/dashboards/compliance-posture/scripts/serve.js`
- `node --check plugins/dashboards/compliance-posture/public/app.js`
- `./node_modules/.bin/markdownlint-cli2 plugins/dashboards/compliance-posture/README.md plugins/dashboards/compliance-posture/commands/compliance-posture.md`
- `npm run test:contract`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Compliance Posture Dashboard with metrics, trend visualization, framework results, and alert monitoring powered by monitor-continuous data.
  * New CLI command to launch the dashboard with configurable data source, host/port, and demo preview mode.

* **Documentation**
  * Added comprehensive usage guides, CLI examples, input format details, and demo instructions for the dashboard.

* **Bug Fixes / Reliability**
  * Improved capture and cleanup of monitor-continuous run output for more reliable dashboard ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->