### PR TITLE
chore: working-tree polish — node -e hardening, namespace fixes, manifest cross-check, SCF typo workaround

### DIFF
--- a/plugins/connectors/aws-inspector/scripts/status.sh
+++ b/plugins/connectors/aws-inspector/scripts/status.sh
@@ -65,8 +65,8 @@ elif (( AGE_H < 168 )); then AGE="$((AGE_H/24))d ago"; STATUS="ready"
 else AGE="$((AGE_H/24))d ago"; STATUS="stale"
 fi
 
-RES=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$LATEST','utf8')).length)}catch{console.log('?')}")
-EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync('$LATEST','utf8'));let n=0;for(const d of a)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}")
+RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
+EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}" "$LATEST")
 
 printf '  status:        %s\n' "$STATUS"
 printf '  last run:      %s (%s)\n' "$AGE" "$(basename "$LATEST" .json)"

--- a/plugins/connectors/gcp-inspector/scripts/status.sh
+++ b/plugins/connectors/gcp-inspector/scripts/status.sh
@@ -61,8 +61,8 @@ elif (( AGE_H < 168 )); then LABEL="$((AGE_H/24))d ago"; STATUS="ready"
 else LABEL="$((AGE_H/24))d ago"; STATUS="stale"
 fi
 
-RES=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$LATEST','utf8')).length)}catch{console.log('?')}")
-EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync('$LATEST','utf8'));let n=0;for(const d of a)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}")
+RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
+EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}" "$LATEST")
 
 printf '  status:        %s\n' "$STATUS"
 printf '  last run:      %s (%s)\n' "$LABEL" "$(basename "$LATEST" .json)"

--- a/plugins/connectors/github-inspector/scripts/status.sh
+++ b/plugins/connectors/github-inspector/scripts/status.sh
@@ -71,17 +71,17 @@ STATUS_LABEL="${STATUS_LABEL:-ready}"
 
 RESOURCES=$(node -e "
 const fs=require('fs');
-try{const a=JSON.parse(fs.readFileSync('$LATEST','utf8')); console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}
-")
+try{const a=JSON.parse(fs.readFileSync(process.argv[1],'utf8')); console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}
+" "$LATEST")
 EVALS=$(node -e "
 const fs=require('fs');
 try{
-  const a=JSON.parse(fs.readFileSync('$LATEST','utf8'));
+  const a=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));
   const arr=Array.isArray(a)?a:[a];
   let n=0; for(const d of arr) n+=(d.evaluations||[]).length;
   console.log(n);
 }catch{console.log('?')}
-")
+" "$LATEST")
 
 printf '  status:        %s\n' "$STATUS_LABEL"
 printf '  last run:      %s (%s)\n' "$AGE_LABEL" "$(basename "$LATEST" .json)"

--- a/plugins/connectors/okta-inspector/scripts/status.sh
+++ b/plugins/connectors/okta-inspector/scripts/status.sh
@@ -54,8 +54,8 @@ if (( AGE_H < 24 )); then LABEL="${AGE_H}h ago"; STATUS="ready"
 elif (( AGE_H < 168 )); then LABEL="$((AGE_H/24))d ago"; STATUS="ready"
 else LABEL="$((AGE_H/24))d ago"; STATUS="stale"
 fi
-RES=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$LATEST','utf8')).length)}catch{console.log('?')}")
-EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync('$LATEST','utf8'));let n=0;for(const d of a)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}")
+RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
+EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}" "$LATEST")
 
 printf '  status:        %s\n' "$STATUS"
 printf '  last run:      %s (%s)\n' "$LABEL" "$(basename "$LATEST" .json)"

--- a/plugins/fedramp-ssp/scripts/convert.sh
+++ b/plugins/fedramp-ssp/scripts/convert.sh
@@ -104,11 +104,11 @@ SIZE=$(wc -c < "$OUTPUT" | awk '{print $1}')
 IMPL_COUNT=$(node -e "
 const fs=require('fs');
 try{
-  const d=JSON.parse(fs.readFileSync('$OUTPUT','utf8'));
+  const d=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));
   const ssp=d['system-security-plan']||d.ssp||d;
   const ir=(ssp['control-implementation']||{})['implemented-requirements']||[];
   console.log(ir.length);
