### PR TITLE
feat(framework): CCPA/CPRA plugin at Reference depth (closes #15)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -249,6 +249,12 @@
       "source": "./plugins/connectors/poam-automation",
       "description": "GRC connector wrapping networkbm/POAM-Automation-Tool: converts vulnerability scans into FedRAMP POA&M Excel and emits NIST-800-53-r5 (SI-2) findings → v1 finding contract.",
       "version": "0.1.0"
+    },
+    {
+      "name": "us-ccpa",
+      "source": "./plugins/frameworks/us-ccpa",
+      "description": "California Consumer Privacy Act (CCPA) and California Privacy Rights Act (CPRA) — Reference plugin with scope determination, evidence checklist, and SCF-backed gap assessment for the California Privacy Protection Agency (CPPA) regulations.",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/frameworks/us-ccpa/.claude-plugin/plugin.json
+++ b/plugins/frameworks/us-ccpa/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "us-ccpa",
+  "description": "California Consumer Privacy Act (CCPA) / California Privacy Rights Act (CPRA) compliance for businesses subject to California Civil Code §1798.100 et seq., enforced by the California Privacy Protection Agency (CPPA) and the California Attorney General.",
+  "version": "0.1.0",
+  "author": {
+    "name": "GRC Engineering Club Contributors"
+  },
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "framework_metadata": {
+    "scf_framework_id": "usa-state-ca-ccpa-cpra-2026",
+    "display_name": "California Consumer Privacy Act / California Privacy Rights Act (CCPA/CPRA)",
+    "region": "Americas",
+    "country": "United States",
+    "depth": "reference",
+    "scf_controls_mapped": 258,
+    "framework_controls_mapped": 623,
+    "industry": [],
+    "regulator": "California Privacy Protection Agency (CPPA); California Attorney General",
+    "citations": ["California Civil Code §1798.100 et seq.", "11 CCR §7000 et seq. (CPPA regulations)"]
+  },
+  "commands": ["assess", "scope", "evidence-checklist"],
+  "skills": ["us-ccpa-expert"]
+}

