### PR TITLE
feat(framework): NIST CSF 2.0 plugin at Reference depth (closes #16)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -249,6 +249,12 @@
       "source": "./plugins/connectors/poam-automation",
       "description": "GRC connector wrapping networkbm/POAM-Automation-Tool: converts vulnerability scans into FedRAMP POA&M Excel and emits NIST-800-53-r5 (SI-2) findings → v1 finding contract.",
       "version": "0.1.0"
+    },
+    {
+      "name": "nist-csf-20",
+      "source": "./plugins/frameworks/nist-csf-20",
+      "description": "NIST Cybersecurity Framework (v2.0) — reference-depth plugin backed by the SCF crosswalk (250 SCF → 134 framework controls).",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/frameworks/nist-csf-20/.claude-plugin/plugin.json
+++ b/plugins/frameworks/nist-csf-20/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "nist-csf-20",
+  "description": "NIST Cybersecurity Framework (v2.0) — Reference plugin with scope determination, evidence checklist, and SCF-backed gap assessment across the six Functions (GV/ID/PR/DE/RS/RC).",
+  "version": "0.1.0",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "framework_metadata": {
+    "scf_framework_id": "general-nist-csf-2-0",
+    "display_name": "NIST Cybersecurity Framework (v2.0)",
+    "region": "Global",
+    "country": "US",
+    "depth": "reference",
+    "scf_controls_mapped": 250,
+    "framework_controls_mapped": 134,
+    "industry": ["cross-sector", "critical-infrastructure", "federal-contractor", "private-sector"],
+    "regulator": "NIST (voluntary framework; not enforced — adopted as baseline by US federal agencies, sector regulators, and contracts)",
+    "citations": ["NIST CSF 2.0 (February 26, 2024)", "NIST CSF 2.0 Quick Start Guides (NIST SP 1300 series)", "Informative References to NIST SP 800-53 Rev. 5, ISO/IEC 27001:2022, CIS Controls v8"]
+  },
+  "commands": ["scope", "assess", "evidence-checklist"],
+  "skills": ["nist-csf-20-expert"]
+}