-}catch{console.log('?')}")
+}catch{console.log('?')}" "$OUTPUT")
 
 echo "fedramp-ssp:convert ✓"
 printf '  source (SSP):      %s\n' "$SSP_DOCX"

--- a/plugins/grc-engineer/commands/collect-evidence.md
+++ b/plugins/grc-engineer/commands/collect-evidence.md
@@ -29,7 +29,7 @@ Generates scripts to collect point-in-time evidence for audit controls.
 1. Run the collect-evidence script:
 
    ```bash
-   node scripts/collect-evidence.js "$ARGUMENTS"
+   node plugins/grc-engineer/scripts/collect-evidence.js "$ARGUMENTS"
    ```
 
 2. The script generates an evidence collection script.
@@ -44,14 +44,14 @@ Generates scripts to collect point-in-time evidence for audit controls.
 
 ```bash
 # Collect AWS MFA evidence for SOC 2
-/grc:collect-evidence "MFA for all root users" aws python
+/grc-engineer:collect-evidence "MFA for all root users" aws python
 
 # Collect PCI-DSS Requirement 8.4.2 evidence (MFA for CDE access)
-/grc:collect-evidence "MFA for cardholder data environment access" aws bash
+/grc-engineer:collect-evidence "MFA for cardholder data environment access" aws bash
 
 # Collect Azure access control evidence
-/grc:collect-evidence "Role-based access controls" azure python
+/grc-engineer:collect-evidence "Role-based access controls" azure python
 
 # Collect Kubernetes RBAC evidence
-/grc:collect-evidence "Pod security policies" kubernetes bash
+/grc-engineer:collect-evidence "Pod security policies" kubernetes bash
 ```

--- a/plugins/grc-engineer/commands/generate-policy.md
+++ b/plugins/grc-engineer/commands/generate-policy.md
@@ -24,7 +24,7 @@ Converts natural language compliance requirements into executable policy code.
 1. Run the generate-policy script:
 
    ```bash
-   node scripts/generate-policy.js "$ARGUMENTS"
+   node plugins/grc-engineer/scripts/generate-policy.js "$ARGUMENTS"
    ```
 
 2. The script generates policy code in the specified format.
@@ -35,14 +35,14 @@ Converts natural language compliance requirements into executable policy code.
 
 ```bash
 # Generate OPA policy for S3 bucket security
-/grc:generate-policy "Ensure no S3 buckets are public and all must have a 'Department' tag" rego
+/grc-engineer:generate-policy "Ensure no S3 buckets are public and all must have a 'Department' tag" rego
 
 # Generate PCI-DSS Requirement 3 policy (protect stored data)
-/grc:generate-policy "All databases storing cardholder data must use encryption at rest" aws-config
+/grc-engineer:generate-policy "All databases storing cardholder data must use encryption at rest" aws-config
 
 # Generate network segmentation policy for PCI-DSS Requirement 1
-/grc:generate-policy "Cardholder data environment must be isolated via network segmentation" sentinel
+/grc-engineer:generate-policy "Cardholder data environment must be isolated via network segmentation" sentinel
 
 # Generate HIPAA encryption policy
-/grc:generate-policy "All PHI storage must use AES-256 encryption" terraform
+/grc-engineer:generate-policy "All PHI storage must use AES-256 encryption" terraform
 ```

--- a/plugins/grc-engineer/commands/map-control.md
+++ b/plugins/grc-engineer/commands/map-control.md
@@ -34,7 +34,7 @@ Maps infrastructure-as-code (IaC) files to specific compliance framework control
 1. Run the map-control script:
 
    ```bash
-   node scripts/map-control.js $ARGUMENTS
+   node plugins/grc-engineer/scripts/map-control.js $ARGUMENTS
    ```
 
 2. The script analyzes the IaC file and generates a compliance mapping report.
@@ -47,14 +47,14 @@ Maps infrastructure-as-code (IaC) files to specific compliance framework control
 
 ```bash
 # Map to SOC 2 controls
-/grc:map-control main.tf SOC2
+/grc-engineer:map-control main.tf SOC2
 
 # Map to PCI-DSS requirements
-/grc:map-control main.tf PCIDSS
+/grc-engineer:map-control main.tf PCIDSS
 
 # Map to ISO 27001 controls
-/grc:map-control terraform/ ISO27001
+/grc-engineer:map-control terraform/ ISO27001
 
 # Map to NIST 800-53 controls
-/grc:map-control infrastructure/ NIST80053
+/grc-engineer:map-control infrastructure/ NIST80053
 ```