--- a/plugins/frameworks/us-ccpa/README.md
+++ b/plugins/frameworks/us-ccpa/README.md
@@ -1,0 +1,47 @@
+# us-ccpa — California Consumer Privacy Act (CCPA / CPRA)
+
+Reference-depth framework plugin for the California Consumer Privacy Act, as amended by the California Privacy Rights Act. Codified at California Civil Code §1798.100 et seq. Enforced by the California Privacy Protection Agency (CPPA) and the California Attorney General.
+
+## Install and run
+
+```bash
+/plugin install us-ccpa@grc-engineering-suite
+/us-ccpa:scope                    # determine applicability first
+/us-ccpa:evidence-checklist       # see what to collect
+/us-ccpa:assess                   # run the gap assessment
+```
+
+## Status: Reference
+
+This plugin is at **Reference depth** — it provides:
+
+- **Scope determination** for the three CPRA-amended applicability thresholds and the federal-statute carve-outs
+- **Evidence checklist** organized by California Civil Code section (1798.100 / .105 / .106 / .110 / .115 / .120 / .121 / .125 / .130 / .135 / .140 / .145)
+- **Gap assessment** delegated to `/grc-engineer:gap-assessment` against the SCF crosswalk (258 SCF controls → 623 framework controls)
+- **CPPA-specific context**: risk assessments, cybersecurity audits, Universal Opt-Out Mechanism (GPC) handling, Service Provider / Contractor / Third Party distinctions, and the limited private right of action
+
+### Level up to Full
+
+Full depth would add framework-native workflow commands tied to CPPA enforcement and audit ritual — e.g. risk-assessment generators per the CPPA regulations, DSAR ticket review, or vendor-contract DPA-addendum drafters. See the [Framework Plugin Guide](../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the level-up checklist.
+
+## Metadata
+
+| | |
+|---|---|
+| SCF framework ID | `usa-state-ca-ccpa-cpra-2026` |
+| Region | Americas |
+| Country | United States |
+| Regulator | California Privacy Protection Agency (CPPA); California Attorney General |
+| Statute | California Civil Code §1798.100 et seq. |
+| SCF controls mapped | 258 |
+| Framework controls mapped | 623 |
+| Depth | Reference |
+
+## References
+
+- [California Privacy Protection Agency (CPPA)](https://cppa.ca.gov) — primary regulator; rulemaking, enforcement, guidance
+- [California Attorney General — CCPA page](https://oag.ca.gov/privacy/ccpa) — co-enforcer; pre-CPRA enforcement history
+- California Civil Code §1798.100 through §1798.199.100 (current text via the [California Legislative Information portal](https://leginfo.legislature.ca.gov))
+- 11 California Code of Regulations §7000 et seq. — CPPA implementing regulations
+- [Secure Controls Framework](https://securecontrolsframework.com) — crosswalk source (CC BY-ND 4.0)
+- [SCF API entry](https://grcengclub.github.io/scf-api/api/crosswalks/usa-state-ca-ccpa-cpra-2026.json)

--- a/plugins/frameworks/us-ccpa/README.md
+++ b/plugins/frameworks/us-ccpa/README.md
@@ -16,7 +16,7 @@ Reference-depth framework plugin for the California Consumer Privacy Act, as ame
 This plugin is at **Reference depth** — it provides:
 
 - **Scope determination** for the three CPRA-amended applicability thresholds and the federal-statute carve-outs
-- **Evidence checklist** organized by California Civil Code section (1798.100 / .105 / .106 / .110 / .115 / .120 / .121 / .125 / .130 / .135 / .140 / .145)
+- **Evidence checklist** organized by California Civil Code section (1798.100 / .105 / .106 / .110 / .115 / .120 / .121 / .125 / .130 / .135 / .140 / .145 / .150 / .185)
 - **Gap assessment** delegated to `/grc-engineer:gap-assessment` against the SCF crosswalk (258 SCF controls → 623 framework controls)
 - **CPPA-specific context**: risk assessments, cybersecurity audits, Universal Opt-Out Mechanism (GPC) handling, Service Provider / Contractor / Third Party distinctions, and the limited private right of action
 

--- a/plugins/frameworks/us-ccpa/commands/assess.md
+++ b/plugins/frameworks/us-ccpa/commands/assess.md
@@ -1,0 +1,165 @@
+---
+description: CCPA / CPRA compliance gap assessment via SCF crosswalk
+---
+
+# CCPA / CPRA Assessment
+
+Runs a compliance gap assessment against the California Consumer Privacy Act and the California Privacy Rights Act amendments by delegating to `/grc-engineer:gap-assessment` with the framework's SCF identifier, then overlays CCPA/CPRA-specific context.
+
+## Usage
+
+```
+/us-ccpa:assess [--scope=<scope>] [--sources=<connector-list>]
+```
+
+## Arguments
+
+- `--scope` (optional) — narrow the assessment to a thematic slice. Valid scopes:
+  - `notices` — Privacy Policy, Notice at Collection, financial-incentive notices (§§1798.100, 1798.125, 1798.130)
+  - `rights` — consumer-rights workflows (§§1798.100, 1798.105, 1798.106, 1798.110, 1798.115, 1798.120, 1798.121)
+  - `opt-out` — sale/share opt-out, GPC handling, and Limit Use mechanisms (§§1798.120, 1798.121, 1798.135)
+  - `vendors` — Service Provider, Contractor, and Third Party contracts and classification (§§1798.140, 1798.115)
+  - `risk-and-audit` — CPPA risk assessments and annual cybersecurity audit (§1798.185)
+  - `security` — reasonable security and §1798.150 private-right-of-action exposure
+  - Default: full assessment across all sections
+- `--sources` (optional) — comma-separated connector plugins to feed evidence into the assessment.
+
+## Pre-assessment confirmation
+
+Before running, confirm with the user:
+
+1. **Have you run `/us-ccpa:scope`?** Applicability determination should precede assessment. If not, run scope first.
+2. **Entity classification**: Are you assessing yourself as a business, a Service Provider, or a Contractor? Different obligations attach.
+3. **Sale-vs-share posture**: Do you sell PI? Do you share PI for cross-context behavioral advertising? Both? Neither?
+4. **SPI processing posture**: Do you process Sensitive Personal Information for purposes beyond strictly necessary?
+5. **CPPA triggers**: Do any of your processing activities trigger the CPPA risk-assessment regulation (selling/sharing PI, processing SPI, ADMT for significant decisions, generative-AI training on PI, other high-risk processing)?
+6. **Enforcement history**: Any prior CPPA or California AG inquiries, investigations, settlements, or active complaints?
+
+## What the assessment produces
+
+1. **Compliance score** — overall CCPA/CPRA readiness percentage, weighted by mapped SCF controls.
+2. **Applicable-requirements summary** — which parts of the framework apply, based on `/us-ccpa:scope` outputs and the answers above.
+3. **Control-by-control gap** — every mapped control, with pass/fail/inconclusive status from connector findings.
+4. **Section-grouped findings** — gaps organized by California Civil Code section with severity and remediation guidance.
+5. **Evidence gaps** — controls where no evidence source is configured.
+6. **Remediation roadmap** — prioritized by severity, exposure (per-violation and class-action), and effort.
+
+## Delegation
+
+Under the hood:
+
+```
+/grc-engineer:gap-assessment "usa-state-ca-ccpa-cpra-2026" [--sources=<connector-list>]
+```
+
+The SCF crosswalk expands 258 SCF controls into the 623 CCPA/CPRA framework controls.
+
+## Output structure
+
+| Civil Code section | Topic | SCF control(s) | Status | Severity | Remediation |
+|---|---|---|---|---|---|
+| §1798.100(a) | Notice at Collection | PRI-04, PRI-05 | Gap | High | Deploy Notice at Collection at all data-collection surfaces; include SPI categories and Limit Use link |
+| §1798.105 | Right to Delete | PRI-09 | Partially | Medium | Add downstream propagation to Service Provider deletion endpoints |
+| §1798.121 | Right to Limit SPI | PRI-06 | Gap | High | Determine SPI processing posture; deploy Limit Use mechanism if any non-strictly-necessary use |
+| §1798.135(b) | GPC honoring | PRI-07 | Gap | Critical | Implement Sec-GPC header recognition; propagate through ad-tech and analytics fanout |
+| §1798.140(ag) | Service Provider contracts | TPM-04 | Partially | High | Audit existing DPAs for missing required provisions; remediate or reclassify recipient as Third Party |
+| §1798.185(a)(15)(B) | Risk assessment | RSK-04 | Gap | High | Conduct risk assessment per CPPA regulation for triggering processing activities |
+| §1798.185(a)(15)(A) | Cybersecurity audit | AST-09 | Gap | High | Engage independent auditor per CPPA regulation; establish annual cadence |
+
+**Status categories**:
+
+- **Implemented**: fully compliant with no identified gaps
+- **Partially**: partially compliant; remediation needed
+- **Gap**: not implemented — non-compliant
+- **N/A**: not applicable based on scope outputs
+
+**Severity**:
+
+- **Critical**: enforcement risk, ongoing public-facing violation, blocks defensible posture
+- **High**: serious gap, remediate before next regulator inquiry or audit cycle
+- **Medium**: important improvement
+- **Low**: best-practice recommendation
+
+## Common assessment scopes
+
+### Most-requested scopes
+
+- **`rights`** — consumer-rights workflow assessment is the most-requested standalone scope; useful when DSAR volume is rising or SLA breaches have been observed.
+- **`opt-out`** — driven by post-Sephora enforcement attention to GPC handling.
+- **`vendors`** — driven by enforcement attention to Service Provider contractual deficiencies.
+- **`risk-and-audit`** — driven by the CPPA regulations becoming operative; first audit cycle is the riskiest.
+
+### Combined regimes
+
+- **CCPA/CPRA + GDPR** — overlapping rights and vendor management; use `/grc-engineer:find-conflicts` and `/grc-engineer:optimize-multi-framework` to identify "implement once, satisfy many" controls. Do not maintain a hand-curated CCPA-to-GDPR mapping inside this plugin.
+- **CCPA/CPRA + HIPAA** — bifurcate at the data-carve-out boundary; PHI is governed by HIPAA, residual PI by CCPA/CPRA.
+- **CCPA/CPRA + state analogs** (Virginia, Colorado, Connecticut, Texas, Utah, etc.) — for multi-state programs, run CCPA/CPRA first because it is the most stringent in several dimensions and the others can largely be satisfied by a CCPA/CPRA-compliant baseline.
+
+## Cadence and recurrence
+
+CCPA/CPRA does not impose a single recertification cycle, but the following are time-bound:
+
+- **Privacy Policy review and update**: at least every 12 months.
+- **Annual cybersecurity audit**: annual once triggered.
+- **Risk assessments**: per CPPA regulatory cadence; submit abridged version on schedule.
+- **Public metrics**: annual, in Privacy Policy, for businesses processing PI of ≥10M California consumers.
+- **Internal recommended cadence**: full assessment annually plus targeted scope assessments quarterly (rights, opt-out) and semi-annually (vendors).
+
+## Common findings
+
+Based on CPPA enforcement advisories, AG settlements, and observed assessment patterns:
+
+1. **Failure to honor GPC end-to-end** (post-Sephora — most cited)
+2. **"Share" misclassified as not a "sale"** — adtech disclosures excluded from opt-out logic
+3. **Missing or deficient Service Provider contractual provisions** — particularly the subcontractor flow-down and the no-combining restriction
+4. **Notice at Collection missing or stale** at one or more collection surfaces
+5. **SPI processing without a Limit Use mechanism** — typically precise geolocation in adtech or contents of communications in support tooling
+6. **Missing risk assessments** for processing that triggers the CPPA regulation
+7. **No annual independent cybersecurity audit** for businesses that trigger the requirement
+8. **DSAR response timelines missed** without notice-of-extension
+9. **Verification procedures inadequate** — over-collecting verification information or under-verifying for high-risk requests
+10. **Reasonable-security posture undocumented** — making §1798.150 private-right-of-action defense difficult
+
+## Examples
+
+```bash
+# Full assessment
+/us-ccpa:assess
+
+# Consumer-rights workflow assessment only
+/us-ccpa:assess --scope=rights
+
+# Opt-out and GPC handling assessment
+/us-ccpa:assess --scope=opt-out
+
+# Vendor / Service Provider assessment
+/us-ccpa:assess --scope=vendors
+
+# CPPA risk-assessment and cybersecurity-audit readiness
+/us-ccpa:assess --scope=risk-and-audit
+
+# Pull connector evidence
+/us-ccpa:assess --sources=aws-inspector,github-inspector,okta-inspector
+```
+
+## Related commands
+
+- `/us-ccpa:scope` — determine applicability before assessing.
+- `/us-ccpa:evidence-checklist` — enumerate evidence requirements organized by Civil Code section.
+- `/grc-engineer:gap-assessment usa-state-ca-ccpa-cpra-2026` — direct SCF crosswalk assessment.
+
+## Enforcement context
+
+- **Penalties** (§1798.155): up to **US $2,500 per violation** non-intentional; up to **US $7,500 per violation** intentional or involving consumers under 16. Per-consumer aggregation applies — exposure for a noncompliant data-driven business reaches the millions even at the lower rate.
+- **No mandatory cure period** under post-CPRA AG enforcement; CPPA may discretionarily consider good-faith remediation.
+- **Private right of action** (§1798.150): statutory damages of US $100–$750 per consumer per incident for breaches of non-encrypted, non-redacted PI caused by failure to maintain reasonable security.
+- **Two enforcers**: CPPA (administrative) and California AG (civil action in superior court). Coordination via interagency MOU.
+
+---
+
+**Statute**: California Civil Code §1798.100 et seq.
+**Implementing regulations**: 11 California Code of Regulations §7000 et seq.
+**Regulators**: California Privacy Protection Agency (CPPA); California Attorney General
+**Region**: Americas
+**Country**: United States
+**Depth**: Reference (tier 2 of 3)

--- a/plugins/frameworks/us-ccpa/commands/evidence-checklist.md
+++ b/plugins/frameworks/us-ccpa/commands/evidence-checklist.md
@@ -1,0 +1,270 @@
+---
+description: CCPA / CPRA evidence checklist organized by California Civil Code section
+---
+
+# CCPA / CPRA Evidence Checklist
+
+Generates a comprehensive evidence request list for a CCPA / CPRA assessment, organized by the relevant California Civil Code section. Suitable for internal readiness, external counsel review, or response to a CPPA or California AG inquiry.
+
+> **Never commit evidence artifacts to source control.** Evidence outputs include consumer PI, ticketing data, ad-tech configurations, and contracts that may contain confidential business or personal information. `.gitignore` covers `evidence/` by default; durable storage is your responsibility. Use an encrypted, access-controlled evidence locker.
+
+## Usage
+
+```bash
+/us-ccpa:evidence-checklist [--section=<sec>] [--format=<fmt>] [--audience=<aud>]
+```
+
+## Arguments
+
+- `--section`: Civil Code section grouping to include
+  - `1798.100` — Notice at Collection and general business obligations
+  - `1798.105` — Right to Delete
+  - `1798.106` — Right to Correct (CPRA)
+  - `1798.110` — Right to Know — categories
+  - `1798.115` — Right to Know — sales/sharing/disclosures
+  - `1798.120` — Right to Opt Out of Sale or Sharing
+  - `1798.121` — Right to Limit Use of Sensitive Personal Information (CPRA)
+  - `1798.125` — Non-Discrimination and Financial Incentives
+  - `1798.130` — Notices, methods, response timelines, training, metrics
+  - `1798.135` — Opt-out and Limit-Use links and Universal Opt-Out Mechanism (GPC)
+  - `1798.140` — Definitions; vendor classification (Service Provider / Contractor / Third Party)
+  - `1798.145` — Carve-outs and exceptions
+  - `1798.150` — Private right of action (security-incident readiness)
+  - `1798.185` — CPPA risk assessments and cybersecurity audits
+  - Default: all sections
+- `--format`: `table` (default), `markdown` (detailed list), `csv` (spreadsheet)
+- `--audience`: `auditor` (external counsel / CPPA / AG, with citations), `internal` (simplified readiness check)
+
+## Evidence checklist
+
+### §1798.100 — Notice at Collection and general business obligations
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Notice at Collection** for each data-collection surface (web, mobile, in-store, telephone, employment) | §1798.100(a); 11 CCR §7012 | Notice templates with version history | Must enumerate categories of PI collected, categories of SPI collected, purposes for each, sale/share status, retention period (or criteria), and link to Limit Use page if SPI processed beyond strictly necessary |
+| **Data inventory** mapping PI and SPI categories → sources → purposes → recipients → retention → sale/share/limit-use status | §1798.100(b)–(d) | Spreadsheet, dataflow diagram, or CDP/IGA export | Foundational — every other obligation depends on it |
+| **Retention schedule** with documented criteria for each category | §1798.100(a)(3) | Records-retention policy, system-by-system retention configurations | Indefinite retention is not a defensible criterion |
+| **Reasonable security measures** appropriate to the nature of the PI | §1798.100(e) | Information-security program documentation, control mapping (e.g. NIST SP 800-53, ISO 27001) | "Reasonable" judged ex post by the regulator |
+| **Documentation of personnel access** to consumer PI | §1798.100(e) | IAM exports, access-review records | Supports both reasonable-security obligation and breach-readiness |
+
+### §1798.105 — Right to Delete
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Deletion intake** workflow with at least two methods | §1798.130(a)(1) | DSAR portal screenshots, email alias inbox, ticketing exports | One method must be toll-free unless business operates exclusively online with a direct consumer relationship |
+| **Verification procedures** matched to risk and PI sensitivity | 11 CCR §7060 et seq. | Verification policy, sample request transcripts | Reasonable-degree-of-certainty standard; document escalation for high-risk requests |
+| **Deletion fulfillment evidence**: ticket logs with timestamps, downstream-system propagation records | §1798.105(c) | Ticket export, deletion-job logs from each system | Must direct Service Providers / Contractors to delete; must use commercially reasonable efforts to notify Third Parties to whom PI was sold or shared |
+| **Documented deletion exceptions** with rationale per the nine §1798.105(d) categories | §1798.105(d) | Denial templates, reviewer sign-offs | Common exceptions: completing the transaction, security/integrity, debugging, free-speech rights, research, legal compliance |
+| **Response timing**: acknowledgment within 10 business days; substantive response within 45 calendar days (extendable once by 45 days with notice) | 11 CCR §7021; §1798.130(a)(2) | Ticketing SLA dashboards, sample notice-of-extension communications | Track end-to-end metrics; missed timelines are individually citable violations |
+
+### §1798.106 — Right to Correct (CPRA)
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Correction intake** workflow | §1798.106(a) | DSAR portal screenshots | Same intake channels as deletion |
+| **Documentation request procedure** for supporting evidence of inaccuracy | 11 CCR §7023 | Request templates, sample correspondence | May require consumer to provide documentation; cannot impose unreasonable burdens |
+| **Correction fulfillment evidence** | §1798.106(c) | Ticket export, downstream-correction propagation logs | Must use commercially reasonable efforts to correct in all systems |
+| **Denial documentation** with rationale | §1798.106(c) | Denial templates with citation to exception | Denials must be reasoned; consumer may file complaint with CPPA |
+
+### §1798.110 — Right to Know (categories)
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Categories disclosure**: PI categories collected, sources, business/commercial purposes, recipients | §1798.110(a) | Standardized response template | Must align with the data inventory |
+| **12-month look-back, plus pre-2022 collected PI** unless impossible / disproportionate effort | §1798.130(a)(2)(B) | Response procedure documentation | CPRA extended look-back beyond 12 months for PI collected on/after Jan 1, 2022 |
+
+### §1798.115 — Right to Know (sales / sharing / disclosures)
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Categories of PI sold or shared** by category and recipient class | §1798.115(a)–(c) | Disclosure template | Includes "share" (cross-context behavioral advertising) added by CPRA |
+| **Categories of PI disclosed for a business purpose** | §1798.115(a) | Disclosure template | Distinct from sale/share — covers Service Provider and Contractor disclosures |
+
+### §1798.120 — Right to Opt Out of Sale or Sharing
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Opt-out intake mechanism** | §1798.120(a); §1798.135 | Footer link, intake page | "Do Not Sell or Share My Personal Information" or single combined "Your Privacy Choices" with the standardized icon |
+| **Downstream propagation evidence** to ad-tech, analytics, and partner recipients | §1798.120(a) | Tag-management configuration, CMP exports, partner opt-out API logs | Most common gap — opt-out honored at page level but ad-tech pixels still fire |
+| **No-reverify-for-12-months evidence** | §1798.135(c)(4) | Reconsent flow logic, suppression list | Cannot solicit reconsent for at least 12 months after opt-out |
+
+### §1798.121 — Right to Limit Use of SPI (CPRA)
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **SPI inventory** with purpose-of-use classification: strictly necessary vs. beyond | §1798.121(a) | Spreadsheet keyed to data inventory | If only strictly-necessary uses, Right to Limit does not apply; document the determination |
+| **Limit Use intake mechanism** if any SPI is processed beyond strictly necessary | §1798.135(a)(2) | Footer link, intake page | "Limit the Use of My Sensitive Personal Information" link |
+| **Limit Use fulfillment evidence**: SPI use restricted to the §1798.121(a) enumerated purposes (strictly necessary, security, fraud prevention, transient use, quality improvement) | §1798.121(a) | Configuration evidence, suppression rules | Includes downstream Service Provider obligations |
+
+### §1798.125 — Non-Discrimination and Financial Incentives
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Equal-service evidence**: opt-out consumers receive equivalent goods, services, prices, quality | §1798.125(a) | Pricing-engine logic, A/B-test exclusion configurations | Cannot degrade UX for opt-out consumers |
+| **Notice of Financial Incentive** for any program conditioning price/quality on PI collection or sale/share, including loyalty programs | §1798.125(b) | Standalone notice document, opt-in confirmation records | Opt-in consent required; value-of-data calculation must be documented |
+| **Bona-fide loyalty program documentation**: data-value calculation, terms, opt-in records | 11 CCR §7080 | Program documentation, opt-in evidence | Discount must be reasonably related to the value of the PI to the business |
+
+### §1798.130 — Notices, methods, response timelines, training, metrics
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Privacy Policy** updated within the last 12 months | §1798.130(a)(5); 11 CCR §7011 | Posted policy with version history | Must contain all enumerated disclosures; review and update at least annually |
+| **At least two methods** to submit consumer requests | §1798.130(a)(1) | Web form + email + (toll-free if not exclusively online) | One method must be toll-free unless business operates exclusively online with direct consumer relationship |
+| **Response-timing records** | §1798.130(a)(2); 11 CCR §7021 | Ticketing SLA dashboards | 10-business-day acknowledgment, 45-calendar-day substantive response (one 45-day extension permitted with notice) |
+| **Training records** for personnel handling consumer requests | §1798.130(a)(6) | LMS exports, completion rosters, training content | All personnel handling requests or compliance must be trained |
+| **Metrics** for businesses processing PI of ≥10,000,000 California consumers in a calendar year | 11 CCR §7102 | Annual metrics published in Privacy Policy | Number of requests received, complied with, denied; median and mean response time |
+
+### §1798.135 — Opt-out / Limit-Use links and Universal Opt-Out Mechanism (GPC)
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **"Do Not Sell or Share My Personal Information" link** in website footer | §1798.135(a)(1) | Website screenshot, sitewide-template confirmation | Required if business sells or shares; must be clear and conspicuous on every page |
+| **"Limit the Use of My Sensitive Personal Information" link** in website footer | §1798.135(a)(2) | Website screenshot | Required if SPI processed beyond strictly necessary |
+| **Single combined "Your Privacy Choices" link** with standardized opt-out icon (alternative format) | 11 CCR §7015 | Website screenshot, icon implementation | Permitted alternative under regulation |
+| **GPC handling evidence**: server-side or client-side recognition of `Sec-GPC: 1` header that propagates through ad-tech and analytics fanout | §1798.135(b); 11 CCR §7025 | Test transcripts, network captures, CMP configuration, opt-out propagation logs | Sephora settlement (Aug 2022) made clear this is enforced; treat as real-time |
+| **Display of opt-out status when known** | 11 CCR §7025(c)(7) | UI screenshot showing "you have opted out" message | Must reflect GPC-derived opt-out, not just account-bound preference |
+
+### §1798.140 — Definitions; Service Provider / Contractor / Third Party classification
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Vendor inventory** classifying each recipient as Service Provider, Contractor, Third Party, or Other (e.g. carved-out by §1798.145) | §1798.140(ag), (j), (ai) | Spreadsheet keyed to vendor management system | Misclassification of a Third Party as a Service Provider is a common enforcement finding |
+| **Service Provider / Contractor contracts** with all required §1798.140(ag)(1) / (j)(1) provisions | §1798.140(ag)(1), (j)(1) | Signed master agreements, DPAs, addenda | Must include: limited business purpose, no sale/share, no use beyond contract, no combining with other sources, subcontractor flow-down, monitoring rights, notification of inability to comply |
+| **Third Party contracts** with §1798.115(d) certification re: notice and opt-out | §1798.115(d) | Contract terms, certification documentation | Recipient must certify it understands restrictions and will comply |
+| **Subcontractor flow-down evidence** | 11 CCR §7053 | Subcontractor agreements with materially equivalent terms | Required for Service Providers and Contractors |
+| **Vendor monitoring / audit evidence** | §1798.140(ag)(1)(F) | Periodic compliance attestations, audit reports, SOC 2 reports | Monitoring may be manual, automated scans, periodic assessments, audits, or technical/operational testing |
+
+### §1798.145 — Carve-outs and exceptions
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Documentation of which data carve-outs are claimed** (HIPAA, GLBA, FCRA, DPPA, clinical trials) | §§1798.145–1798.146 | Carve-out determination memo with data scope | Carve-outs are data-level, not entity-level; document residual in-scope PI |
+| **Boundary documentation** showing how carved-out data is segregated from in-scope PI | §1798.146 | Data-flow diagram, system boundary documentation | Auditors will look for commingling that defeats the carve-out |
+
+### §1798.150 — Private right of action (security-incident readiness)
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Encryption-and-redaction posture** for the categories of PI subject to the private right of action | §1798.150(a) | Encryption inventory by data store, key-management documentation | Statutory damages of $100–$750 per consumer per incident apply only to non-encrypted, non-redacted PI |
+| **Reasonable security procedures and practices** documentation | §1798.150(a) | Security program documentation, control catalog mapping | "Reasonable" judged against organizational size, complexity, and nature of activities |
+| **Breach response plan** with notification procedures | Civil Code §1798.82 (separate California breach-notification statute) | IRP document, tabletop exercise records | Note: §1798.82 (not §1798.150) governs breach notification; both are relevant to private right of action exposure |
+| **Tabletop / IR test results** with corrective actions tracked | Implicit in §1798.150(a) | Exercise reports, AAR documentation | Pattern of unaddressed findings can defeat reasonable-security defense |
+
+### §1798.185 — CPPA risk assessments and cybersecurity audits
+
+| Evidence item | Citation | Common format | Notes / Gotchas |
+|---|---|---|---|
+| **Risk assessment** for each processing activity that triggers the CPPA risk-assessment regulation (selling/sharing PI, processing SPI, ADMT for significant decisions, training generative AI/ML on PI, other high-risk processing) | §1798.185(a)(15)(B); 11 CCR §7150 et seq. | Risk-assessment report; abridged version submitted to CPPA per regulatory cadence | Must include purpose, categories of PI, processing operations, benefits, harms, safeguards, and a documented determination that benefits outweigh risks |
+| **Annual independent cybersecurity audit** with appropriate scope and rigor | §1798.185(a)(15)(A); 11 CCR §7120 et seq. | Engagement letter, audit report, certification, abridged report submitted to CPPA | Auditor independence requirements apply; scope must cover the processing activities that triggered the obligation |
+| **Auditor independence documentation** | 11 CCR §7122 | Engagement letter with independence representations, conflict-of-interest disclosures | Internal audit can perform if it meets independence standards; external audit is the safer default |
+| **ADMT documentation** for any automated decision-making technology used for significant decisions or extensive profiling | §1798.185(a)(15)(C); 11 CCR §7200 et seq. | Pre-use notice, opt-out mechanism, access-right response, logic and outcome documentation | Active rulemaking area — confirm the operative regulatory text at assessment time |
+
+## Evidence collection patterns
+
+### Privacy Policy snapshot
+
+```bash
+# Capture current Privacy Policy with timestamp for version history
+curl -sS https://example.com/privacy > evidence/ccpa/policies/privacy-policy-$(date +%Y%m%d).html
+```
+
+### Notice at Collection inventory
+
+```bash
+# Enumerate collection surfaces and their notices
+# (manually maintained; output to spreadsheet keyed to data inventory)
+```
+
+### GPC honoring validation
+
+```bash
+# Cloud-agnostic test: send Sec-GPC header and confirm response treats it as opt-out
+curl -sS -H 'Sec-GPC: 1' https://example.com/ -o /dev/null -D - | tee evidence/ccpa/gpc/headers-$(date +%Y%m%d).txt
+# Confirm downstream ad-tech: load the page in a headless browser with GPC enabled
+# and capture network requests to ad-tech and analytics destinations
+```
+
+### DSAR ticket export
+
+```bash
+# From your ticketing system (cloud-agnostic):
+# Export the prior 12 months of consumer-rights tickets with timestamps,
+# request type, verification method, disposition, and response time.
+# Format: CSV with columns ticket_id, received_at, acknowledged_at,
+# substantive_response_at, request_type, verified, disposition, denial_reason
+```
+
+### Vendor classification spreadsheet
+
+| Vendor | Data shared | Classification | Contract reference | §1798.140(ag)/(j) provisions confirmed | Subcontractor flow-down |
+|---|---|---|---|---|---|
+| Example CDP | Hashed email, browsing events | Service Provider | MSA §12 + DPA Addendum A | Yes (all 9) | Yes |
+| Example ad network | Hashed email, IP, page URL | Third Party (share) | IO + standard adtech terms | N/A — Third Party | N/A |
+
+## Output formats
+
+### For external counsel / CPPA / AG inquiry response
+
+Provide an organized package with:
+
+1. **Cover letter**: scope, point of contact, time period covered.
+2. **Index**: table of contents keyed to Civil Code section.
+3. **Executive summary**: applicability determination (from `/us-ccpa:scope`), high-level posture, identified gaps, remediation status.
+4. **Evidence sections**: by Civil Code section, in the order above.
+5. **Vendor inventory and contracts**: with §1798.140(ag)/(j) provision checklist per vendor.
+6. **Risk assessments and cybersecurity audit**: separately tabbed.
+7. **Attachments**: notices, policies, training materials, ticketing exports, screenshots.
+
+### For internal readiness
+
+Simplified checklist:
+
+- [ ] Data inventory current and complete
+- [ ] Privacy Policy reviewed and updated within last 12 months
+- [ ] Notice at Collection deployed at every collection surface
+- [ ] DSAR intake operational with at least two methods, verification procedures, and SLA tracking
+- [ ] Right to Delete, Know, Correct, Opt Out, and Limit Use workflows implemented end-to-end
+- [ ] Do Not Sell or Share / Limit Use links live in footer (or combined Your Privacy Choices link with icon)
+- [ ] GPC signal honored end-to-end through ad-tech and analytics fanout
+- [ ] All vendor contracts classified and reviewed against §1798.140(ag)/(j) provisions
+- [ ] SPI inventory current; Right to Limit applicability determined
+- [ ] Risk assessments performed for processing activities that trigger the CPPA regulation
+- [ ] Annual cybersecurity audit scoped, scheduled, and (if triggered) completed
+- [ ] Personnel training completed for staff handling consumer requests
+- [ ] Public metrics published if processing PI of ≥10M California consumers
+- [ ] Encryption / redaction posture documented for §1798.150 exposure reduction
+- [ ] Breach-response plan tested
+
+## Examples
+
+```bash
+# Generate full evidence checklist (all sections)
+/us-ccpa:evidence-checklist
+
+# Generate checklist limited to consumer-rights sections
+/us-ccpa:evidence-checklist --section=1798.105
+/us-ccpa:evidence-checklist --section=1798.120
+
+# Generate vendor / Service Provider checklist
+/us-ccpa:evidence-checklist --section=1798.140
+
+# Export to CSV for spreadsheet import
+/us-ccpa:evidence-checklist --format=csv
+
+# Internal readiness checklist
+/us-ccpa:evidence-checklist --audience=internal
+```
+
+## Related commands
+
+- `/us-ccpa:scope` — determine applicability before collecting evidence.
+- `/us-ccpa:assess` — run the gap assessment via SCF crosswalk.
+- `/grc-engineer:gap-assessment usa-state-ca-ccpa-cpra-2026` — direct SCF crosswalk assessment.
+
+---
+
+**Statute**: California Civil Code §1798.100 et seq.
+**Implementing regulations**: 11 California Code of Regulations §7000 et seq.
+**Regulators**: California Privacy Protection Agency (CPPA); California Attorney General
+**Region**: Americas
+**Country**: United States

--- a/plugins/frameworks/us-ccpa/commands/scope.md
+++ b/plugins/frameworks/us-ccpa/commands/scope.md
@@ -1,0 +1,141 @@
+---
+description: Determine whether and how the California Consumer Privacy Act (CCPA / CPRA) applies to the organization
+---
+
+# CCPA / CPRA Scope Determination
+
+Walks the three CPRA-amended applicability thresholds in California Civil Code §1798.140(d) plus the federal-statute data carve-outs, and outputs an in-scope / partially-in-scope / out-of-scope verdict with the specific triggers that led there.
+
+## Usage
+
+```
+/us-ccpa:scope
+```
+
+## What this produces
+
+- **Applicability verdict**: in-scope / partially in-scope / out-of-scope, with citations to the threshold(s) triggered.
+- **In-scope data categories**: which categories of Personal Information (PI) and Sensitive Personal Information (SPI) the business handles for California consumers.
+- **Carve-outs claimed**: which federally-preempted data categories are out-of-scope at the data level (HIPAA, GLBA, FCRA, DPPA, clinical trials), with the residual non-carved-out PI still in scope.
+- **Entity classification**: business, Service Provider, Contractor, or Third Party for each processing relationship.
+- **Sale-vs-share posture**: whether the business sells PI, shares PI for cross-context behavioral advertising, or neither.
+- **SPI processing posture**: whether SPI is processed strictly necessary or beyond, triggering the Right to Limit.
+- **Next steps**: whether to proceed with `/us-ccpa:assess` and `/us-ccpa:evidence-checklist`.
+
+## Pre-scope confirmation
+
+Before walking the thresholds, confirm with the user:
+
+1. **For-profit?** CCPA/CPRA applies only to **for-profit** entities. Nonprofits and government entities are categorically out of scope (though they may be in scope under other California privacy laws — separate analysis).
+2. **Doing business in California?** Conducting commercial activity directed at California consumers — sales, marketing, service delivery, employment of California residents — generally satisfies this prong. Mere passive availability of a website is not by itself "doing business" but combined with revenue or user-base presence in California typically is.
+3. **California consumers in scope?** "Consumer" under §1798.140(i) means a natural person who is a California resident. Includes employees, applicants, B2B contacts, and customers as of January 1, 2023 (the HR and B2B partial exemptions sunset).
+
+If any of these is "no," the organization is out of scope at the entity level — stop here and document the rationale.
+
+## Threshold flow
+
+A for-profit business that does business in California and collects PI of California consumers is in scope if it meets **any one** of the three thresholds in §1798.140(d):
+
+### Threshold 1 — Revenue (§1798.140(d)(1)(A))
+
+Annual gross revenues in excess of **US $25 million** in the **preceding calendar year**.
+
+- "Annual gross revenues" is the entity's worldwide gross revenue for the prior calendar year, not California-specific revenue.
+- The threshold is subject to periodic CPPA inflation adjustment — confirm the current dollar figure against the current text of §1798.140(d) and any CPPA Board-adopted adjustment notice.
+
+**Walk**: ask the user for the entity's prior calendar year worldwide gross revenue. If > $25M (or the current adjusted figure), Threshold 1 is met.
+
+### Threshold 2 — Volume of PI handled (§1798.140(d)(1)(B))
+
+Alone or in combination, annually **buys, sells, or shares** the personal information of **100,000 or more** California consumers or households.
+
+- "Buys" includes paid acquisition of PI from a data broker or partner.
+- "Sells" includes any disclosure for monetary or other valuable consideration.
+- "Shares" includes any disclosure for cross-context behavioral advertising — even with no monetary exchange.
+- The CPRA-era threshold is **100,000** (raised from CCPA's original 50,000) and now uses **consumers or households** rather than CCPA's "consumers, households, or devices."
+
+**Walk**: ask the user to estimate the number of distinct California consumers or households whose PI the business buys, sells, or shares annually. Account for ad-tech and analytics partner disclosures (these are commonly underestimated). If ≥ 100,000, Threshold 2 is met.
+
+### Threshold 3 — Revenue derivation (§1798.140(d)(1)(C))
+
+Derives **50 percent or more** of annual revenue from **selling or sharing** consumers' personal information.
+
+- Applies even at very low absolute revenue.
+- Captures pure-play data brokers and adtech intermediaries.
+
+**Walk**: ask whether selling or sharing PI is the primary revenue model. If ≥ 50%, Threshold 3 is met.
+
+### Affiliate / common-branding hook
+
+Even if no threshold is met, the entity is in scope if it:
+
+- Controls or is controlled by a covered business **and** shares common branding (parent, subsidiary, sister entity), where common branding means a shared name, service mark, or trademark such that the average consumer would understand they are commonly owned, **and** with whom the business shares consumers' PI; or
+- Is a joint venture or partnership composed of businesses in which each has at least a 40 percent interest, with the JV treated as a separate business.
+
+**Walk**: ask about parent/subsidiary structure and whether PI is shared across commonly-branded entities.
+
+## Carve-out flow
+
+Even when an entity is in scope, specific **categories of data** are carved out of CCPA/CPRA. These are data-level carve-outs, not entity exemptions — the entity remains in scope for any non-carved-out PI.
+
+| Data category | Citation | Notes |
+|---|---|---|
+| Protected Health Information governed by HIPAA, plus information collected by a covered entity / business associate to the extent treated under HIPAA or California Confidentiality of Medical Information Act | §1798.146 | The PHI itself is out of scope; web analytics on the marketing site, employee marketing, non-PHI loyalty data are still in scope. |
+| Personal information collected, processed, sold, or disclosed pursuant to GLBA or California Financial Information Privacy Act | §1798.145(e) | Covers financial-account data; non-financial PI from the same institution remains in scope. |
+| Personal information collected, processed, sold, or disclosed under the Driver's Privacy Protection Act | §1798.145(f) | DMV-derived data only. |
+| Personal information processed pursuant to the Fair Credit Reporting Act when used for FCRA-permissible purposes | §1798.145(d) | Carve-out is purpose-specific; non-FCRA uses of the same data are not exempt. |
+| Clinical-trial information governed by federal common rule | §1798.145(c) | Specifically defined research contexts. |
+
+**Walk**: for each data carve-out category, ask whether the business holds data of that category. For each "yes," confirm the residual non-carved-out PI is still being assessed.
+
+## Outputs
+
+After the walk, produce a structured verdict:
+
+```
+APPLICABILITY VERDICT: IN SCOPE
+
+Triggers met:
+  ✓ Threshold 1 (Revenue): $X.YM in calendar year 2025
+  ✓ Threshold 2 (Volume): ~140,000 California consumers in shared ad-tech audiences
+
+Carve-outs claimed:
+  - HIPAA-covered PHI: YES — separate HIPAA program in place
+    Residual in-scope: marketing PI, web analytics, non-PHI portal accounts
+
+Sale/share posture:
+  - Sells PI: NO
+  - Shares PI for cross-context behavioral advertising: YES (Meta Pixel, Google Ads, ad-network partners)
+  - Triggers: Do Not Sell or Share link required; GPC handling required
+
+SPI processing posture:
+  - Processes SPI beyond strictly necessary: YES (precise geolocation for ad targeting)
+  - Triggers: Limit Use link required; Right to Limit applies
+
+Recommended next commands:
+  - /us-ccpa:evidence-checklist
+  - /us-ccpa:assess
+```
+
+## Common scoping mistakes this command corrects
+
+- **Treating "we don't sell data" as out-of-scope of the opt-out**. If the business shares for cross-context behavioral advertising, the opt-out applies — that is the "share" added by CPRA.
+- **Assuming employee or B2B data is exempt**. The HR and B2B partial exemptions sunset on January 1, 2023; both are fully in scope.
+- **Treating the HIPAA carve-out as entity-wide**. Only the HIPAA-covered PHI is exempt; everything else the entity holds about California consumers is in scope.
+- **Underestimating the volume threshold**. Programmatic ad-tech, analytics, and CDP partner disclosures push most consumer-facing businesses past 100,000 California consumers/households quickly. Audit the partner list, not just the customer list.
+- **Treating the $25M revenue threshold as the only trigger**. Threshold 2 (volume) and Threshold 3 (revenue derivation) are independent — an under-$25M business can still be in scope.
+- **Ignoring the affiliate hook**. Common-branded subsidiaries that share PI are pulled into scope by §1798.140(d)(2)(B).
+
+## Citations
+
+- California Civil Code §1798.140 (definitions and applicability thresholds)
+- California Civil Code §1798.145 (federal-statute carve-outs)
+- California Civil Code §1798.146 (HIPAA carve-out)
+- 11 California Code of Regulations §7000 et seq. (CPPA implementing regulations)
+
+---
+
+**Statute**: California Civil Code §1798.100 et seq.
+**Regulator**: California Privacy Protection Agency (CPPA); California Attorney General
+**Region**: Americas
+**Country**: United States

--- a/plugins/frameworks/us-ccpa/skills/us-ccpa-expert/SKILL.md
+++ b/plugins/frameworks/us-ccpa/skills/us-ccpa-expert/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Glob, Grep, Write
 
 # California Consumer Privacy Act / California Privacy Rights Act Expert
 
-Reference-depth expertise for the California Consumer Privacy Act (CCPA) as amended by the California Privacy Rights Act (CPRA). This skill paraphrases the statute and citing California Civil Code section by section — never reproduce verbatim statute text.
+Reference-depth expertise for the California Consumer Privacy Act (CCPA) as amended by the California Privacy Rights Act (CPRA). This skill paraphrases the statute and cites California Civil Code section by section — never reproduce verbatim statute text.
 
 ## Framework identity
 

--- a/plugins/frameworks/us-ccpa/skills/us-ccpa-expert/SKILL.md
+++ b/plugins/frameworks/us-ccpa/skills/us-ccpa-expert/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: us-ccpa-expert
+description: California Consumer Privacy Act (CCPA) and California Privacy Rights Act (CPRA) expert. Deep knowledge of California Civil Code §1798.100 et seq., CPRA-amended applicability thresholds, the seven consumer rights, Sensitive Personal Information handling, Service Provider / Contractor / Third Party distinctions, the Universal Opt-Out Mechanism (Global Privacy Control), CPPA risk assessments and cybersecurity audits, and dual enforcement by the California Privacy Protection Agency and the California Attorney General.
+allowed-tools: Read, Glob, Grep, Write
+---
+
+# California Consumer Privacy Act / California Privacy Rights Act Expert
+
+Reference-depth expertise for the California Consumer Privacy Act (CCPA) as amended by the California Privacy Rights Act (CPRA). This skill paraphrases the statute and citing California Civil Code section by section — never reproduce verbatim statute text.
+
+## Framework identity
+
+- **SCF framework ID**: `usa-state-ca-ccpa-cpra-2026`
+- **Region**: Americas
+- **Country**: United States
+- **Statute**: California Civil Code §1798.100 et seq.
+- **Implementing regulations**: 11 California Code of Regulations §7000 et seq.
+- **Regulators**: California Privacy Protection Agency (CPPA) and the California Attorney General — both have civil-enforcement authority.
+
+## Framework in plain language
+
+CCPA gives California residents ("consumers" in the statute, which includes households for some rights) the right to know what personal information a business collects about them, the right to delete and correct it, the right to opt out of its sale or sharing, and the right to limit a business's use of certain sensitive categories. CPRA — passed by California voters as Proposition 24 in November 2020 and operative January 1, 2023 with enforcement beginning July 1, 2023 — amended the original 2018 CCPA (effective 2020) by adding the right to correct, the right to limit use of Sensitive Personal Information, the new "share" concept covering cross-context behavioral advertising, the standalone CPPA agency, and a mandatory recognition of Universal Opt-Out Mechanisms such as the Global Privacy Control. CPRA also raised one of the applicability thresholds, removed the AG's prior 30-day mandatory cure period, and authorized CPPA rulemaking on risk assessments and cybersecurity audits for processing that presents significant risk.
+
+## Key dates and history
+
+- **June 2018**: California Legislature enacts AB 375 (CCPA), Civil Code §§1798.100–1798.199.
+- **January 1, 2020**: CCPA operative.
+- **July 1, 2020**: Attorney General begins enforcement under original CCPA.
+- **November 3, 2020**: Voters pass Proposition 24 (CPRA).
+- **January 1, 2023**: CPRA amendments operative; B2B and HR partial exemptions sunset; CPPA rulemaking authority active.
+- **July 1, 2023**: CPPA enforcement begins (the CPPA, distinct from the AG, takes over its share of administrative enforcement).
+- **2024–2026**: CPPA finalizes regulations on automated decision-making technology (ADMT), risk assessments, cybersecurity audits, and Universal Opt-Out Mechanisms — practitioners should track CPPA Board meeting agendas for current rulemaking status.
+
+## Territorial scope and applicability
+
+CCPA/CPRA applies to a **for-profit business** that:
+
+1. **Does business in California**, AND
+2. **Collects (or has collected on its behalf) personal information about California residents**, AND **alone or jointly determines the purposes and means** of processing that information, AND
+3. Meets **at least one** of the following three thresholds — see California Civil Code §1798.140(d) for the current text:
+
+   - **Revenue threshold**: had annual gross revenues in excess of **US $25 million** in the preceding calendar year (the dollar figure was $25M from inception and is subject to periodic CPPA inflation adjustment — confirm current value at assessment time).
+   - **Volume threshold**: alone or in combination, annually **buys, sells, or shares** the personal information of **100,000 or more** California consumers or households. *(CCPA's original threshold was 50,000 consumers/households/devices and used "buys, receives, sells, or shares for commercial purposes." CPRA raised the count to 100,000, removed "receives," removed "devices," and added "shares" — narrowing what triggers the threshold but extending coverage to behavioral-advertising recipients.)*
+   - **Revenue-derivation threshold**: derives **50 percent or more** of annual revenue from **selling or sharing** consumers' personal information. *(CPRA added "sharing" — relevant for adtech businesses that exchange data without monetary consideration.)*
+
+Two additional categories of entity are also covered:
+
+- Any **entity that controls or is controlled by** a covered business and shares common branding (the parent/affiliate hook).
+- A **joint venture or partnership** in which each business has at least a 40 percent interest, with the joint venture itself treated as a separate business for compliance.
+
+### Coverage carve-outs
+
+Several categories of data — not entire entities — are carved out so that the Civil Code does not apply to them:
+
+- **Protected Health Information** governed by HIPAA / California Confidentiality of Medical Information Act, and other patient information collected by a covered entity or business associate to the extent it is treated under those laws.
+- **Personal information collected, processed, sold, or disclosed pursuant to the GLBA** (financial institutions) or California Financial Information Privacy Act.
+- **Personal information collected, processed, sold, or disclosed under the Driver's Privacy Protection Act**.
+- **Personal information processed pursuant to the Fair Credit Reporting Act** when used for FCRA-permissible purposes.
+- **Clinical-trial information** governed by federal common-rule requirements.
+
+Important: these are **data-level carve-outs**, not entity-level exemptions. A bank that holds GLBA-covered customer financial data is still subject to CCPA/CPRA for its non-GLBA personal information (employee marketing, cookie-collected web traffic, etc.).
+
+The **B2B exemption** (personal information collected from a person in a business-to-business communications context) and the **HR exemption** (personal information of employees, applicants, contractors, owners, directors, officers) **expired on January 1, 2023**. From that date forward, employee and B2B contact data are fully in scope, including the right to know, delete, correct, opt out of sale/share, and limit use of SPI.
+
+## Definitions worth getting right
+
+- **Consumer** — a natural person who is a California resident (Civil Code §1798.140(i)). Includes employees, applicants, B2B contacts, and customers; the post-2023 sunset of the partial exemptions made this matter much more.
+- **Personal information** (§1798.140(v)) — information that identifies, relates to, describes, is reasonably capable of being associated with, or could reasonably be linked, directly or indirectly, with a particular consumer or household. Includes inferred profiles. Does **not** include deidentified or aggregate consumer information, or publicly available information from government records.
+- **Sensitive Personal Information (SPI)** (§1798.140(ae)) — a CPRA-introduced category whose processing for purposes other than those strictly necessary to provide the goods or services requested triggers the **Right to Limit**. SPI includes:
+  - Government identifiers — Social Security number, driver's license, state ID, passport.
+  - Account credentials — username/password combinations or security questions allowing account access.
+  - Precise geolocation (defined in regulations as a radius of 1,850 feet or smaller).
+  - Racial or ethnic origin, religious or philosophical beliefs, union membership.
+  - Contents of mail, email, and text messages (unless the business is the intended recipient).
+  - Genetic data.
+  - Biometric information processed for the purpose of uniquely identifying a consumer.
+  - Personal information collected and analyzed concerning health.
+  - Personal information collected and analyzed concerning sex life or sexual orientation.
+- **Sale** (§1798.140(ad)) — selling, renting, releasing, disclosing, disseminating, making available, transferring, or otherwise communicating personal information to a third party for **monetary or other valuable consideration**. Note: the "or other valuable consideration" language is broad; data-for-data swaps and ad-network exchanges have been treated as sales by the AG.
+- **Share** (§1798.140(ah)) — disclosing personal information to a third party for **cross-context behavioral advertising**, whether or not for monetary consideration. Specifically introduced by CPRA to cover programmatic-advertising disclosures that businesses argued did not qualify as "sales."
+- **Cross-context behavioral advertising** (§1798.140(k)) — targeting based on personal information obtained from the consumer's activity across businesses, distinctly-branded websites, applications, or services other than those with which the consumer intentionally interacts.
+- **Service Provider** (§1798.140(ag)) — a person that processes personal information on behalf of a business pursuant to a written contract that meets the CCPA's specific restrictions (use limited to specified business purposes, no selling/sharing, no combining with other sources, etc.).
+- **Contractor** (§1798.140(j)) — same role as Service Provider but for entities to whom the business **makes available** personal information rather than discloses it; contractually equivalent obligations.
+- **Third party** (§1798.140(ai)) — anyone who is not the business that collected the personal information and is not a Service Provider or Contractor of that business. Disclosures to a Third Party generally constitute a "sale" or "share."
+
+The **Service Provider / Contractor / Third Party trichotomy** is one of the most error-prone areas in CCPA/CPRA practice. The contractual provisions in §1798.140(ag)/(j) — including the obligation to flow down restrictions to subcontractors, to comply with consumer-rights requests, and to notify the business of any use that exceeds the contract — are mandatory; if they're missing, the recipient is treated as a Third Party even if both parties intended a Service Provider relationship.
+
+## Consumer rights
+
+CPRA recognizes seven consumer rights (often counted as eight if you split out access from "right to know"):
+
+1. **Right to Know / Access** (§1798.100, §1798.110, §1798.115) — categories of PI collected, sources, business or commercial purposes, third parties to whom PI was disclosed, and the specific pieces of PI collected. Lookback period is generally the prior 12 months; CPRA extended this to allow consumers to request information beyond 12 months for PI collected on or after January 1, 2022, unless doing so is impossible or would involve disproportionate effort.
+2. **Right to Delete** (§1798.105) — request deletion of PI collected from the consumer. Subject to nine enumerated exceptions including completing the transaction, security, debugging, exercising free speech, complying with legal obligations, internal uses reasonably aligned with consumer expectations, and so on. Business must direct Service Providers and Contractors to delete; must use commercially reasonable efforts to notify Third Parties to whom the PI was sold or shared.
+3. **Right to Correct** (§1798.106) — *new with CPRA*. Request correction of inaccurate PI. Business must use commercially reasonable efforts to correct; consumer may be required to provide documentation supporting the correction.
+4. **Right to Opt Out of Sale or Sharing** (§1798.120, §1798.135) — at any time. Opt-out applies prospectively; reverification cannot be required for at least 12 months. Businesses that sell or share must provide a clear and conspicuous "Do Not Sell or Share My Personal Information" link, and must process Universal Opt-Out Mechanisms (see GPC discussion below).
+5. **Right to Limit Use and Disclosure of Sensitive Personal Information** (§1798.121) — *new with CPRA*. Restricts use of SPI to that which is strictly necessary to perform the services or provide the goods reasonably expected by an average consumer, plus enumerated security, fraud-prevention, transient-use, and quality-improvement purposes. If a business processes SPI only for these strictly-necessary purposes, the right to limit does not apply (and the "Limit Use" link is not required). Otherwise, a "Limit the Use of My Sensitive Personal Information" link is mandatory.
+6. **Right to Non-Discrimination / Equal Service** (§1798.125) — a business may not deny goods or services, charge different prices, or provide a different level of quality because a consumer exercised CCPA rights. Financial incentives and bona-fide loyalty programs are permitted but must be reasonably related to the value of the consumer's data and require opt-in consent.
+7. **Right to Data Portability** — implemented as part of the Right to Know: when responding to an access request, the response must be in a portable and, to the extent technically feasible, readily usable format that allows the consumer to transmit the information to another entity without hindrance.
+
+CPRA also imposes obligations around **automated decision-making technology (ADMT)** — the CPPA has issued multiple draft regulations through 2024–2026 covering pre-use notice, opt-out rights, and access rights for significant decisions and extensive profiling. Practitioners should treat ADMT as an active rulemaking area and confirm the operative regulatory text at assessment time.
+
+### Verification, response timelines, and method
+
+- **Acknowledgment**: within **10 business days** of receiving a request.
+- **Substantive response**: within **45 calendar days**, extendable once by an additional 45 days when reasonably necessary, with notice to the consumer.
+- **Verification**: businesses must verify the requester's identity to a reasonable degree of certainty (or higher for Right to Know specific pieces). Verification standards are set in the CPPA regulations at 11 CCR §7060 et seq.
+- **At least two methods to submit requests**: a toll-free phone number is no longer mandatory for businesses operating exclusively online with a direct relationship to the consumer; a designated email address plus an interactive web form is acceptable. Other businesses must offer two methods, one of which must be toll-free.
+
+## Universal Opt-Out Mechanism (Global Privacy Control)
+
+CPRA and the CPPA regulations require businesses that sell or share personal information to honor a Universal Opt-Out Mechanism that meets the technical specification in 11 CCR §7025. The **Global Privacy Control (GPC)** signal — a browser-based HTTP header (`Sec-GPC: 1`) and JavaScript property — is the recognized implementation. Treatment requirements:
+
+- Treat a GPC signal as a valid opt-out of sale **and** sharing for that browser/device, plus any consumer profile linked by an identifier already known to the business.
+- Honor it as soon as technically feasible (the AG's 2022 Sephora settlement made clear that "reasonable" is measured in seconds, not days).
+- Do not require additional account creation, sign-in, or attestation as a precondition to honoring GPC.
+- Display the consumer's opt-out status when known.
+
+A common failure mode is recognizing GPC at the page level but continuing to fire ad-tech pixels and SDKs that propagate the consumer's PI to programmatic exchanges. Treat the requirement as covering the full pixel/SDK fanout, not just the visible cookie banner.
+
+## Service Provider, Contractor, and Third Party contracts
+
+A written contract with required CPRA provisions (§1798.140(ag)(1), (j)(1)) is **mandatory** to establish Service Provider or Contractor status. Required terms include:
+
+- Specified, limited business purpose for processing.
+- Prohibition on selling or sharing the PI.
+- Prohibition on retaining, using, or disclosing the PI for any purpose other than the specified business purpose, including a prohibition on using PI outside the direct business relationship.
+- Prohibition on combining the received PI with PI from other sources except as permitted (security, fraud, regulatory).
+- Obligation to comply with applicable CCPA/CPRA obligations, including consumer-rights requests passed through.
+- Obligation to notify the business if it can no longer meet its CCPA/CPRA obligations.
+- Obligation to allow the business to take reasonable and appropriate steps to remediate unauthorized use.
+- Flow-down to subcontractors with materially equivalent restrictions.
+- Right to monitor compliance through measures such as ongoing manual reviews, automated scans, regular assessments, audits, or technical and operational testing.
+
+If the contract is missing any required term, the regulator may treat the recipient as a Third Party — and the disclosure as a "sale" or "share" requiring opt-out, notice, and Do Not Sell/Share linkage.
+
+## CPPA risk assessments and cybersecurity audits
+
+CPRA §1798.185(a)(15) directs the CPPA to issue regulations requiring businesses whose processing presents **significant risk** to consumers' privacy or security to:
+
+- **Conduct and submit risk assessments** to the CPPA on a regular basis. Triggers in the draft and adopted CPPA regulations include selling or sharing PI, processing SPI, using ADMT for significant decisions, training generative AI/ML on PI, and other high-risk processing.
+- **Perform annual independent cybersecurity audits** with appropriate scope and rigor for the size and complexity of the business and the nature of the processing. The CPPA regulations specify auditor independence, scope, methodology, retention, and certification requirements.
+
+These requirements are operative in regulatory form and have phased compliance dates — practitioners should treat the operative compliance date as a moving target through the first full enforcement cycle and confirm against the current text of 11 CCR §7150 et seq. (risk assessments) and §7120 et seq. (cybersecurity audits).
+
+## Notices and disclosures
+
+- **Notice at Collection** (§1798.100(a), 11 CCR §7012) — provided at or before the point of collection. Must enumerate categories of PI collected, categories of SPI collected, the purposes for each, whether each is sold or shared, and the retention period (or criteria) for each category. If the business uses SPI for purposes that trigger the Right to Limit, the notice must say so and link to the limit-use page.
+- **Privacy Policy** (§1798.130(a)(5), 11 CCR §7011) — a comprehensive online disclosure updated at least every 12 months. Includes the categories of PI collected in the prior 12 months, sources, business and commercial purposes, categories of recipients, sale/share status by category, retention, all consumer rights, and contact methods.
+- **Notice of Right to Opt Out / Notice of Right to Limit** — accessible from a clear and conspicuous link in the website footer. Common labels: "Do Not Sell or Share My Personal Information" and "Limit the Use of My Sensitive Personal Information." A single combined "Your Privacy Choices" link is permitted under 11 CCR §7015 with the standardized opt-out icon.
+- **Notice of Financial Incentive** (§1798.125(b)) — for any program that conditions price, level, or quality on the collection, retention, sale, or sharing of PI, including loyalty programs and bona-fide bring-your-own-discount tiers.
+
+## Enforcement and penalties
+
+- **Two enforcers**, both via civil action: the CPPA (administrative enforcement under its own procedures, 11 CCR §7300 et seq.) and the California Attorney General (civil action in superior court). Coordination is governed by an MOU but both agencies have independent authority.
+- **Civil penalties** under §1798.155: up to **US $2,500 per violation** for non-intentional violations; up to **US $7,500 per violation** for intentional violations or violations involving the personal information of consumers under 16. Each affected consumer can be a separate violation.
+- **No mandatory 30-day right to cure** for AG actions after CPRA. CPPA enforcement may, but is not required to, consider a business's good-faith efforts to comply when assessing penalties.
+- **Limited private right of action** (§1798.150) — only available for **data breaches involving non-encrypted and non-redacted personal information** (a defined subset, narrower than the general "personal information" definition) caused by the business's failure to implement and maintain reasonable security procedures and practices. Statutory damages: **US $100 to $750 per consumer per incident**, or actual damages, whichever is greater. Class-action vehicle in practice.
+- **Notable enforcement examples to internalize**:
+  - Sephora (AG, August 2022) — US $1.2 million settlement for failure to disclose sale of PI, failure to process opt-out signals (including GPC), and contract-deficiency findings. First public CCPA enforcement action and the touchstone for GPC compliance expectations.
+  - DoorDash (AG, February 2024) — US $375,000 settlement involving alleged sale of PI through a marketing co-op without proper notice/opt-out.
+  - CPPA enforcement advisories on data-broker registration and dark-pattern opt-out flows have signaled near-term enforcement priorities.
+
+## How CCPA/CPRA differs from GDPR (narrative contrast)
+
+CCPA/CPRA and the EU GDPR are both broad consumer/data-subject privacy regimes, but they're structurally different in ways that matter operationally. GDPR is **opt-in for processing** generally (a lawful basis must be established before processing) and applies to any controller or processor handling EU/EEA data subjects' personal data regardless of size. CCPA/CPRA is **opt-out for sale and sharing**, presumes the business may collect and use PI for disclosed purposes, and only applies to for-profit entities meeting the revenue/scale thresholds described above. GDPR's right to erasure mirrors CCPA's right to delete but with different exceptions; GDPR's right to data portability is broader (covers all data the subject provided and is processed by automated means under consent or contract). GDPR has a 72-hour breach notification to the supervisory authority; CCPA/CPRA has no parallel administrative breach-notification requirement (California's separate breach-notification statute, Civil Code §1798.82, governs that). GDPR fines reach the greater of €20M or 4% of global turnover; CCPA/CPRA per-violation penalties are smaller in absolute terms but accumulate rapidly. Sensitive Personal Information under CPRA partially overlaps with GDPR's special categories of personal data (Article 9) but adds account credentials and contents of communications, and provides a "right to limit" rather than a near-prohibition with enumerated exceptions. A practical implication: an organization meeting GDPR Article 5 / 6 / 9 / 13–22 obligations is *not* automatically CCPA/CPRA-compliant — it still needs the Notice at Collection, the Do Not Sell or Share / Limit Use links, GPC handling, the Service Provider / Contractor contractual terms, and the CPPA risk-assessment and cybersecurity-audit posture.
+
+Do **not** maintain a hand-curated CCPA-to-GDPR control mapping inside this plugin — use the SCF crosswalk for that.
+
+## Common misinterpretations this plugin should correct
+
+1. **"We don't sell data, so the opt-out doesn't apply."** Wrong if the business engages in cross-context behavioral advertising — that is a "share" under §1798.140(ah) and triggers the same Do Not Sell or Share link, GPC handling, and contractual obligations.
+2. **"Service Provider status protects us by default if we use the vendor's standard DPA."** Wrong if the contract is missing any of the §1798.140(ag) provisions. Vendor-default DPAs frequently lack the subcontractor flow-down or the explicit business-purpose limitation. Audit the contract against the statute, not against the vendor's marketing.
+3. **"GPC is a browser-vendor preference, not a legal opt-out."** Wrong post-Sephora. The AG and CPPA both treat GPC as a valid Universal Opt-Out Mechanism; failure to honor it is enforceable.
+4. **"Employee data is exempt."** Wrong since January 1, 2023. The HR partial exemption sunset; employee, applicant, contractor, and B2B contact PI is fully in scope.
+5. **"We're under $25M in revenue, so we're exempt."** Not necessarily. The revenue threshold is one of three independent triggers — a small business that buys, sells, or shares PI of 100,000+ California consumers/households, or that derives 50%+ of revenue from selling/sharing, is still in scope.
+6. **"The 30-day cure period gives us time to fix issues."** That mandatory cure period was removed by CPRA. Cure is now discretionary on the regulator's part.
+7. **"Anonymized data is fine."** True only if it actually meets the deidentification standard in §1798.140(m): the business has implemented technical safeguards and business processes specifically prohibiting reidentification, has implemented business processes to prevent inadvertent release, and makes no attempt to reidentify.
+8. **"HIPAA covers all of our health data, so CCPA doesn't apply."** Only the HIPAA-covered PHI itself is carved out. Health data collected outside the HIPAA context — wellness apps, web analytics on a clinic's marketing site, employee health records that are not part of the HIPAA-covered group health plan — is in scope and is SPI under §1798.140(ae).
+9. **"Adequacy or SCCs cover our cross-border transfers."** Those are GDPR concepts. CCPA/CPRA does not impose data-localization or adequacy requirements on cross-border transfers, but transferring PI to a non-Service-Provider/Contractor recipient is a "sale" or "share" regardless of destination.
+
+## Mandatory artifacts
+
+Reference-depth assessment expects a business to be able to produce or attest to the following:
+
+- **Data inventory** of PI and SPI by category, source, purpose, recipients, retention, and sale/share/limit-use status. This is not statutorily mandated as a freestanding "ROPA," but every other obligation depends on it.
+- **Privacy Policy** updated within the last 12 months containing the §1798.130(a)(5) / 11 CCR §7011 disclosures.
+- **Notice at Collection** templates for each data-collection surface (web, mobile, in-store, telephone, employment).
+- **Do Not Sell or Share My Personal Information** mechanism — link, intake page, downstream propagation.
+- **Limit the Use of My Sensitive Personal Information** mechanism — if SPI is processed beyond strictly-necessary purposes.
+- **GPC handling implementation** — server-side or client-side recognition that propagates through the ad-tech and analytics fanout.
+- **Consumer-rights intake and fulfillment workflow** — at least two methods, verification process per 11 CCR §7060, response within 45 days, training records for personnel handling requests.
+- **Service Provider / Contractor contracts** with the §1798.140(ag) / (j) provisions; a vendor inventory categorizing each recipient as Service Provider, Contractor, Third Party, or Other (e.g. CCPA-exempt by data carve-out).
+- **Risk assessment artifacts** for any processing that triggers the CPPA risk-assessment regulation (selling/sharing, SPI, ADMT for significant decisions, generative AI training on PI, etc.) — including the assessment, the management response, and the abridged version submitted to the CPPA on its required cadence.
+- **Cybersecurity audit artifacts** — independent auditor engagement, scope, methodology, findings, certification, and the abridged report submitted to the CPPA.
+- **Records of consumer-rights requests** including ticketing data, response times, dispositions, denial reasons.
+- **Training records** for personnel handling consumer requests (§1798.130(a)(6)).
+- **Metrics** for any business that processes PI of 10,000,000 or more consumers in a calendar year (§1798.130(a)(5)(B)) — number of requests received, complied with, denied, and median/mean response time, posted in the Privacy Policy.
+
+## Cadence and timelines
+
+| Obligation | Cadence | Citation |
+|---|---|---|
+| Privacy Policy update | At least every 12 months | §1798.130(a)(5) |
+| Acknowledgment of consumer request | Within 10 business days | 11 CCR §7021 |
+| Substantive response to consumer request | Within 45 calendar days (extendable once by 45 days) | §1798.130(a)(2) |
+| Honor opt-out signal (sale/share, including GPC) | As soon as feasible; reverification not for at least 12 months | §1798.135(c) |
+| Look-back for Right to Know | Generally 12 months; extended for PI collected on or after Jan 1, 2022 unless impossible / disproportionate | §1798.130(a)(2)(B) |
+| Honor opt-out from sale/share | Until consumer reconsents; cannot solicit reconsent for 12 months | §1798.135(c)(4) |
+| Notice at Collection for new data category | At or before point of collection | §1798.100(a) |
+| Annual cybersecurity audit | Annual once triggered (per CPPA regs) | §1798.185(a)(15)(A) |
+| Risk assessment | Per CPPA regs; submit abridged version on the cadence the regulation specifies | §1798.185(a)(15)(B) |
+| Public metrics for >10M-consumer businesses | Annual (in Privacy Policy) | 11 CCR §7102 |
+
+## Regulator and enforcement detail
+
+- **California Privacy Protection Agency (CPPA)** — the only privacy-dedicated state agency in the United States. Five-member board. Created by CPRA. Has rulemaking authority for all CCPA/CPRA implementing regulations, runs administrative enforcement actions through the Enforcement Division, can order compliance, and can impose civil penalties through administrative orders.
+- **California Attorney General** — retains civil enforcement authority in California superior court. Was the sole enforcer 2020–2023. Continues to handle larger and higher-profile actions; coordinates with CPPA via interagency MOU.
+- **Penalty calculation** — per violation; "violation" can be a single consumer's PI mishandled, a single failure to honor an opt-out, a single missing required disclosure. Aggregate exposure for a noncompliant data-driven business can reach the millions even at the $2,500 per-violation rate.
+- **Recent enforcement themes** — failure to honor GPC, deficient Service Provider contracts, dark-pattern opt-out flows, misclassification of "share" as not a "sale," missing or stale Notice at Collection, data-broker registration failures, and (emerging) ADMT and risk-assessment compliance.
+
+## Interaction with other frameworks
+
+- **GDPR** — overlaps substantially on rights, transparency, and vendor management. Use the SCF crosswalk to identify shared SCF controls; do not maintain a hand-mapped CCPA-to-GDPR table inside this plugin (an anti-pattern per the Framework Plugin Guide).
+- **HIPAA** — PHI carve-out; non-PHI personal information of patients (e.g. marketing, web analytics) and any non-HIPAA-covered health data is still in scope.
+- **GLBA / California Financial Information Privacy Act** — financial-account data is carved out; non-financial PI from the same institution is in scope.
+- **State analogs** — Virginia (VCDPA), Colorado (CPA), Connecticut (CTDPA), Utah (UCPA), Texas (TDPSA), and others have CCPA-influenced regimes with subtly different scope, rights, and definitions. CCPA/CPRA remains the most stringent in several dimensions (broad PI definition, extensive SPI category, GPC mandate, risk-assessment regime).
+- **NIST Privacy Framework / SP 800-53 PT family** — useful for mapping internal controls to a recognized control catalog. Use `/grc-engineer:gap-assessment` and the SCF crosswalk for control-by-control mechanics.
+- **SOC 2 Privacy criterion** — the AICPA Privacy criterion can support evidence for several CCPA/CPRA obligations (notice, choice, access, disclosure to third parties, retention) but does not substitute for the statute's specific requirements.
+
+## Command routing
+
+- `/us-ccpa:scope` — determine applicability against the three CPRA-amended thresholds and the data carve-outs; outputs an in-scope / partially / out-of-scope verdict.
+- `/us-ccpa:assess` — run a gap assessment delegated to `/grc-engineer:gap-assessment` against SCF framework `usa-state-ca-ccpa-cpra-2026`.
+- `/us-ccpa:evidence-checklist` — enumerate evidence items organized by California Civil Code section.
+
+## Levelling up to Full
+
+Full-depth plugins add framework-native workflow commands tied to the audit ritual. Candidates for CCPA/CPRA:
+
+- `/us-ccpa:risk-assessment` — generate a CPPA-compliant risk assessment package for a defined processing activity, including the abridged version for CPPA submission.
+- `/us-ccpa:cybersecurity-audit-prep` — scoping, methodology, and evidence package for the annual independent cybersecurity audit required by CPPA regulations.
+- `/us-ccpa:dsar-review` — review a sample of consumer-rights requests for verification, completeness, response time, and denial-rationale defensibility.
+- `/us-ccpa:vendor-contract-review` — assess Service Provider, Contractor, and Third Party contracts against the §1798.140(ag) / (j) checklist.
+- `/us-ccpa:gpc-validation` — runtime validation that a website honors the Sec-GPC header through the full ad-tech and analytics fanout.
+
+## Capabilities
+
+- CCPA/CPRA scope determination (three thresholds + data carve-outs + entity-affiliate hooks)
+- Privacy Policy and Notice at Collection completeness review
+- Consumer-rights workflow design (intake, verification, fulfillment, denial) per §§1798.100–1798.130 and 11 CCR §7060 et seq.
+- SPI inventory and Right to Limit applicability analysis
+- Service Provider / Contractor / Third Party classification and contract review
+- Universal Opt-Out Mechanism (Global Privacy Control) handling assessment
+- CPPA risk-assessment readiness
+- CPPA cybersecurity-audit readiness
+- Sale-versus-share distinction analysis for ad-tech and partner data flows
+- Data-broker registration scoping (Cal. Civ. Code §1798.99.80 et seq. — the Delete Act, distinct but adjacent)
+- Breach-readiness for the §1798.150 private right of action (encryption / redaction posture)
+- Cross-framework reconciliation with GDPR, HIPAA, GLBA, and other US state privacy laws (via SCF crosswalk)
+
+## References
+
+- [California Privacy Protection Agency (CPPA)](https://cppa.ca.gov)
+- [California Attorney General — CCPA](https://oag.ca.gov/privacy/ccpa)
+- California Civil Code §§1798.100–1798.199.100 (current text via the [California Legislative Information portal](https://leginfo.legislature.ca.gov))
+- 11 California Code of Regulations §7000 et seq. — CPPA regulations
+- [Secure Controls Framework](https://securecontrolsframework.com)
+- [SCF API entry for this framework](https://grcengclub.github.io/scf-api/api/crosswalks/usa-state-ca-ccpa-cpra-2026.json)


### PR DESCRIPTION
## Summary

Adds a Reference-depth framework plugin (`us-ccpa`) for the **California Consumer Privacy Act / California Privacy Rights Act** — California Civil Code §1798.100 et seq. — closing #15. The plugin walks the three CPRA-amended applicability thresholds, enumerates evidence by Civil Code section, and delegates the gap assessment to `/grc-engineer:gap-assessment` via the SCF crosswalk (`usa-state-ca-ccpa-cpra-2026`, 258 SCF → 623 framework controls).

Closes #15.

## Files shipped

The standard six Reference-depth files plus marketplace registration:

- `plugins/frameworks/us-ccpa/.claude-plugin/plugin.json` — metadata with CPPA + California AG dual-regulator block, Civil Code citation
- `plugins/frameworks/us-ccpa/README.md` — install + depth + metadata
- `plugins/frameworks/us-ccpa/commands/scope.md` — three-threshold + carve-out scope walk with applicability verdict
- `plugins/frameworks/us-ccpa/commands/evidence-checklist.md` — evidence organized by Civil Code section (§1798.100 / .105 / .106 / .110 / .115 / .120 / .121 / .125 / .130 / .135 / .140 / .145 / .150 / .185)
- `plugins/frameworks/us-ccpa/commands/assess.md` — gap-assessment wrapper with thematic scopes (`notices`, `rights`, `opt-out`, `vendors`, `risk-and-audit`, `security`)
- `plugins/frameworks/us-ccpa/skills/us-ccpa-expert/SKILL.md` — 268-line framework expertise paraphrasing the statute with section-by-section citations
- `.claude-plugin/marketplace.json` — registration entry updated to reflect CCPA/CPRA + CPPA naming

## Key framework facts encoded (for reviewer accuracy check)

- **Statute and history**: CCPA enacted 2018 (effective 2020), amended by CPRA (Prop 24, 2020, operative Jan 1 2023, enforcement July 1 2023). Codified at California Civil Code §1798.100 et seq. Implementing regs at 11 CCR §7000 et seq.
- **Applicability thresholds** (CPRA-amended, §1798.140(d)): for-profit doing business in California meeting any one of:
  - Annual gross revenue >$25M (prior calendar year)
  - Buys/sells/shares PI of ≥100,000 California consumers or households (CCPA was 50,000; CPRA raised to 100,000, removed "devices," removed "receives," added "shares")
  - Derives ≥50% of annual revenue from selling/sharing PI (CPRA added "sharing")
- **Sensitive Personal Information** (§1798.140(ae), CPRA-introduced): SSN, DL, account credentials, precise geolocation, race/ethnicity, religion, union membership, contents of mail/email/text, genetic data, biometric for ID, health data, sex life / sexual orientation. Triggers Right to Limit unless processing is strictly necessary.
- **"Sale" vs "Share"**: §1798.140(ad) sale = consideration (monetary or other valuable); §1798.140(ah) share = cross-context behavioral advertising regardless of consideration. CPRA-added "share" closes the adtech loophole.
- **Seven consumer rights**: Know (§§1798.100/110/115), Delete (§1798.105), Correct (§1798.106 — new in CPRA), Opt Out of Sale/Share (§§1798.120/135), Limit Use of SPI (§1798.121 — new in CPRA), Non-Discrimination (§1798.125), Data Portability (within Right to Know).
- **Universal Opt-Out Mechanism (GPC)**: mandatory under §1798.135(b) and 11 CCR §7025; Sephora settlement (Aug 2022) is the GPC-enforcement touchstone.
- **CPPA risk assessments and annual cybersecurity audits**: §1798.185(a)(15) authorizes; 11 CCR §7150 et seq. and §7120 et seq. operative.
- **Service Provider / Contractor / Third Party**: §1798.140(ag), (j), (ai); contractual provisions in §1798.140(ag)(1) / (j)(1) are mandatory; missing provisions reclassify the recipient as a Third Party.
- **Penalties** (§1798.155): up to $2,500 per violation; $7,500 per intentional or minor-involving violation. CPRA removed the AG's mandatory 30-day cure period.
- **Private right of action** (§1798.150): limited to data breaches of non-encrypted, non-redacted PI from failure to maintain reasonable security; $100–$750 per consumer per incident.
- **Two enforcers**: CPPA (administrative) + California Attorney General (civil action).
- **Carve-outs** (§§1798.145, 1798.146): data-level (not entity-level) for HIPAA/CMIA, GLBA/CFIPA, FCRA, DPPA, clinical-trial information.
- **Sunset**: B2B and HR partial exemptions sunset Jan 1, 2023 — employee, applicant, contractor, and B2B PI fully in scope.
- **GDPR contrast**: narrative paragraph in SKILL.md noting CCPA/CPRA is opt-out for sale/share and threshold-gated, GDPR is opt-in with lawful-basis requirement and applies regardless of size; SPI partially overlaps GDPR Article 9 special categories but adds account credentials and contents of communications. **No hand-curated CCPA-to-GDPR mapping table** — uses the SCF crosswalk per the Framework Plugin Guide anti-pattern.

## Validation

- [x] `bash tests/validate-plugin-manifests.sh` prints "All manifests valid" and "Marketplace registration matches 41 plugin manifest(s)."
- [x] No `TODO:` markers remain in the SKILL body or commands.
- [x] No verbatim statute prose — all citations are by California Civil Code section number.
- [x] Cloud-agnostic; vendor examples optional.
- [x] No hand-curated cross-framework mapping table.

## Test plan

- [ ] Reviewer confirms statute citations resolve to the correct California Civil Code sections.
- [ ] Reviewer confirms the three CPRA-amended thresholds are stated correctly and the CCPA-vs-CPRA delta callouts are accurate.
- [ ] Reviewer confirms the SPI category enumeration matches §1798.140(ae).
- [ ] Reviewer confirms the Service Provider / Contractor required-provision list matches §1798.140(ag)(1) / (j)(1).
- [ ] Reviewer runs `/plugin install us-ccpa@grc-engineering-suite` followed by `/us-ccpa:scope` and confirms the scope walk produces a meaningful applicability verdict.
- [ ] Reviewer runs `/us-ccpa:evidence-checklist` and confirms it groups by Civil Code section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)