### PR TITLE
chore(release): prepare 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes follow the format from [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+## [0.0.3] — 2026-04-30
+
 ### Added
 
 - **Quickstart plugin decision tree.** `docs/QUICKSTART.md` now includes a "Which plugin do I need?" flowchart covering connectors, framework plugins, persona plugins, learning support, OSCAL/FedRAMP utilities, and the compliance posture dashboard. Closes [#36](https://github.com/GRCEngClub/claude-grc-engineering/issues/36).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grc-engineering-plugin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "GRC engineering toolkit for Claude Code: connector findings to SCF crosswalk to multi-framework gap reports, policy-as-code, OSCAL workflows.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary\n- bump package version to 0.0.3\n- move current changelog entries under 0.0.3 dated 2026-04-30\n\n## Validation\n- bash tests/validate-plugin-manifests.sh\n- npm run test:contract