--- a/plugins/grc-engineer/commands/review-pr.md
+++ b/plugins/grc-engineer/commands/review-pr.md
@@ -27,7 +27,7 @@ Reviews GitHub pull requests for compliance regressions and security issues.
 2. Run the review-pr script:
 
    ```bash
-   node scripts/review-pr.js $ARGUMENTS
+   node plugins/grc-engineer/scripts/review-pr.js $ARGUMENTS
    ```
 
 3. The script analyzes the PR diff and generates compliance review comments.
@@ -37,5 +37,5 @@ Reviews GitHub pull requests for compliance regressions and security issues.
 ## Example
 
 ```bash
-/grc:review-pr myorg/infrastructure 42 SOC2
+/grc-engineer:review-pr myorg/infrastructure 42 SOC2
 ```

--- a/plugins/grc-engineer/commands/transform-risk.md
+++ b/plugins/grc-engineer/commands/transform-risk.md
@@ -16,7 +16,7 @@ Converts unstructured risk assessments into structured Jira tickets.
 1. Run the transform-risk script:
 
    ```bash
-   node scripts/transform-risk.js "$ARGUMENTS"
+   node plugins/grc-engineer/scripts/transform-risk.js "$ARGUMENTS"
    ```
 
 2. The script extracts likelihood, impact, and mitigation from the description.
@@ -28,5 +28,5 @@ Converts unstructured risk assessments into structured Jira tickets.
 ## Example
 
 ```bash
-/grc:transform-risk "Vulnerability in auth service. High likelihood, critical impact. Mitigation: Implement OAuth2 with PKCE." SEC
+/grc-engineer:transform-risk "Vulnerability in auth service. High likelihood, critical impact. Mitigation: Implement OAuth2 with PKCE." SEC
 ```

