### PR TITLE
feat(ci): add OpenSSF Scorecard + OSV-Scanner workflows

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,41 @@
+name: OSV-Scanner
+
+# Dependency vulnerability scanning via Google's OSV-Scanner against the
+# OSV.dev database. Runs on PRs (only flags newly introduced vulns), on
+# pushes to main, and weekly to surface newly disclosed CVEs in pinned deps.
+#
+# Closes https://github.com/GRCEngClub/claude-grc-engineering/issues/75
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * 1'  # Monday 07:00 UTC, between scorecard (06:00) and lychee (08:00)
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan-scheduled:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@3d5827dbebf8a3f7ba681e730a8a1b116e8ebddd # v2.3.5
+    with:
+      scan-args: |-
+        --include-git-root
+        -r
+        ./
+
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@3d5827dbebf8a3f7ba681e730a8a1b116e8ebddd # v2.3.5
+    with:
+      scan-args: |-
+        --include-git-root
+        -r
+        ./

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,51 @@
+name: OpenSSF Scorecard
+
+# Supply-chain posture scoring via the OpenSSF Scorecard. Runs on the default
+# branch only (per Scorecard requirements) and emits SARIF to the Code
+# Scanning dashboard so security findings live alongside the other CI signal.
+#
+# Closes https://github.com/GRCEngClub/claude-grc-engineering/issues/73
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'  # Monday 06:00 UTC, ahead of lychee's 08:00 weekly slot
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF to Code Scanning
+      id-token: write          # OIDC token for publish_results
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to Code Scanning
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Adds two supply-chain security workflows, closing the long-standing security-CI gap:

- **`scorecard.yml`** — OpenSSF Scorecard runs on push to main + `branch_protection_rule` events + Monday 06:00 UTC. Emits SARIF to Code Scanning. `publish_results: true` so the public Scorecard project picks up our score. Closes #73.
- **`osv-scanner.yml`** — Google's OSV-Scanner via the official reusable workflows. `scan-pr` runs on every PR (flags newly-introduced vulns only); `scan-scheduled` runs on push to main + Monday 07:00 UTC (catches newly disclosed CVEs in pinned deps). Closes #75.

Both actions are SHA-pinned per supply-chain hygiene (the irony of using floating tags on your supply-chain security actions, etc.).

## Cron staggering

Weekly CI is now spread across the hour to avoid the 06:00 / 07:00 / 08:00 thundering-herd against GitHub Actions:

| Workflow | Day | Time (UTC) |
|---|---|---|
| `scorecard.yml` | Monday | 06:00 |
| `osv-scanner.yml` (scheduled) | Monday | 07:00 |
| `link-check.yml` (lychee) | Monday | 08:00 |

## Test plan

- [ ] Manifest validation + lychee + CodeRabbit pass
- [ ] Scorecard workflow runs on the merge commit and uploads SARIF (visible in Security → Code scanning)
- [ ] OSV-Scanner `scan-pr` job runs on this PR (verify in Actions tab — first run will be on this PR itself)
- [ ] OSV-Scanner `scan-scheduled` job runs on the merge commit

Closes #73, closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated dependency vulnerability scanning on pull requests and scheduled intervals
  * Implemented automated security analysis with vulnerability reporting capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->