--- a/plugins/frameworks/nist-csf-20/README.md
+++ b/plugins/frameworks/nist-csf-20/README.md
@@ -1,0 +1,59 @@
+# nist-csf-20 — NIST Cybersecurity Framework v2.0
+
+Reference-depth framework plugin for the **NIST Cybersecurity Framework v2.0** (released February 26, 2024). Provides scope determination, evidence collection guidance, and a Profile-style gap assessment organized around the six CSF Functions: Govern, Identify, Protect, Detect, Respond, Recover.
+
+```bash
+/plugin install nist-csf-20@grc-engineering-suite
+/nist-csf-20:scope                    # decide Functions, Tier target, Profile starting point
+/nist-csf-20:evidence-checklist       # evidence patterns per Function
+/nist-csf-20:assess                   # Profile gap assessment via SCF crosswalk
+```
+
+## Status: Reference
+
+This plugin is at **Reference depth** — it provides scope determination, an evidence checklist organized by Function, and a Profile-style gap assessment, all backed by the SCF crosswalk (250 SCF controls → 134 CSF 2.0 Subcategories).
+
+### Level up to Full
+
+Full depth adds framework-native workflow commands tied to how CSF is actually consumed in practice. Candidate Full-depth commands documented in `skills/nist-csf-20-expert/SKILL.md`:
+
+- `/nist-csf-20:profile-build` — interactive Current/Target Profile authoring
+- `/nist-csf-20:tier-assessment` — guided Tier 1–4 evaluation
+- `/nist-csf-20:community-profile` — apply published Community Profiles (manufacturing, election infrastructure, electric grid)
+- `/nist-csf-20:board-report` — Function-level executive summary for board / audit committee
+- `/nist-csf-20:csf1-to-csf2` — migrate an existing CSF 1.1 Profile to 2.0 (accounts for the new Govern Function)
+- `/nist-csf-20:sec-disclosure-prep` — map Govern outcomes to SEC Reg S-K Item 106 disclosure requirements
+
+If you have practitioner experience in any of these workflows, see the [Framework Plugin Guide](../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the level-up checklist.
+
+## Metadata
+
+| | |
+|---|---|
+| SCF framework ID | `general-nist-csf-2-0` |
+| Publisher | NIST (U.S. Department of Commerce) |
+| Released | February 26, 2024 (final) |
+| Region | Global |
+| Country origin | United States |
+| Status | Voluntary; widely adopted as U.S. cybersecurity baseline |
+| SCF controls mapped | 250 |
+| Framework controls mapped | 134 |
+| Functions | 6 (Govern, Identify, Protect, Detect, Respond, Recover) |
+| Categories | 22 |
+| Depth | Reference |
+
+## What CSF 2.0 is (and is not)
+
+**CSF 2.0 is**: a cybersecurity outcomes framework, organized as Function → Category → Subcategory, used as a shared vocabulary between CISOs, boards, regulators, and contracting officers. The headline change in 2.0 is the new **Govern (GV)** Function, which holds the cybersecurity program itself (strategy, policy, oversight, supply chain) accountable rather than just incident-response activities.
+
+**CSF 2.0 is not**: a control catalog (use NIST SP 800-53, ISO 27001 Annex A, or CIS Controls v8 for that), a certification program (no CSF certification exists), or a substitute for sectoral regulation (HIPAA, PCI DSS, GLBA, CMMC, etc. still apply on their own terms).
+
+For the full picture — scope decision tree, Tier guidance, Subcategory examples, common misinterpretations, and Full-depth roadmap — see `skills/nist-csf-20-expert/SKILL.md`.
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com) — crosswalk source
+- [SCF API entry](https://grcengclub.github.io/scf-api/api/crosswalks/general-nist-csf-2-0.json)
+- NIST CSF 2.0 (final, February 26, 2024) — `nist.gov/cyberframework`
+- NIST CSF 2.0 Quick Start Guides (SP 1300 series)
+- NIST CSF 2.0 Reference Tool — interactive Subcategory browser

--- a/plugins/frameworks/nist-csf-20/commands/assess.md
+++ b/plugins/frameworks/nist-csf-20/commands/assess.md
@@ -1,0 +1,129 @@
+---
+description: NIST CSF 2.0 Profile gap assessment via SCF crosswalk
+---
+
+# NIST CSF 2.0 Assessment
+
+Runs a Profile gap assessment against **NIST Cybersecurity Framework v2.0** by delegating to `/grc-engineer:gap-assessment` with the framework's SCF identifier, then overlays CSF-specific framing (Function / Category / Subcategory, Current Profile vs Target Profile, Tier rationale).
+
+## Usage
+
+```
+/nist-csf-20:assess [--function=<GV|ID|PR|DE|RS|RC>] [--profile=<current|target|gap>] [--sources=<connector-list>]
+```
+
+## Arguments
+
+- `--function=<code>` (optional) — narrow the assessment to a single Function. Codes: `GV` (Govern), `ID` (Identify), `PR` (Protect), `DE` (Detect), `RS` (Respond), `RC` (Recover). Default: all six.
+- `--profile=<phase>` (optional) — which Profile phase to produce:
+  - `current` — Current Profile only (snapshot of present-state outcomes)
+  - `target` — Target Profile only (desired-state outcomes; usually informed by a Community Profile)
+  - `gap` (default) — both, with the delta highlighted
+- `--sources=<connector-list>` (optional) — comma-separated connector plugins (e.g. `aws-inspector,github-inspector,okta-inspector`).
+
+If `/nist-csf-20:scope` has been run, this command will pick up the recorded Function scope, Tier targets, and Community Profile selection from that session.
+
+## What the assessment produces
+
+1. **Profile snapshot** — Current Profile, Target Profile, or both (per `--profile`), organized by Function → Category → Subcategory.
+2. **Subcategory-level status** — for each Subcategory: implemented / partially implemented / not implemented / not applicable, with evidence pointers and gap rationale.
+3. **Function-level rollup** — board-readable summary (% Subcategories meeting target, by Function).
+4. **Tier rationale** — the practitioner's assessment of organizational Tier (1–4), grounded in observed risk-management practices, not Subcategory counts.
+5. **Evidence gaps** — Subcategories where no evidence source is configured (typically Govern outcomes that depend on policy / charter documents not yet linked).
+6. **Remediation roadmap** — prioritized initiatives mapped to Subcategories, with effort and impact estimates. Pulls multi-framework optimization data when other frameworks are also being assessed.
+
+## Delegation
+
+Under the hood:
+
+```
+/grc-engineer:gap-assessment "general-nist-csf-2-0" [--sources=<connector-list>]
+```
+
+The SCF crosswalk expands 250 SCF controls into the 134 CSF 2.0 Subcategory mappings. This command then re-organizes the SCF-family-grouped output into the CSF Function structure that practitioners and boards expect.
+
+## CSF-specific assessment notes
+
+### Most-requested scope
+
+The most common assessment requests are:
+
+- **Full Profile (all six Functions)** — annual reassessment driver. Default.
+- **Govern Function only** — when refreshing the new (CSF 2.0) governance content, often as a discrete project after the migration from CSF 1.1.
+- **Detect + Respond + Recover** — incident-readiness assessment, often triggered by a near-miss or a peer breach.
+- **Protect** — technical hardening assessment, often before or after a major architecture change.
+- **Single Subcategory (advanced)** — typically used when a regulator has flagged a specific outcome.
+
+### Sibling-framework interactions
+
+CSF assessments are rarely run in isolation. Common combined assessments:
+
+- **CSF + NIST SP 800-53 Rev. 5** — federal contractors / FedRAMP workloads. CSF assessment rolls up 800-53 control evidence into Subcategory-level Profile statements.
+- **CSF + ISO/IEC 27001:2022** — international organizations. ISO certification work feeds CSF Subcategories via Annex A Informative References.
+- **CSF + HIPAA Security Rule** — healthcare. CSF Profile becomes the umbrella; HIPAA Security Rule controls feed PR/DE/RS/RC Subcategories.
+- **CSF + PCI DSS v4.0.1** — anyone handling cardholder data. PCI DSS controls feed PR.DS, PR.AA, DE.CM Subcategories within CDE scope.
+- **CSF + CMMC** — defense contractors. CSF Profile is a useful pre-assessment sanity check before C3PAO engagement.
+- **CSF + NIS2** — EU operations. CSF can serve as the internal cybersecurity management framework demonstrating NIS2-required risk-management measures.
+
+For multi-framework optimization, see `/grc-engineer:optimize-multi-framework` and `/grc-engineer:map-controls-unified`.
+
+### Cadence
+
+CSF imposes no mandatory cadence (it's voluntary), but a defensible practitioner cadence is:
+
+- **Annual full-Profile reassessment** — aligned with fiscal year budgeting
+- **Quarterly Function-level review** — initiative tracking, board reporting
+- **Triggered partial reassessment** — material change (M&A, major incident, new business line, new regulation, significant supply chain shift) triggers reassessment of affected Functions
+- **CSF 1.1 → 2.0 migration** — one-time exercise; plan around the new Govern Function and rebalanced Categories
+
+If the assessment is feeding into a regulator's examination cycle (HIPAA risk analysis, PCI DSS ROC, NERC CIP audit, etc.), align CSF cadence with the regulator's cadence so artifacts can be reused.
+
+### Common misinterpretations to correct during assessment
+
+- **"This Subcategory is N/A because we use a SaaS vendor."** Outcomes may shift to the vendor, but the *outcome itself* still applies; document the vendor's evidence (e.g. their SOC 2 report, their CSF Profile if they publish one) rather than marking N/A.
+- **"We're at Tier 4 because we have lots of tools."** Tooling does not equal Tier. Tier characterizes risk-management practice rigor and adaptiveness, not technology stack depth.
+- **"Govern is just policy documents."** Govern includes strategy, oversight, risk tolerance, RACI, and cybersecurity supply chain risk management (GV.SC). Do not collapse it to policy.
+- **"Implementation Examples are mandatory."** They are not. Examples are non-prescriptive starting points; the Subcategory outcome is what's being assessed.
+- **"CSF gives us a compliance certification."** It does not. There is no CSF certification. Assessment outputs are Profiles and Tier statements, not certifications.
+
+### Output formats
+
+- `text` (default) — full markdown gap analysis report
+- `json` — machine-readable, suitable for downstream tooling and CI/CD gating
+- `csv` — Subcategory-by-Subcategory matrix for spreadsheet import (common ask from boards and program managers)
+
+Specify via `--format=<text|json|csv>`.
+
+## Examples
+
+```
+# Full Profile gap assessment (all six Functions, current vs target)
+/nist-csf-20:assess
+
+# Govern Function only — board reporting prep
+/nist-csf-20:assess --function=GV
+
+# Detect/Respond/Recover for IR readiness review
+/nist-csf-20:assess --function=DE
+/nist-csf-20:assess --function=RS
+/nist-csf-20:assess --function=RC
+
+# Current Profile snapshot only (no Target comparison yet)
+/nist-csf-20:assess --profile=current
+
+# Pull connector evidence
+/nist-csf-20:assess --sources=aws-inspector,github-inspector,okta-inspector
+```
+
+## Related commands
+
+- `/nist-csf-20:scope` — define Profile scope, Tier target, sector overlays before assessment
+- `/nist-csf-20:evidence-checklist` — enumerate evidence per Function before / during assessment
+- `/grc-engineer:gap-assessment general-nist-csf-2-0` — direct SCF-crosswalk-driven assessment
+- `/grc-engineer:optimize-multi-framework` — when CSF is being assessed alongside multiple frameworks
+
+---
+
+**Framework**: NIST Cybersecurity Framework v2.0 (final, February 26, 2024)
+**SCF ID**: `general-nist-csf-2-0`
+**Status**: Voluntary; widely adopted as a U.S. and international cybersecurity baseline

--- a/plugins/frameworks/nist-csf-20/commands/evidence-checklist.md
+++ b/plugins/frameworks/nist-csf-20/commands/evidence-checklist.md
@@ -1,0 +1,177 @@
+---
+description: NIST CSF 2.0 evidence checklist organized by Function (GV / ID / PR / DE / RS / RC) with representative Subcategories
+---
+
+# NIST CSF 2.0 Evidence Checklist
+
+Baseline evidence checklist for a **NIST Cybersecurity Framework v2.0** Profile assessment. CSF is outcomes-based, not control-based — evidence demonstrates that an outcome (a Subcategory) is achieved, regardless of *how*. This checklist is organized by the six Functions, with a few representative Subcategories per Function and the artifacts an assessor or board reviewer typically expects to see.
+
+> **Never commit evidence artifacts to source control.** Configuration exports, access logs, and incident records frequently contain sensitive operational detail. Use an encrypted, access-controlled evidence locker. The repo's default `.gitignore` should already cover `evidence/`.
+
+## Usage
+
+```
+/nist-csf-20:evidence-checklist [--function=<GV|ID|PR|DE|RS|RC>] [--format=table|markdown|csv]
+```
+
+## Arguments
+
+- `--function=<code>` (optional) — restrict to a single Function. Codes: `GV`, `ID`, `PR`, `DE`, `RS`, `RC`. Default: all six.
+- `--format=<fmt>` (optional) — `table` (default Markdown table), `markdown` (detailed list), `csv` (spreadsheet import).
+- `--family=<SCF_family_code>` (optional, advanced) — restrict to a single SCF family (e.g. `IAC`, `CRY`, `AST`, `BCD`). Most users should use `--function` instead; use `--family` only when reusing evidence collection scripts written against the SCF crosswalk.
+
+## How CSF evidence works
+
+CSF Subcategory outcomes can be evidenced in many ways. The same outcome may be supported by:
+
+- A **policy document** (Govern outcomes especially)
+- A **configuration export** (Protect, Detect)
+- A **log sample** (Detect, Respond)
+- A **ticket / runbook** (Respond, Recover)
+- A **training completion record** (Protect)
+- A **board minute** or **risk register entry** (Govern)
+
+Reference-depth practitioners should accept multiple forms of evidence per Subcategory and avoid demanding a specific format unless the assessment driver (e.g. a federal contract or a sector regulator) imposes one.
+
+## Evidence by Function
+
+### Govern (GV) — strategy, policy, oversight, supply chain
+
+Govern is the new 2.0 Function and the one boards care most about. Govern evidence is mostly **document + sign-off**, not technical config exports.
+
+| Representative Subcategory | What it asks for | Evidence the assessor / board expects |
+|---|---|---|
+| **GV.OC-01** — mission understands cybersecurity risk | Cybersecurity tied to the organization's mission | Cybersecurity strategy document referencing mission; board / executive sign-off |
+| **GV.OC-03** — legal/regulatory cybersecurity requirements identified | Catalog of regulatory obligations (HIPAA, PCI DSS, GLBA, state breach laws, sector regulators) | Regulatory inventory / register; ownership map; review cadence record |
+| **GV.RM-01** — risk tolerance and appetite established | Documented risk tolerance / appetite statements | Approved risk appetite statement; integration record with enterprise risk function |
+| **GV.RR-02** — roles, responsibilities, authorities for cybersecurity established | RACI for cybersecurity decisions | Cybersecurity RACI / org chart; CISO charter; board cybersecurity oversight charter |
+| **GV.PO-01** — policies for managing cybersecurity risk are established | Written, approved cybersecurity policies | Policy library with version control, approval signatures, and review history |
+| **GV.OV-01** — cybersecurity strategy results inform improvements | Board / audit committee oversight of strategy | Board cybersecurity reporting deck; audit committee minutes; independent review report |
+| **GV.SC-01** — cyber supply chain risk management process established | C-SCRM program documentation | Vendor risk management policy; tiered vendor inventory; due diligence templates |
+| **GV.SC-05** — supply chain requirements addressed in contracts | Contract language for vendor cybersecurity | Standard cybersecurity contract clauses; sample executed vendor agreements |
+
+### Identify (ID) — context, assets, risk assessment, improvement
+
+Identify evidence is mostly **inventories and assessments**.
+
+| Representative Subcategory | What it asks for | Evidence |
+|---|---|---|
+| **ID.AM-01** — hardware inventory maintained | Asset inventory of physical devices | Asset inventory export (CMDB / IT asset management tool); reconciliation cadence record |
+| **ID.AM-02** — software inventory maintained | Software inventory | Software asset management export; SBOM (software bill of materials) where applicable |
+| **ID.AM-03** — data flows mapped | Data flow diagrams and data inventory | Data flow diagrams; data classification register; data lineage documentation |
+| **ID.AM-05** — assets prioritized based on classification, criticality, business value | Asset criticality / classification scheme | Asset classification scheme; tier assignment per system; review record |
+| **ID.RA-01** — vulnerabilities in assets identified, validated, recorded | Vulnerability management process | Vulnerability scan reports; remediation ticket samples; SLA / process documentation |
+| **ID.RA-05** — threats, vulnerabilities, likelihoods, impacts used to determine risk | Risk assessment methodology and outputs | Risk assessment report; risk register; methodology documentation (often NIST SP 800-30 aligned) |
+| **ID.IM-01** — improvements identified from evaluations | Lessons-learned and continuous improvement | Post-incident review reports; security program review minutes; improvement backlog |
+
+### Protect (PR) — identity, training, data, platform, infrastructure
+
+Protect evidence is the largest bucket and is mostly **technical configuration plus operational records**.
+
+| Representative Subcategory | What it asks for | Evidence |
+|---|---|---|
+| **PR.AA-01** — identities and credentials managed | Identity and access management baseline | IAM configuration export (cloud IdP / Active Directory / Entra / Okta); user provisioning workflow documentation |
+| **PR.AA-03** — users, services, hardware authenticated commensurate with risk | Authentication strength | MFA enrollment / enforcement reports; authentication policy; service-account inventory |
+| **PR.AA-05** — access permissions managed per least privilege and separation of duties | Role-based access and separation of duties | RBAC role definitions; access review records; SoD conflict matrix |
+| **PR.AT-01** — personnel awareness training | Security awareness training program | Training completion reports; training content / curriculum; phishing simulation results |
+| **PR.DS-01** — data-at-rest protected | Encryption at rest | Encryption configuration evidence (KMS keys, storage encryption settings); key rotation records |
+| **PR.DS-02** — data-in-transit protected | Encryption in transit | TLS configuration evidence; cert inventory; mTLS / VPN configuration where applicable |
+| **PR.DS-10** — data integrity protected | Integrity controls | Hash / signature verification logs; tamper-evident logging; change-detection alerts |
+| **PR.PS-01** — configuration baselines maintained | System hardening baselines | CIS Benchmark scan reports; STIG compliance reports; configuration management tool (Puppet/Chef/Ansible/Terraform) state |
+| **PR.PS-04** — log records generated and made available | Logging coverage | Logging architecture diagram; log source inventory; SIEM ingestion proof |
+| **PR.PS-06** — secure software development practices | Secure SDLC | SAST / DAST scan results; code review records; security gates in CI/CD pipeline |
+| **PR.IR-01** — networks and environments protected from unauthorized access | Network segmentation and perimeter | Network architecture diagrams; security group / firewall rule exports; segmentation test results |
+| **PR.IR-04** — adequate resource capacity ensures availability | Capacity and resilience | Capacity planning documents; load test results; auto-scaling configuration |
+
+### Detect (DE) — continuous monitoring, adverse event analysis
+
+Detect evidence is mostly **monitoring config + log samples + alert records**.
+
+| Representative Subcategory | What it asks for | Evidence |
+|---|---|---|
+| **DE.CM-01** — networks and network services monitored to find adverse events | Network monitoring | SIEM dashboard screenshots / exports; NDR / IDS configuration; sample alerts |
+| **DE.CM-03** — personnel activity monitored to find adverse events | UEBA / insider threat detection | UEBA tool configuration; sample anomalous-activity alerts; data access monitoring |
+| **DE.CM-06** — external service provider activities monitored | Third-party access monitoring | Vendor access audit logs; CASB configuration; sample alerts on third-party anomalies |
+| **DE.CM-09** — computing hardware/software, runtime environments, configurations monitored | Endpoint and configuration drift monitoring | EDR configuration; configuration drift reports; sample drift alerts |
+| **DE.AE-02** — potentially adverse events analyzed to better understand activity | Triage and analysis | SOC playbooks; analyst notes / case management records; sample triaged events |
+| **DE.AE-04** — estimated impact and scope of adverse events understood | Impact / scope assessment | Incident severity scoring rubric; sample severity assignments; escalation criteria |
+| **DE.AE-06** — information about adverse events provided to authorized staff/tools | Alert routing | Alert routing rules; on-call / paging configuration; escalation matrix |
+
+### Respond (RS) — incident management, analysis, communication, mitigation
+
+Respond evidence is mostly **incident records, runbooks, and after-action reports**.
+
+| Representative Subcategory | What it asks for | Evidence |
+|---|---|---|
+| **RS.MA-01** — incident response plan executed in coordination with relevant third parties | IR plan in use | Incident response plan; sample incident records; tabletop exercise reports |
+| **RS.MA-02** — incidents categorized and prioritized | Incident classification scheme | Severity / category taxonomy; sample categorized incidents |
+| **RS.AN-03** — analysis performed to establish what has happened during an incident | Forensic / analysis capability | Forensic analysis reports; chain-of-custody logs (where applicable); analysis tool inventory |
+| **RS.CO-02** — internal and external stakeholders notified of incidents | Stakeholder notification | Communication plan; sample notification records (internal and external); regulator notification samples (HHS OCR, state AGs, etc., where applicable) |
+| **RS.CO-03** — information shared with designated internal and external stakeholders | Cross-functional coordination | Sample executive briefings; sample post-incident customer notifications |
+| **RS.MI-01** — incidents contained | Containment | Sample containment actions; runbook for containment; quarantine / isolation evidence |
+| **RS.MI-02** — incidents eradicated | Eradication | Eradication runbooks; sample eradication action records (malware removal, account disablement, etc.) |
+
+### Recover (RC) — recovery plan execution, recovery communication
+
+Recover evidence is mostly **BCDR plans, test reports, and recovery records**.
+
+| Representative Subcategory | What it asks for | Evidence |
+|---|---|---|
+| **RC.RP-01** — recovery portion of incident response plan executed | Recovery plan in use | BCDR plan; sample recovery records; recovery time achieved vs RTO |
+| **RC.RP-02** — recovery actions selected, scoped, prioritized | Recovery prioritization | Recovery priority ranking; sample prioritization decisions during exercises |
+| **RC.RP-03** — integrity of backups and other restoration assets verified before use | Backup integrity | Backup verification logs; sample restoration tests; integrity check evidence |
+| **RC.RP-04** — critical mission functions and cybersecurity risk management considered to establish post-incident operational norms | Post-incident operational baseline | Post-incident operating model; sample reset-state documentation |
+| **RC.RP-06** — end of incident recovery declared and incident-related documentation completed | Recovery closeout | Sample closeout records; lessons-learned reports; incident closure approvals |
+| **RC.CO-03** — recovery activities and progress communicated to designated stakeholders | Recovery communication | Sample recovery status updates; executive / customer / regulator communication records |
+
+## Reusing evidence across frameworks
+
+CSF evidence is highly reusable. If the organization is also subject to:
+
+- **HIPAA Security Rule** — most PR and DE evidence (encryption configs, audit logs, training records, BAAs) doubles as HIPAA evidence
+- **PCI DSS v4.0.1** — PR.AA, PR.DS, DE.CM evidence covers most of the PCI technical requirements within CDE scope
+- **NIST SP 800-53 Rev. 5** — direct mapping via Informative References; reuse 800-53 control evidence wholesale
+- **ISO/IEC 27001:2022** — Annex A controls map to CSF Subcategories; reuse ISO ISMS evidence
+- **GLBA Safeguards Rule** — Govern + Identify + Protect evidence covers most of the Safeguards Rule's written-program requirements
+- **SOX ITGC** — PR.AA (access control), PR.PS-01 (configuration baselines), DE.CM (monitoring) feed ITGC testing
+
+Use `/grc-engineer:optimize-multi-framework` to plan evidence collection that satisfies multiple frameworks at once. Avoid duplicating collection effort.
+
+## Retention
+
+CSF imposes no specific retention period. In practice, retain evidence for at least:
+
+- **3 years** for general CSF Profile assessment artifacts (most cyber insurance carriers and federal contracting officers expect this)
+- **6 years** if the same evidence supports HIPAA Security Rule (45 CFR §164.316(b)(2))
+- **As specified by sector regulator** if the evidence is reused for FERC/NERC, FFIEC, PCI DSS, etc. — those regulators' retention requirements govern.
+- **As specified by state law** for breach-related evidence — varies by state; conservative default is 7 years.
+
+## Examples
+
+```
+# Full evidence checklist (all six Functions)
+/nist-csf-20:evidence-checklist
+
+# Govern Function evidence only — useful for board reporting prep
+/nist-csf-20:evidence-checklist --function=GV
+
+# Detect + Respond + Recover for an IR readiness engagement
+/nist-csf-20:evidence-checklist --function=DE
+/nist-csf-20:evidence-checklist --function=RS
+/nist-csf-20:evidence-checklist --function=RC
+
+# CSV export for spreadsheet-driven evidence tracking
+/nist-csf-20:evidence-checklist --format=csv
+```
+
+## Related commands
+
+- `/nist-csf-20:scope` — define Profile / Tier / Function scope before collecting evidence
+- `/nist-csf-20:assess` — gap-assess the collected evidence against the Target Profile
+- `/grc-engineer:gap-assessment general-nist-csf-2-0` — direct SCF-crosswalk-driven assessment
+
+---
+
+**Framework**: NIST Cybersecurity Framework v2.0 (final, February 26, 2024)
+**SCF ID**: `general-nist-csf-2-0`
+**Status**: Voluntary; widely adopted as a U.S. and international cybersecurity baseline

--- a/plugins/frameworks/nist-csf-20/commands/scope.md
+++ b/plugins/frameworks/nist-csf-20/commands/scope.md
@@ -1,0 +1,132 @@
+---
+description: Determine NIST CSF 2.0 applicability, Profile scope, Tier target, and Function selection for the organization
+---
+
+# NIST CSF 2.0 Scope
+
+Determines how **NIST Cybersecurity Framework v2.0** should be applied to the organization. CSF is voluntary and cross-sector — there is no "in scope vs out of scope" determination in the regulatory sense. Instead, this command answers the practitioner questions: *which Functions, which Profile target, which Tier target, which sector overlay?*
+
+## Usage
+
+```
+/nist-csf-20:scope
+```
+
+## What this produces
+
+- **Applicability rationale** — *why* the organization is using CSF (federal contract, sector regulator alignment, board reporting, internal management), and what that implies for breadth/depth
+- **Functions in scope** — typically all six (GV, ID, PR, DE, RS, RC), but a Profile may legitimately defer some Subcategories
+- **Tier target** — Tier 1, 2, 3, or 4, with rationale grounded in risk tolerance and resourcing
+- **Profile starting point** — build from scratch, adapt a published Community Profile, or migrate from an existing CSF 1.1 Profile
+- **Sector overlays** — which sector regulator(s) the CSF Profile must support (HIPAA, GLBA, PCI DSS, NERC CIP, FFIEC, TSA, etc.)
+- **Next steps** — whether to proceed with `/nist-csf-20:evidence-checklist` (collection) or `/nist-csf-20:assess` (gap analysis)
+
+## Pre-scope questions
+
+Before producing scope output, confirm with the user:
+
+### 1. Why is the organization using CSF?
+
+Pick the *primary* driver (multiple may apply, but one usually dominates):
+
+- **Federal contract requirement** — solicitation explicitly references CSF or asks for a Profile
+- **Sector regulator alignment** — CSF Profile feeds into HIPAA, GLBA, PCI DSS, NERC CIP, FFIEC, TSA, or similar examinations
+- **EO 14028 / critical infrastructure** — operator of critical infrastructure adopting the U.S. national cybersecurity baseline
+- **SEC cybersecurity disclosure** — public company structuring its Reg S-K Item 106 disclosures around CSF Functions
+- **Cyber insurance** — carrier requesting CSF Profile / Tier as part of underwriting
+- **Board / audit committee reporting** — CISO needs a stable communication framework for governance reporting
+- **Internal program management** — first formal cybersecurity program, building from CSF as the structure
+- **State affirmative-defense statute** — qualifying for a state safe-harbor in breach litigation (Connecticut, Ohio, Utah, others)
+- **CSF 1.1 → 2.0 migration** — existing CSF 1.1 Profile being upgraded to CSF 2.0
+
+The driver determines the level of evidence rigor and the cadence of reassessment.
+
+### 2. Which version is in play?
+
+- CSF 2.0 (this plugin) — published February 26, 2024
+- CSF 1.1 — superseded but still referenced by some contracts and regulators
+
+If existing artifacts reference 1.1, plan a migration. The Govern (GV) Function is new in 2.0; many ID Subcategories from 1.1 (especially supply chain) moved into GV.SC.
+
+### 3. What sector(s) is the organization in?
+
+CSF is cross-sector, but several **Community Profiles** exist for specific sectors. Using a Community Profile as the starting Target Profile is faster and more defensible than building from scratch. Confirm whether one applies:
+
+- Manufacturing (CSF Manufacturing Profile)
+- Election infrastructure
+- Electric grid / energy sector
+- Healthcare
+- Telecommunications
+- Federal civilian (alongside SP 800-53)
+- Smart Grid / OT
+- Other published Community Profiles — check the NIST CSF 2.0 Reference Tool
+
+### 4. What other frameworks does the organization already comply with?
+
+This dictates what evidence is reusable. Common combinations:
+
+- **HIPAA Security Rule** — most ePHI controls roll up under PR.DS, PR.AA, DE.CM, RS.MA, RC.RP
+- **PCI DSS v4.0.1** — cardholder data controls roll up under PR.DS, PR.AA, DE.CM
+- **NIST SP 800-53 Rev. 5** — direct Informative Reference; FedRAMP / federal systems
+- **NIST SP 800-171 Rev. 3 / CMMC** — DIB / CUI
+- **ISO/IEC 27001:2022** — international ISMS; Annex A is an Informative Reference
+- **CIS Controls v8** — community catalog; Informative Reference
+- **GLBA Safeguards Rule** — financial institutions
+- **SOX ITGCs** — public-company financial-reporting IT controls
+
+Reuse evidence; do not collect twice.
+
+### 5. What's the Tier target?
+
+Refer the user to the SKILL's Tier section. Anchors:
+
+- **Tier 1 (Partial)** — startup with limited cybersecurity capability; CSF being adopted as the structure for building a first program
+- **Tier 2 (Risk Informed)** — established cybersecurity practices, but not consistently policy-backed or organization-wide. Common starting point for mid-market.
+- **Tier 3 (Repeatable)** — formalized policies, consistent application, integrated supply chain risk management. Common target for regulated mid-market and large enterprise.
+- **Tier 4 (Adaptive)** — risk management adapts based on lessons learned and predictive indicators; cybersecurity culturally integrated. High-resource organizations with high risk exposure.
+
+A reasonable default for an organization in the "we should formalize this" stage is **Current Tier 1, Target Tier 3, achievable over 18–24 months** — but the right answer is whatever reflects the organization's actual risk tolerance and resourcing.
+
+### 6. Which Functions are in scope?
+
+The default is all six (GV, ID, PR, DE, RS, RC). Legitimate reasons to narrow:
+
+- Pure design / architecture engagement → GV + ID + PR (defer DE/RS/RC if they're handled by a separate operations team)
+- Incident readiness engagement → DE + RS + RC (assume GV/ID/PR baseline established)
+- Governance refresh → GV alone (the new 2.0 Function), often done as a discrete project
+
+Document the rationale; partial Function scope tends to surface during board reporting and is worth defending in writing.
+
+## Output format
+
+After collecting the answers above, produce a scope memo with:
+
+```
+NIST CSF 2.0 Scope — <Organization Name>
+
+Driver:           <primary driver>
+CSF version:      2.0  (migrating from 1.1: yes/no)
+Sector(s):        <sectors>
+Community Profile: <selected Community Profile or "build from scratch">
+Functions in scope: GV, ID, PR, DE, RS, RC  (or narrowed list with rationale)
+Tier — current:   <T1 / T2 / T3 / T4>
+Tier — target:    <T1 / T2 / T3 / T4>
+Reassessment cadence: annual / quarterly / triggered-only
+Coexisting frameworks: <HIPAA / PCI DSS / 800-53 / ISO 27001 / etc>
+Sector regulator overlays: <FERC/NERC, HHS/HPH, FFIEC, TSA, etc>
+Next steps:       /nist-csf-20:evidence-checklist  →  /nist-csf-20:assess
+```
+
+## What this command does NOT do
+
+- It does not impose Functions or Tiers — those are organizational decisions informed by risk tolerance and resourcing.
+- It does not certify the organization as "CSF compliant" — there is no CSF certification (see SKILL: Common misinterpretations).
+- It does not enumerate every Subcategory — that's `/nist-csf-20:assess` (control-by-control gap) and `/nist-csf-20:evidence-checklist` (per-Function evidence patterns).
+- It does not replace sector-regulator scoping (HIPAA, PCI DSS, etc.). If the organization is regulated, run the regulator-specific scope command first; CSF scope is an overlay.
+
+## Related commands
+
+- `/nist-csf-20:assess` — run the gap assessment once scope is defined
+- `/nist-csf-20:evidence-checklist` — enumerate evidence patterns per Function
+- `/grc-engineer:gap-assessment general-nist-csf-2-0` — direct SCF-crosswalk-driven assessment
+- `/grc-engineer:optimize-multi-framework` — when CSF is being implemented alongside multiple regulations

--- a/plugins/frameworks/nist-csf-20/skills/nist-csf-20-expert/SKILL.md
+++ b/plugins/frameworks/nist-csf-20/skills/nist-csf-20-expert/SKILL.md
@@ -91,7 +91,7 @@ Total Categories in CSF 2.0: 22 (compared to 23 in CSF 1.1 — the structure was
 
 ### 3. Subcategories
 
-Subcategories are the leaf nodes — concrete cybersecurity outcomes phrased as statements (not directives). CSF 2.0 has roughly 106 Subcategories. They're coded as `<Function>.<Category>-<Number>`. Examples:
+Subcategories are the leaf nodes — concrete cybersecurity outcomes phrased as statements (not directives). CSF 2.0 has 106 official Subcategories. The SCF crosswalk used by this plugin resolves those outcomes into 134 mappable entries for assessment and reporting. CSF Subcategories are coded as `<Function>.<Category>-<Number>`. Examples:
 
 - **GV.OC-01** — The organizational mission is understood and informs cybersecurity risk management
 - **PR.AA-01** — Identities and credentials for authorized users, services, and hardware are managed by the organization

--- a/plugins/frameworks/nist-csf-20/skills/nist-csf-20-expert/SKILL.md
+++ b/plugins/frameworks/nist-csf-20/skills/nist-csf-20-expert/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: nist-csf-20-expert
+description: NIST Cybersecurity Framework v2.0 expert. Reference-depth knowledge of the six Functions (Govern, Identify, Protect, Detect, Respond, Recover), Categories and Subcategories, Profiles (Current vs Target), Tiers, Implementation Examples, and the practitioner workflow of using CSF as a board-readable cybersecurity outcomes language. Backed by the SCF crosswalk for control-by-control mechanics.
+allowed-tools: Read, Glob, Grep, Write
+---
+
+# NIST Cybersecurity Framework (v2.0) Expert
+
+Reference-depth expertise for **NIST Cybersecurity Framework v2.0** — the cross-sector outcomes-based framework published by the U.S. National Institute of Standards and Technology. CSF 2.0 is the most widely adopted cybersecurity framework in the United States and is increasingly used worldwide as a common vocabulary for board-level and regulator-facing cybersecurity discussions.
+
+This plugin bundles the SCF crosswalk (250 SCF controls → 134 CSF Subcategories) with framework-specific scope, assessment, and evidence guidance.
+
+## Framework identity
+
+- **SCF framework ID**: `general-nist-csf-2-0`
+- **Publisher**: NIST (National Institute of Standards and Technology), U.S. Department of Commerce
+- **Version**: 2.0 (final)
+- **Released**: February 26, 2024 (supersedes CSF 1.1, April 2018)
+- **Region**: Global (U.S.-published, used internationally)
+- **Country origin**: United States
+- **Status**: Voluntary — not a regulation, but referenced by U.S. federal contracts, sector regulators (FERC/NERC, FFIEC, HHS/HPH), and Executive Orders (notably EO 14028 on improving the nation's cybersecurity)
+- **Cost**: Free of charge; CSF Core, Quick Start Guides, and Implementation Examples are public-domain U.S. government works
+- **Successor relationship**: CSF 2.0 supersedes CSF 1.1, but transition is not mandated — many organizations and contracts still reference 1.1 in 2026
+
+## Framework in plain language
+
+CSF 2.0 is a cybersecurity outcomes framework, not a control catalog. Its job is to give an organization a small, common vocabulary it can use to (a) describe what cybersecurity outcomes it currently achieves, (b) describe what it wants to achieve, and (c) plan the gap between the two. The framework deliberately avoids prescribing *how* to achieve outcomes — that's what control catalogs like NIST SP 800-53, ISO 27001 Annex A, and CIS Controls are for. CSF cites those catalogs as **Informative References**.
+
+The headline change in CSF 2.0 is the addition of the **Govern (GV)** Function. CSF 1.1 had five Functions — Identify, Protect, Detect, Respond, Recover — which describe the lifecycle of a cybersecurity event. CSF 2.0 adds Govern as a cross-cutting Function that holds the board, executives, and risk-management processes accountable for the cybersecurity program itself, not just for responding to events. This change reflects what regulators, boards, and the SEC's 2023 cybersecurity disclosure rule have been pushing for years.
+
+## Territorial scope and applicability
+
+CSF is **voluntary** and **cross-sector**. It does not impose territorial obligations on its own. Practical sweet spots where it's the right framework to reach for:
+
+- **U.S. federal contractors** before they're mature enough for full NIST SP 800-53 compliance — CSF gives them a defensible structure and a glide path
+- **Critical infrastructure operators** under EO 14028 and sector-specific guidance (energy, water, transportation, healthcare, financial services) — CSF is the U.S. government's preferred shared vocabulary
+- **Healthcare and finance** organizations that already comply with HIPAA, GLBA, or PCI DSS and want a board-readable summary that maps cleanly to those underlying frameworks
+- **Mid-market organizations** building a first formal cybersecurity program — CSF Tier 1 → Tier 2 → Tier 3 progression scales gracefully
+- **International organizations** using CSF as a U.S.-aligned reference alongside ISO/IEC 27001 (Informative References include ISO 27001:2022 mappings)
+- **Private-sector boards and audit committees** who want a single page of "what we do for cybersecurity" that is not a 1,200-control spreadsheet
+
+CSF is **not** a substitute for sectoral regulation. A hospital still owes HIPAA Security Rule compliance regardless of its CSF posture; a bank still owes GLBA Safeguards Rule; a defense contractor still owes CMMC. CSF sits *above* those — it's the shared language a CISO uses to explain the program to a board that doesn't read CFR citations.
+
+## The CSF Core: Functions, Categories, Subcategories
+
+CSF is organized hierarchically. The Core has three layers:
+
+### 1. Functions (6)
+
+The Functions are the highest-level grouping and the single most important thing to memorize. CSF 2.0 has six:
+
+| Code | Function | What it covers |
+|---|---|---|
+| **GV** | **Govern** | Cybersecurity strategy, expectations, policy, roles, risk tolerance, supply chain risk management, oversight. New in 2.0. |
+| **ID** | **Identify** | Asset management, business environment, risk assessment, improvement. Understand your context. |
+| **PR** | **Protect** | Identity management and access control, awareness and training, data security, platform security, technology infrastructure resilience. |
+| **DE** | **Detect** | Continuous monitoring, adverse event analysis. |
+| **RS** | **Respond** | Incident management, analysis, response reporting and communication, mitigation. |
+| **RC** | **Recover** | Incident recovery plan execution, recovery communication. |
+
+The mnemonic the community uses is **GIPDRR** (or **G + IPDRR**, since IPDRR was the CSF 1.x ordering). Note that **Govern is not the first Function executed during an incident** — it's the wrapper around all the others. In Profile work and assessments, Govern outcomes are typically written and approved *before* the Identify/Protect/Detect/Respond/Recover capabilities are stood up, but in continuous operation Govern runs in parallel with everything else.
+
+### 2. Categories
+
+Each Function decomposes into **Categories**. Categories are coded as `<Function>.<Category>`. Examples that come up constantly in practice:
+
+- **GV.OC** — Organizational Context (mission, stakeholder expectations, legal/regulatory requirements, threat landscape)
+- **GV.RM** — Risk Management Strategy (risk tolerance, risk appetite statements, integration with enterprise risk)
+- **GV.RR** — Roles, Responsibilities, and Authorities (RACI for cybersecurity decisions)
+- **GV.PO** — Policy
+- **GV.OV** — Oversight (board reporting, independent review)
+- **GV.SC** — Cybersecurity Supply Chain Risk Management (C-SCRM, expanded substantially from CSF 1.1's ID.SC)
+- **ID.AM** — Asset Management
+- **ID.RA** — Risk Assessment
+- **ID.IM** — Improvement (lessons learned, continuous improvement)
+- **PR.AA** — Identity Management, Authentication, and Access Control
+- **PR.AT** — Awareness and Training
+- **PR.DS** — Data Security
+- **PR.PS** — Platform Security
+- **PR.IR** — Technology Infrastructure Resilience
+- **DE.CM** — Continuous Monitoring
+- **DE.AE** — Adverse Event Analysis
+- **RS.MA** — Incident Management
+- **RS.AN** — Incident Analysis
+- **RS.CO** — Incident Response Reporting and Communication
+- **RS.MI** — Incident Mitigation
+- **RC.RP** — Incident Recovery Plan Execution
+- **RC.CO** — Incident Recovery Communication
+
+Total Categories in CSF 2.0: 22 (compared to 23 in CSF 1.1 — the structure was rebalanced as part of the Govern restructuring).
+
+### 3. Subcategories
+
+Subcategories are the leaf nodes — concrete cybersecurity outcomes phrased as statements (not directives). CSF 2.0 has roughly 106 Subcategories. They're coded as `<Function>.<Category>-<Number>`. Examples:
+
+- **GV.OC-01** — The organizational mission is understood and informs cybersecurity risk management
+- **PR.AA-01** — Identities and credentials for authorized users, services, and hardware are managed by the organization
+- **DE.CM-01** — Networks and network services are monitored to find potentially adverse events
+- **RS.MA-01** — The incident response plan is executed in coordination with relevant third parties once an incident is declared
+
+Subcategories are the **assessment unit**. When practitioners say "we're at Partial on PR.AA-01 and Repeatable on DE.CM-01," they're scoring at the Subcategory level. This plugin's `evidence-checklist` command is organized by Function → Category → representative Subcategories.
+
+## Implementation Examples (new in 2.0)
+
+CSF 2.0 introduced **Implementation Examples** — short, concrete actions an organization can take to achieve a Subcategory's outcome. These are intentionally not exhaustive and not prescriptive; they're a starting point. They are published in the NIST CSF 2.0 Reference Tool alongside each Subcategory.
+
+Implementation Examples are not the same as **Informative References**. References point to *other catalogs* (NIST SP 800-53, ISO 27001:2022, CIS Controls v8, etc.); Examples describe *actions* an organization can take directly. Cite Implementation Examples by Subcategory ID and the example's enumeration in the published CSF 2.0 Reference Tool — do not paste the Example text verbatim into customer-facing artifacts.
+
+## Profiles: the primary practitioner workflow
+
+The Profile is where CSF stops being theoretical and starts being useful. A Profile is just a list of Subcategories with annotations. The practitioner workflow:
+
+1. **Current Profile** — Walk every (in-scope) Subcategory. For each, document:
+   - Which controls / processes / tools currently meet the outcome
+   - The maturity / completeness of that implementation (often expressed via Tier or a custom rubric)
+   - Evidence that demonstrates it (logs, configs, policies, tickets)
+   - Gaps and blockers
+2. **Target Profile** — Decide which Subcategories the organization wants to achieve, and to what degree. Targets are informed by:
+   - Mission, business objectives, threat landscape (GV.OC outcomes)
+   - Risk tolerance and appetite (GV.RM outcomes)
+   - Legal and regulatory obligations (GV.OC-03)
+   - Cost / benefit, capacity to execute
+3. **Gap analysis** — The delta between Current and Target. This becomes the prioritized backlog for the next fiscal year (or whatever planning cycle the organization uses).
+4. **Action plan / roadmap** — Initiatives with owners, milestones, budget asks, and Subcategory-level success criteria.
+5. **Reassessment cadence** — Most organizations reassess the Current Profile annually, with quarterly or monthly check-ins on initiatives in flight.
+
+CSF 2.0 publishes **Community Profiles** for specific contexts (e.g., manufacturing, election security, electric grid). Community Profiles are pre-built Target Profiles maintained by NIST or industry working groups; using one short-circuits a lot of the "what should our Target Profile look like?" debate. Always check whether a Community Profile exists for the organization's sector before building one from scratch.
+
+## Tiers (1–4): rigor of risk management practices, NOT maturity
+
+This is the single most-misunderstood part of CSF. The Tiers describe **how rigorous and integrated the organization's cybersecurity risk management practices are** — not how many controls it has, not how technically mature its security tooling is.
+
+| Tier | Name | Plain-language description |
+|---|---|---|
+| **1** | Partial | Risk management is ad hoc, reactive, often informal. Awareness limited. Governance and supply chain risk practices not formalized. |
+| **2** | Risk Informed | Risk management practices are approved by management but not established as organization-wide policy. Some prioritization happens. Governance present but inconsistent. |
+| **3** | Repeatable | Risk management practices are formally approved, expressed as policy, applied consistently. Governance is regular. Supply chain risk management is integrated. Continuous awareness. |
+| **4** | Adaptive | Risk management practices adapt to changing threats based on lessons learned and predictive indicators. Cybersecurity risk is integrated into enterprise risk culture. Continuous improvement. |
+
+Two critical points:
+
+1. **Tier 4 is not the goal for every organization.** A Tier 2 posture may be entirely appropriate for a small business with low risk exposure. Pushing a Tier 1 organization to Tier 4 in one cycle is unrealistic and usually counterproductive.
+2. **Tiers are not assigned per Subcategory** — they characterize the *organization's overall risk-management practice*. Subcategory implementations are scored separately (typically against a custom rubric in the Current/Target Profile work).
+
+## Informative References
+
+CSF 2.0 Subcategories map to other widely-used catalogs through **Informative References**. These are maintained in the NIST CSF 2.0 Reference Tool and updated periodically. The official mappings include (non-exhaustive):
+
+- **NIST SP 800-53 Rev. 5** — controls catalog used by U.S. federal systems and FedRAMP
+- **NIST SP 800-171 Rev. 3** — controls for protecting CUI in non-federal systems (relevant to CMMC)
+- **NIST SP 800-221A** — enterprise risk management for cybersecurity
+- **ISO/IEC 27001:2022** — Annex A controls
+- **CIS Controls v8** — community-curated control set
+- **COBIT 2019** — IT governance framework
+
+Treat Informative References as a starting point, not a substitute for the underlying frameworks. If an organization is implementing controls to satisfy ISO 27001:2022 certification, the ISO standard's normative text governs — CSF references it, but auditors against ISO 27001 will assess against the ISO text directly.
+
+## Cadence and timelines
+
+CSF itself doesn't impose timelines (it's voluntary), but practitioners should plan around:
+
+- **Annual Profile reassessment** — refresh Current Profile, validate Target Profile, recompute gap. Common alignment with fiscal year for budget asks.
+- **Quarterly initiative review** — review the action plan, update Subcategory status for items in flight.
+- **Triggered reassessment** — material changes (new business line, M&A, major incident, new regulation, significant supply chain shift) should trigger a partial reassessment of affected Functions.
+- **Board reporting cadence** — most CISOs report Function-level summary metrics to the board quarterly or semi-annually. CSF's Function structure gives the board a stable mental model that doesn't change every quarter.
+
+For organizations using CSF to support sector regulation (e.g., NERC CIP audits, HIPAA risk analyses, PCI DSS Reports on Compliance), the *regulator's* cadence governs — CSF assessment work is usually scheduled to feed into those external assessments rather than the other way around.
+
+## Regulator and enforcement
+
+CSF is **voluntary**. NIST is a measurement and standards body, not a regulator, and does not enforce CSF. There are no fines, no mandatory audits, no certification body for CSF itself.
+
+What CSF posture *does* affect:
+
+- **Federal contracts** — solicitations increasingly request a "CSF Profile" or "CSF Tier" as an attachment. Misrepresentation here can become a False Claims Act issue.
+- **Sector regulator examinations** — FERC/NERC (energy), FFIEC (banking), HHS/HPH (healthcare), TSA (transportation/pipeline) reference CSF or align their examination programs with it. A weak CSF posture often correlates with weak findings in those examinations.
+- **State law** — a few U.S. states (e.g., Connecticut, Ohio, Utah) provide affirmative defense or safe harbor in data breach litigation if the defendant followed a recognized framework like CSF. This is a litigation defense lever, not regulatory enforcement.
+- **Cyber insurance underwriting** — carriers increasingly use CSF Function maturity as an underwriting input.
+- **SEC cybersecurity disclosure (Item 106 of Reg S-K)** — public companies must describe their cybersecurity risk management, strategy, and governance. CSF's Govern Function gives a clean structure for that disclosure.
+
+There is **no CSF certification**. Vendors offering "CSF certified" products or assessors are using the term loosely; NIST does not accredit or certify against CSF.
+
+## Interaction with other frameworks
+
+CSF is designed to play well with others. Common interactions:
+
+- **CSF + NIST SP 800-53** — CSF Subcategories cite 800-53 controls as Informative References. A federal system using 800-53 baseline controls can roll those up into CSF Subcategory status. This is the canonical pairing for federal contractors.
+- **CSF + ISO/IEC 27001:2022** — CSF Subcategories cite ISO Annex A. Many international organizations use ISO 27001 for the certifiable ISMS and CSF as the U.S.-aligned reporting layer above it.
+- **CSF + CIS Controls v8** — CIS Controls are a more prescriptive, action-oriented set. Organizations often start with CIS for technical hardening and use CSF Profiles to communicate program maturity upward.
+- **CSF + CMMC** — CMMC Levels 1/2/3 build on NIST SP 800-171/172. CSF doesn't replace CMMC, but CSF Profile work is a useful pre-engagement sanity check before a C3PAO assessment.
+- **CSF + HIPAA Security Rule** — HHS OCR audit protocols map to CSF. Many healthcare organizations use the CSF as the umbrella and HIPAA Security Rule controls as the implementation evidence under PR/DE/RS/RC Functions.
+- **CSF + PCI DSS v4.0.1** — CSF doesn't satisfy PCI DSS, but PCI DSS controls map cleanly into PR.DS (data security), PR.AA (access control), DE.CM (monitoring) Subcategories.
+- **CSF + NIS2 (EU)** — both are outcomes-oriented. NIS2 imposes obligations on essential and important entities operating in the EU; CSF can be used as the internal cybersecurity management framework that demonstrates NIS2-required risk management measures.
+
+For multi-framework optimization and crosswalk-driven implementation work, see `/grc-engineer:optimize-multi-framework` and `/grc-engineer:map-controls-unified`.
+
+## Common misinterpretations
+
+Reference-depth practitioners should be ready to correct these in conversations with engineers, executives, and auditors:
+
+1. **"CSF tells us *what controls to implement*."** No. CSF describes outcomes (Subcategories). Controls live in 800-53, ISO 27001 Annex A, CIS Controls v8, etc. Use CSF to organize and communicate; use a control catalog to actually implement.
+2. **"We need to be Tier 4."** Tier 4 is not the universal target. Tier 4 is appropriate for organizations with high risk exposure, mature operations, and the resources to sustain adaptive practices. Many organizations are appropriately at Tier 2 or Tier 3.
+3. **"Tiers describe maturity per control."** Tiers describe the *organization's overall risk-management practice* — not per-Subcategory implementation maturity. Subcategory status is scored separately.
+4. **"CSF 2.0 is mandatory for federal contractors."** Not directly. Specific contracts may require it; FAR/DFARS reference NIST SP 800-171 and (increasingly) CMMC, not CSF directly. CSF is often used in early stages of a contractor's compliance journey or as an internal management tool.
+5. **"Govern is just policy."** Govern (GV) covers strategy, expectations, policy, roles, oversight, risk management, *and* C-SCRM (supply chain risk). It's substantially broader than "writing policy documents."
+6. **"CSF replaces our existing framework."** It does not. CSF is a layer above existing frameworks. Most organizations keep their existing control work (ISO 27001, 800-53, HIPAA, PCI DSS, etc.) and use CSF as the communication and prioritization layer.
+7. **"There's a CSF certification."** There is not. Beware vendors marketing "CSF certified" products or services.
+8. **"CSF 1.1 is end-of-life."** CSF 2.0 supersedes 1.1, but NIST has not set a sunset date for 1.1 references. Many existing contracts, regulations, and assessment programs still reference 1.1. Plan a migration; do not panic.
+
+## Mandatory artifacts
+
+Because CSF is voluntary and outcomes-based, there are no NIST-mandated artifacts. However, practitioner experience consistently produces (and assessors / regulators / boards consistently expect) the following deliverables when an organization claims a CSF posture:
+
+- **Current Profile** — Subcategory-by-Subcategory snapshot of present-state outcomes, with evidence pointers.
+- **Target Profile** — Subcategory-by-Subcategory desired-state outcomes, often informed by a Community Profile.
+- **Gap analysis** — explicit delta between Current and Target, with severity / effort scoring.
+- **Action plan** — initiatives mapped to Subcategories, with owners, milestones, budget asks.
+- **Tier statement** — organization's self-assessed Tier (1–4) with rationale and the Tier the organization is targeting.
+- **Govern outputs** — board-approved cybersecurity strategy, written cybersecurity policies, RACI for cybersecurity decisions, supply chain risk management process documentation.
+
+Federal contractors and regulated entities should additionally produce mappings from their CSF Profile to the underlying regulation's control catalog (800-53, 800-171, HIPAA, PCI DSS, etc.) so that CSF artifacts can be reused as evidence across multiple compliance regimes.
+
+## Assessment workflow (what this plugin produces)
+
+When using this plugin, the typical workflow is:
+
+```
+1. /nist-csf-20:scope             # decide what's in scope, pick or build a Target Profile
+2. /nist-csf-20:assess            # run the gap assessment via SCF crosswalk
+3. /nist-csf-20:evidence-checklist # enumerate evidence per Function/Category
+```
+
+Underneath, all three commands delegate the control-by-control mechanics to `/grc-engineer:gap-assessment` with SCF framework ID `general-nist-csf-2-0`. This plugin contributes:
+
+- The CSF-specific scope decision tree (Functions in scope, Tier target, Community Profile selection)
+- CSF-specific framing of the gap assessment output (organized by Function and Category, not by SCF family)
+- Evidence patterns organized by Function with representative Subcategories per Function
+
+For citation purposes, refer to the **NIST CSF 2.0 Quick Start Guides** (NIST SP 1300 series — `1300`, `1301`, etc., each addressing a specific audience or topic) and the public NIST CSF 2.0 Reference Tool. Cite by document ID and section number; do not paste their prose verbatim.
+
+## Cloud-agnostic baseline
+
+CSF is technology-neutral. Implementation Examples are written without naming vendors. When this plugin's evidence checklist suggests artifacts (e.g., "IAM configuration export for PR.AA-01"), treat the artifact as cloud-agnostic — equivalent evidence exists in AWS IAM, Azure AD/Entra ID, GCP IAM, on-prem Active Directory, Kubernetes RBAC, or any combination. Optional vendor-specific examples may be added in a future Full-depth plugin, but Reference depth deliberately does not lock to a single cloud.
+
+## Capabilities
+
+- CSF 2.0 scope determination (Functions in scope, Tier targeting, Community Profile selection)
+- Current Profile and Target Profile authoring guidance
+- Gap analysis across all six Functions and 22 Categories
+- Subcategory-level evidence checklist generation
+- Tier (1–4) assessment guidance for organizational risk-management practices
+- Implementation Example interpretation and adaptation
+- Mapping CSF Subcategories to NIST SP 800-53 / ISO 27001:2022 / CIS Controls v8 via Informative References
+- Coexistence guidance with HIPAA, PCI DSS, GLBA, CMMC, NIS2, and other regulations
+- Board-readable reporting structure aligned with CSF Functions
+- SEC cybersecurity disclosure (Reg S-K Item 106) alignment via Govern Function
+- C-SCRM (cybersecurity supply chain risk management) under GV.SC
+- Multi-framework optimization via `/grc-engineer:optimize-multi-framework`
+- SCF crosswalk navigation (general-nist-csf-2-0 → 250 SCF controls → 134 CSF Subcategories)
+
+## Levelling up to Full
+
+A Full-depth `nist-csf-20` plugin would add framework-native workflow commands tied to how CSF is actually consumed in practice. Candidates worth considering:
+
+- `/nist-csf-20:profile-build` — interactive Current/Target Profile authoring with Subcategory-level scoring rubric
+- `/nist-csf-20:tier-assessment` — guided Tier 1–4 evaluation across the four characteristic dimensions (risk management process, integrated risk management program, external participation, supply chain risk)
+- `/nist-csf-20:community-profile` — search and apply published Community Profiles (manufacturing, election infrastructure, electric grid, etc.) as a starting Target Profile
+- `/nist-csf-20:board-report` — generate a Function-level executive summary suitable for board / audit committee distribution
+- `/nist-csf-20:csf1-to-csf2` — migrate an existing CSF 1.1 Profile to the CSF 2.0 structure, accounting for the new Govern Function and rebalanced Categories
+- `/nist-csf-20:sec-disclosure-prep` — map Govern Function outcomes to SEC Reg S-K Item 106 disclosure requirements
+
+Contributors with practitioner experience in any of these workflows are encouraged to open a level-up PR.
+
+## Command routing
+
+- `/nist-csf-20:scope` — determine applicability and Profile/Tier targeting
+- `/nist-csf-20:assess` — run a gap assessment via SCF crosswalk
+- `/nist-csf-20:evidence-checklist` — enumerate evidence per Function and representative Subcategories
+
+All three delegate to `/grc-engineer:gap-assessment` with SCF framework ID `general-nist-csf-2-0` for the control-by-control mechanics, and wrap the results in CSF 2.0 vocabulary (Function / Category / Subcategory / Profile / Tier).
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com) — crosswalk source
+- [SCF API entry for `general-nist-csf-2-0`](https://grcengclub.github.io/scf-api/api/crosswalks/general-nist-csf-2-0.json)
+- NIST CSF 2.0 (final, February 26, 2024) — published at `nist.gov/cyberframework`
+- NIST CSF 2.0 Quick Start Guides (SP 1300 series) — audience-specific guidance from NIST
+- NIST CSF 2.0 Reference Tool — interactive Subcategory browser with Implementation Examples and Informative References
+- NIST SP 800-53 Rev. 5, NIST SP 800-171 Rev. 3 — control catalogs cited as Informative References
+- ISO/IEC 27001:2022 Annex A, CIS Controls v8 — non-NIST catalogs cited as Informative References


### PR DESCRIPTION
## Summary

Reference-depth framework plugin for **NIST Cybersecurity Framework v2.0** (final, February 26, 2024) backed by the SCF crosswalk for `general-nist-csf-2-0` (250 SCF controls → 134 CSF Subcategories). Closes #16.

The CSF 2.0 plugin gives practitioners a Profile-style gap assessment, Function-based evidence checklist, and CSF-specific scope determination — sitting above existing control-catalog plugins (NIST 800-53, ISO 27001, CIS Controls) and sector-regulation plugins (HIPAA, PCI DSS, GLBA) as the U.S.-aligned outcomes / board-reporting layer.

## Files shipped (Reference depth = 6 files)

- `plugins/frameworks/nist-csf-20/.claude-plugin/plugin.json`
- `plugins/frameworks/nist-csf-20/README.md`
- `plugins/frameworks/nist-csf-20/commands/scope.md`
- `plugins/frameworks/nist-csf-20/commands/assess.md`
- `plugins/frameworks/nist-csf-20/commands/evidence-checklist.md`
- `plugins/frameworks/nist-csf-20/skills/nist-csf-20-expert/SKILL.md` (290 lines, no `TODO:` markers)
- `.claude-plugin/marketplace.json` — registration entry added

Slug `nist-csf-20` chosen over the scaffold-derived `nist-csf-2-0` to match the existing `nist-800-53` style.

## Key framework facts encoded (please verify accuracy)

- **Publisher**: NIST (U.S. Department of Commerce)
- **Released**: February 26, 2024 (CSF 2.0 final); supersedes CSF 1.1 (April 2018) but transition not mandated
- **Status**: Voluntary — no fines, no certification, no enforcement body. NIST is a standards body, not a regulator.
- **Six Functions**: Govern (GV), Identify (ID), Protect (PR), Detect (DE), Respond (RS), Recover (RC). The new **Govern** Function is the headline 2.0 change — it covers strategy, policy, oversight, roles, risk tolerance, and the substantially-expanded **GV.SC** (Cybersecurity Supply Chain Risk Management).
- **22 Categories**, ~106 Subcategories. Subcategory is the assessment unit.
- **Profiles**: Current Profile vs Target Profile gap analysis is the primary practitioner workflow. Community Profiles (manufacturing, election infrastructure, electric grid, etc.) provide pre-built starting Target Profiles.
- **Tiers (1–4)**: Partial / Risk Informed / Repeatable / Adaptive. SKILL emphasizes that Tiers describe *organizational risk-management practice rigor*, not per-Subcategory maturity, and that Tier 4 is not the universal target.
- **Implementation Examples**: new in 2.0 — concrete actions per Subcategory (not the same as Informative References, which point to other catalogs like 800-53, ISO 27001:2022, CIS Controls v8).
- **Sweet spots**: federal contractors pre-800-53, critical infrastructure under EO 14028, healthcare/finance using CSF as board-readable summary above HIPAA/GLBA/PCI DSS, mid-market building first formal program, public companies aligning Reg S-K Item 106 disclosure to the Govern Function.
- **Common misinterpretations corrected** (8 of them in SKILL): "CSF tells us what controls to implement" (no — outcomes only), "we need Tier 4" (no — Tier 2 or 3 is often appropriate), "CSF certification" (does not exist), etc.

No verbatim text from NIST CSF 2.0 PDF or NIST SP 1300-series Quick Start Guides — content is paraphrased and citations reference document IDs only.

## Validation

- `bash tests/validate-plugin-manifests.sh` — passes:
  - `Marketplace registration matches 41 plugin manifest(s).`
  - `All manifests valid.`
- `grep -rn TODO plugins/frameworks/nist-csf-20/` — no TODO markers remaining
- SKILL.md: 290 lines (within Reference-depth 300-800 line target — slightly under but content-dense; can be expanded in a follow-up if reviewers prefer)

## Test plan

- [ ] Verify SCF framework ID `general-nist-csf-2-0` resolves correctly via `/grc-engineer:gap-assessment general-nist-csf-2-0`
- [ ] Spot-check Subcategory codes against the published NIST CSF 2.0 Reference Tool
- [ ] Confirm marketplace.json entry renders correctly in `/grc-engineer:frameworks --installed`
- [ ] Smoke-test `/nist-csf-20:scope`, `/nist-csf-20:assess`, `/nist-csf-20:evidence-checklist`

## Notes for reviewer

- The scaffold-derived slug would have been `nist-csf-2-0`; I overrode to `nist-csf-20` to match existing `nist-800-53` style. Per spec.
- The README template shipped by `scripts/scaffold-framework.js` still hard-codes `hackidle.github.io/scf-api` — I used the canonical `grcengclub.github.io/scf-api` URL in this plugin's README and SKILL. The template itself wasn't touched (out of scope), but it's worth a follow-up to update the template.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NIST Cybersecurity Framework (v2.0) plugin (v0.1.0) with reference-depth capabilities for scoping, Profile-style gap assessments, and Function-organized evidence checklists. Maps SCF controls to CSF controls and exposes three core commands: scope, assess, evidence-checklist.

* **Documentation**
  * Added comprehensive user docs and examples, evidence mapping guidance, command references, and practitioner skill guidance for CSF 2.0 workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->