--- a/plugins/grc-engineer/scripts/frameworks.js
+++ b/plugins/grc-engineer/scripts/frameworks.js
@@ -100,7 +100,7 @@ Examples:
 }
 
 function regionFromFrameworkId(frameworkId) {
-  if (frameworkId.startsWith('americas-') || frameworkId.startsWith('usa-')) return 'americas';
+  if (frameworkId.startsWith('americas-') || frameworkId.startsWith('amaericas-') || frameworkId.startsWith('usa-')) return 'americas';
   if (frameworkId.startsWith('apac-')) return 'apac';
   if (frameworkId.startsWith('emea-')) return 'emea';
   if (frameworkId.startsWith('general-')) return 'global';

--- a/plugins/grc-engineer/scripts/generate-coverage.js
+++ b/plugins/grc-engineer/scripts/generate-coverage.js
@@ -36,7 +36,7 @@ function parseArgs(argv) {
 }
 
 function regionFromFrameworkId(frameworkId) {
-  if (frameworkId.startsWith('americas-') || frameworkId.startsWith('usa-')) return 'Americas';
+  if (frameworkId.startsWith('americas-') || frameworkId.startsWith('amaericas-') || frameworkId.startsWith('usa-')) return 'Americas';
   if (frameworkId.startsWith('apac-')) return 'APAC';
   if (frameworkId.startsWith('emea-')) return 'EMEA';
   return 'Global';

--- a/plugins/grc-engineer/scripts/pipeline-status.sh
+++ b/plugins/grc-engineer/scripts/pipeline-status.sh
@@ -55,8 +55,8 @@ for cfg in "$CONFIG_DIR"/*.yaml; do
   if [[ -d "$src_dir" ]]; then
     latest=$(ls -t "$src_dir"/*.json 2>/dev/null | head -1 || true)
     if [[ -n "$latest" ]]; then
-      r=$(node -e "try{const a=JSON.parse(require('fs').readFileSync('$latest','utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log(0)}")
-      e=$(node -e "try{const a=JSON.parse(require('fs').readFileSync('$latest','utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log(0)}")
+      r=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log(0)}" "$latest")
+      e=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log(0)}" "$latest")
       TOTAL_RESOURCES=$((TOTAL_RESOURCES + r))
       TOTAL_EVALS=$((TOTAL_EVALS + e))
       if stat -f%m "$latest" >/dev/null 2>&1; then m=$(stat -f%m "$latest"); else m=$(stat -c%Y "$latest"); fi

--- a/plugins/grc-engineer/scripts/scaffold-framework.js
+++ b/plugins/grc-engineer/scripts/scaffold-framework.js
@@ -103,7 +103,7 @@ Examples:
 function deriveSlug(frameworkId) {
   let slug = frameworkId.toLowerCase();
   // Drop known region prefixes
-  slug = slug.replace(/^(americas|apac|emea|general)-/, '');
+  slug = slug.replace(/^(americas|amaericas|apac|emea|general)-/, '');
   // Drop trailing -YYYY (year)
   slug = slug.replace(/-\d{4}$/, '');
   // Collapse duplicate dashes just in case
@@ -117,9 +117,10 @@ function deriveNamespace(slug) {
 }
 
 function deriveRegion(frameworkId) {
-  const m = frameworkId.match(/^(americas|apac|emea|general)-/);
+  const m = frameworkId.match(/^(americas|amaericas|apac|emea|general)-/);
   if (!m) return { slug: 'general', display: 'Global' };
-  return { slug: m[1], display: REGION_NAMES[m[1]] };
+  const slug = m[1] === 'amaericas' ? 'americas' : m[1];
+  return { slug, display: REGION_NAMES[slug] };
 }
 
 function deriveCountry(frameworkId) {

--- a/plugins/grc-engineer/skills/audit-ready-pr-reviewer/SKILL.md
+++ b/plugins/grc-engineer/skills/audit-ready-pr-reviewer/SKILL.md
@@ -13,19 +13,19 @@ Reviews GitHub/GitLab pull requests specifically for compliance regressions. Shi
 **Review a PR for SOC 2 compliance:**
 
 ```bash
-node scripts/review-pr.js myorg/infrastructure 42 SOC2
+node plugins/grc-engineer/scripts/review-pr.js myorg/infrastructure 42 SOC2
 ```
 
 **Review a PR for ISO 27001:**
 
 ```bash
-node scripts/review-pr.js myorg/infrastructure 42 ISO27001
+node plugins/grc-engineer/scripts/review-pr.js myorg/infrastructure 42 ISO27001
 ```
 
 **Review a PR with custom framework:**
 
 ```bash
-node scripts/review-pr.js myorg/infrastructure 42 NIST80053
+node plugins/grc-engineer/scripts/review-pr.js myorg/infrastructure 42 NIST80053
 ```
 
 ## What It Checks
@@ -83,4 +83,3 @@ resource "aws_iam_role" "app_role" {
 - PR number
 - `GITHUB_TOKEN` environment variable (requires `repo` scope)
 - Optional: Framework name (defaults to SOC2)
-

--- a/plugins/grc-engineer/skills/code-to-control-mapper/SKILL.md
+++ b/plugins/grc-engineer/skills/code-to-control-mapper/SKILL.md
@@ -13,19 +13,19 @@ Maps infrastructure-as-code (IaC) files to specific compliance framework control
 **Map a Terraform file to SOC 2:**
 
 ```bash
-node scripts/map-control.js main.tf SOC2
+node plugins/grc-engineer/scripts/map-control.js main.tf SOC2
 ```
 
 **Map Kubernetes manifests to ISO 27001:**
 
 ```bash
-node scripts/map-control.js k8s/deployment.yaml ISO27001
+node plugins/grc-engineer/scripts/map-control.js k8s/deployment.yaml ISO27001
 ```
 
 **Map CloudFormation template to NIST 800-53:**
 
 ```bash
-node scripts/map-control.js template.yaml NIST80053
+node plugins/grc-engineer/scripts/map-control.js template.yaml NIST80053
 ```
 
 ## Supported Frameworks

--- a/plugins/grc-engineer/skills/evidence-artifact-collector/SKILL.md
+++ b/plugins/grc-engineer/skills/evidence-artifact-collector/SKILL.md
@@ -13,19 +13,19 @@ Generates scripts to collect audit evidence from cloud infrastructure. Automates
 **Generate AWS evidence script:**
 
 ```bash
-node scripts/collect-evidence.js "MFA for all root users" aws
+node plugins/grc-engineer/scripts/collect-evidence.js "MFA for all root users" aws
 ```
 
 **Generate Azure evidence script:**
 
 ```bash
-node scripts/collect-evidence.js "All storage accounts encrypted" azure
+node plugins/grc-engineer/scripts/collect-evidence.js "All storage accounts encrypted" azure
 ```
 
 **Generate GCP evidence script:**
 
 ```bash
-node scripts/collect-evidence.js "IAM bindings audit" gcp
+node plugins/grc-engineer/scripts/collect-evidence.js "IAM bindings audit" gcp
 ```
 
 ## Supported Providers

--- a/plugins/grc-engineer/skills/policy-as-code-generator/SKILL.md
+++ b/plugins/grc-engineer/skills/policy-as-code-generator/SKILL.md
@@ -13,19 +13,19 @@ Converts natural language compliance requirements into executable policy code. G
 **Generate OPA Rego policy:**
 
 ```bash
-node scripts/generate-policy.js "Ensure no S3 buckets are public and all must have a 'Department' tag" rego
+node plugins/grc-engineer/scripts/generate-policy.js "Ensure no S3 buckets are public and all must have a 'Department' tag" rego
 ```
 
 **Generate AWS Config Rule:**
 
 ```bash
-node scripts/generate-policy.js "All EC2 instances must have encryption enabled" aws-config
+node plugins/grc-engineer/scripts/generate-policy.js "All EC2 instances must have encryption enabled" aws-config
 ```
 
 **Generate Sentinel policy:**
 
 ```bash
-node scripts/generate-policy.js "Terraform plans must not create resources without required tags" sentinel
+node plugins/grc-engineer/scripts/generate-policy.js "Terraform plans must not create resources without required tags" sentinel
 ```
 
 ## Supported Output Formats

--- a/plugins/grc-engineer/skills/risk-to-jira-transformer/SKILL.md
+++ b/plugins/grc-engineer/skills/risk-to-jira-transformer/SKILL.md
@@ -13,13 +13,13 @@ Converts unstructured risk assessments into structured engineering tickets. Turn
 **Transform a risk assessment:**
 
 ```bash
-node scripts/transform-risk.js "Vulnerability in authentication service discovered during pen test. High likelihood, critical impact. Mitigation: Implement OAuth2 with PKCE." SEC
+node plugins/grc-engineer/scripts/transform-risk.js "Vulnerability in authentication service discovered during pen test. High likelihood, critical impact. Mitigation: Implement OAuth2 with PKCE." SEC
 ```
 
 **Transform with custom project:**
 
 ```bash
-node scripts/transform-risk.js "<risk description>" INFRA
+node plugins/grc-engineer/scripts/transform-risk.js "<risk description>" INFRA
 ```
 
 ## Input Format

--- a/tests/validate-plugin-manifests.sh
+++ b/tests/validate-plugin-manifests.sh
@@ -120,6 +120,77 @@ else
   exit 1
 fi
 
+if ! consistency_output=$(node <<'NODE' 2>&1
+const fs = require('fs');
+const path = require('path');
+
+function normalizeSource(source) {
+  return String(source || '').replace(/^\.\//, '').replace(/\/+$/, '');
+}
+
+function walk(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.name === 'plugin.json' && path.basename(path.dirname(full)) === '.claude-plugin') out.push(full);
+  }
+  return out;
+}
+
+const marketplace = JSON.parse(fs.readFileSync('.claude-plugin/marketplace.json', 'utf8'));
+const issues = [];
+const bySource = new Map();
+const byName = new Map();
+
+for (const plugin of marketplace.plugins || []) {
+  const source = normalizeSource(plugin.source);
+  if (!source) issues.push(`marketplace entry "${plugin.name || '<unnamed>'}" is missing source`);
+  if (bySource.has(source)) issues.push(`duplicate marketplace source: ${source}`);
+  if (byName.has(plugin.name)) issues.push(`duplicate marketplace plugin name: ${plugin.name}`);
+  bySource.set(source, plugin);
+  byName.set(plugin.name, plugin);
+}
+
+const manifests = walk('plugins');
+for (const manifestPath of manifests) {
+  const pluginRoot = normalizeSource(path.dirname(path.dirname(manifestPath)));
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const entry = bySource.get(pluginRoot);
+  if (!entry) {
+    issues.push(`${pluginRoot} has .claude-plugin/plugin.json but is not registered in .claude-plugin/marketplace.json`);
+    continue;
+  }
+  if (entry.name !== manifest.name) {
+    issues.push(`${pluginRoot} marketplace name "${entry.name}" does not match plugin.json name "${manifest.name}"`);
+  }
+}
+
+for (const [source, entry] of bySource.entries()) {
+  const manifestPath = path.join(source, '.claude-plugin', 'plugin.json');
+  if (!fs.existsSync(manifestPath)) {
+    issues.push(`marketplace entry "${entry.name}" points to ${source}, but ${manifestPath} does not exist`);
+    continue;
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  if (manifest.name !== entry.name) {
+    issues.push(`marketplace entry "${entry.name}" points to plugin.json named "${manifest.name}" at ${manifestPath}`);
+  }
+}
+
+if (issues.length) {
+  for (const issue of issues) console.error(issue);
+  process.exit(1);
+}
+
+console.log(`Marketplace registration matches ${manifests.length} plugin manifest(s).`);
+NODE
+); then
+  emit_summary_error "$consistency_output"
+  fail=1
+else
+  printf '%s\n' "$consistency_output"
+fi
+
 while IFS= read -r manifest; do
   validate_file "$plugin_schema" "$manifest"
 done < <(find plugins -type f -name plugin.json -path '*/.claude-plugin/*' | sort)


### PR DESCRIPTION
## Summary

Bundles four small, independent improvements that had been sitting in the working tree. Splitting into discrete commits so each is reviewable on its own, but landing as one PR for momentum.

## Commits

### 1. `fix(scripts)` — pass file paths to `node -e` via argv
Six scripts (`status.sh` × 4 connectors, `fedramp-ssp/convert.sh`, `grc-engineer/pipeline-status.sh`) interpolated `$LATEST` / `$OUTPUT` directly into `node -e "...readFileSync('$LATEST',...)"` JS string literals. A path with a single quote, backslash, or newline broke parsing, and a hostile filename could inject JS. Switched to passing the path as `process.argv[1]`.

### 2. `docs(grc-engineer)` — correct command namespaces and script paths in examples
- `/grc:<command>` → `/grc-engineer:<command>` (the actual namespace)
- `node scripts/<x>.js` → `node plugins/grc-engineer/scripts/<x>.js` (works from repo root)

Across 5 command files and 5 SKILL.md files. Docs-only.

### 3. `test(manifests)` — cross-check `marketplace.json` ↔ per-plugin `plugin.json`
Existing validator only checked each manifest in isolation. Adds a Node consistency check that catches:
- Plugin dirs with `plugin.json` but not registered in marketplace
- Marketplace entries pointing at missing paths
- Name mismatches between marketplace entry and plugin manifest
- Duplicate names/sources in marketplace

Passes against the current 41 manifests.

### 4. `fix(scaffold)` — handle SCF `amaericas-` typo prefix
Upstream Secure Controls Framework data has one ID with a misspelled region prefix: `amaericas-can-osfi-self-assessment` (see `docs/FRAMEWORK-COVERAGE.md:258`). Without special-casing, our region detection bucketed it as "global" and our scaffolder produced an ugly slug. Added `amaericas` to the allowlists and normalized back to `americas` in `deriveRegion`. Workaround for an upstream typo — if SCF fixes it, the branch becomes a no-op.

## Validation

- `bash tests/validate-plugin-manifests.sh` → all 41 manifests valid
- Working tree clean post-commit

## Test plan

- [ ] CI: `Validate plugin manifests` workflow passes (includes the new cross-check)
- [ ] CI: `Link check` passes
- [ ] Spot-check that one of the `status.sh` scripts still produces a sensible output for an existing connector run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cross-file validation to ensure plugin manifests are consistently registered and match across configurations.

* **Bug Fixes**
  * Enhanced framework ID region classification to gracefully handle misspelled region prefixes.

* **Documentation**
  * Updated GRC Engineer plugin documentation with correct script paths and command namespaces across all commands and skills.

* **Refactor**
  * Improved argument passing in cloud connector and pipeline scripts for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->