### PR TITLE
[codex] Add scheduled automation metrics snapshot workflow

### DIFF
--- a/docs/GRC-DATA.md
+++ b/docs/GRC-DATA.md
@@ -132,3 +132,28 @@ node plugins/grc-engineer/scripts/record-automation-metrics.js \
   --config=plugins/grc-engineer/examples/automation-metrics.yaml \
   --window-label=current-week
 ```
+
+### Scheduled Automation Snapshots
+
+PR #54 introduced the reporting flows that consume automation-history metrics.
+To keep those reports useful without relying on someone to run the writer by
+hand, copy the scheduled GitHub Actions template at
+[`plugins/grc-engineer/examples/github-actions/automation-metrics-snapshot.yml`](../plugins/grc-engineer/examples/github-actions/automation-metrics-snapshot.yml)
+into `.github/workflows/` in the adopting repo.
+
+The template runs `record-automation-metrics.js` in batch mode with
+`--config=./automation-metrics.yaml`, uploads generated `grc-data/metrics/`
+files as an artifact, and opens a pull request when snapshots changed. Reviewers
+should check:
+
+- the `window.label` matches the intended reporting period
+- `measurement_scope: tooling-capability` rows are treated as toolkit coverage
+  potential, not as proof that automation ran in production
+- `measurement_scope: operator-observed` rows were validated against the target
+  environment before they feed leadership reporting
+- unexpected deletions or count swings are explained before merge
+
+Teams with mature controls around generated GRC data may change the final step
+to commit directly to the default branch. If they do, keep the artifact upload
+or another audit trail so reviewers can reconstruct what the scheduled run
+generated and when.

--- a/plugins/grc-engineer/commands/monitor-continuous.md
+++ b/plugins/grc-engineer/commands/monitor-continuous.md
@@ -160,6 +160,10 @@ For trend analysis over time, consume the JSON output (or the `grc-data/metrics/
 snapshots written when `record_metrics` is enabled) with a reporting workflow
 such as `/report:exec-summary`.
 
+If you only need scheduled automation-history snapshots for the PR #54 reporting
+flows, use the copy-pasteable GitHub Actions template at
+[`examples/github-actions/automation-metrics-snapshot.yml`](../examples/github-actions/automation-metrics-snapshot.yml).
+
 ## Setup
 
 ### 1. Stage a config file

--- a/plugins/grc-engineer/examples/automation-metrics.yaml
+++ b/plugins/grc-engineer/examples/automation-metrics.yaml
@@ -5,15 +5,18 @@ defaults:
     audience: ciso-weekly
 
 entries:
+  # Derived FedRAMP entries produce measurement_scope: tooling-capability.
   - framework: fedramp-moderate
     provider: aws
 
+  # Manual entries produce measurement_scope: operator-observed.
   - framework: soc2
     controls_total: 64
     controls_automated: 22
     dimensions:
       business_unit: platform
 
+  # Manual entries should use counts validated against the target environment.
   - framework: iso27001
     controls_total: 93
     controls_automated: 40

--- a/plugins/grc-engineer/examples/github-actions/automation-metrics-snapshot.yml
+++ b/plugins/grc-engineer/examples/github-actions/automation-metrics-snapshot.yml
@@ -3,6 +3,10 @@
 # This workflow keeps grc-data/metrics/ current for the reporting flows added
 # by PR #54. It opens a review PR by default so humans can verify generated
 # snapshots before they become leadership-reporting inputs.
+#
+# Prerequisite: this template expects the claude-grc-engineering toolkit to be
+# present in the adopting repo, including:
+# plugins/grc-engineer/scripts/record-automation-metrics.js
 name: GRC automation metrics snapshot
 
 on:
@@ -30,15 +34,18 @@ env:
   # measurement_scope: tooling-capability for derived baselines and
   # measurement_scope: operator-observed for manual counts.
   METRICS_CONFIG: ./automation-metrics.yaml
+  WINDOW_LABEL_INPUT: ${{ github.event.inputs.window_label || '' }}
 
 jobs:
   snapshot:
     name: Record automation metric snapshots
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/setup-node@v4
+      # actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20'
 
@@ -49,7 +56,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          WINDOW_LABEL="${{ github.event.inputs.window_label || '' }}"
+          WINDOW_LABEL="$WINDOW_LABEL_INPUT"
           if [ -z "$WINDOW_LABEL" ]; then
             WINDOW_LABEL="$(date -u +'%G-W%V')"
           fi
@@ -62,14 +69,16 @@ jobs:
         run: git diff -- grc-data/metrics/
 
       - name: Upload generated snapshots for review
-        uses: actions/upload-artifact@v4
+        # actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: grc-automation-metrics
           path: grc-data/metrics/
           if-no-files-found: warn
 
       - name: Open review PR if snapshots changed
-        uses: peter-evans/create-pull-request@v6
+        # peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           commit-message: 'chore(grc): record automation metric snapshots'
           title: 'chore(grc): record automation metric snapshots'

--- a/plugins/grc-engineer/examples/github-actions/automation-metrics-snapshot.yml
+++ b/plugins/grc-engineer/examples/github-actions/automation-metrics-snapshot.yml
@@ -1,0 +1,87 @@
+# Copy to .github/workflows/grc-automation-metrics-snapshot.yml in your repo.
+#
+# This workflow keeps grc-data/metrics/ current for the reporting flows added
+# by PR #54. It opens a review PR by default so humans can verify generated
+# snapshots before they become leadership-reporting inputs.
+name: GRC automation metrics snapshot
+
+on:
+  schedule:
+    # Weekly on Mondays at 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      window_label:
+        description: 'Reporting window label, for example 2026-W16. Defaults to current ISO week.'
+        required: false
+        type: string
+
+concurrency:
+  group: grc-automation-metrics-snapshot
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  # Copy plugins/grc-engineer/examples/automation-metrics.yaml to your repo
+  # root and edit it for your frameworks. The metric writer emits
+  # measurement_scope: tooling-capability for derived baselines and
+  # measurement_scope: operator-observed for manual counts.
+  METRICS_CONFIG: ./automation-metrics.yaml
+
+jobs:
+  snapshot:
+    name: Record automation metric snapshots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Record batch snapshot
+        run: |
+          set -euo pipefail
+
+          WINDOW_LABEL="${{ github.event.inputs.window_label || '' }}"
+          if [ -z "$WINDOW_LABEL" ]; then
+            WINDOW_LABEL="$(date -u +'%G-W%V')"
+          fi
+
+          node plugins/grc-engineer/scripts/record-automation-metrics.js \
+            --config="$METRICS_CONFIG" \
+            --window-label="$WINDOW_LABEL"
+
+      - name: Show generated snapshot diff
+        run: git diff -- grc-data/metrics/
+
+      - name: Upload generated snapshots for review
+        uses: actions/upload-artifact@v4
+        with:
+          name: grc-automation-metrics
+          path: grc-data/metrics/
+          if-no-files-found: warn
+
+      - name: Open review PR if snapshots changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'chore(grc): record automation metric snapshots'
+          title: 'chore(grc): record automation metric snapshots'
+          body: |
+            Weekly automation metric snapshot for `grc-data/metrics/`.
+
+            Review checklist:
+            - Confirm the reporting window label matches the intended period.
+            - Confirm `measurement_scope: tooling-capability` rows are not presented as live operator-observed performance.
+            - Confirm `measurement_scope: operator-observed` counts were validated against the running environment.
+
+            This supports the PR #54 reporting intent: keep automation-history
+            snapshots fresh so `/report:automation-coverage` can show trends.
+          branch: bot/grc-automation-metrics
+          delete-branch: true


### PR DESCRIPTION
## Summary
- Adds a copy-pasteable scheduled GitHub Actions workflow for automation metrics snapshots.
- Runs `record-automation-metrics.js` in batch mode and opens a review PR when generated metrics change.
- Documents review/direct-commit handling and keeps tooling-capability vs operator-observed sources explicit.

Closes #57.

## Validation
- `node -e ... yaml.load(...)` for metrics config and workflow template
- `node plugins/grc-engineer/scripts/record-automation-metrics.js --config=plugins/grc-engineer/examples/automation-metrics.yaml --window-label=2026-W16 --dry-run`
- `git diff --check`
- `npm run test:contract`

## Caveat
The workflow template was validated as YAML but was not executed inside GitHub Actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on automating metrics snapshots via GitHub Actions workflow.
  * Introduced reviewer verification criteria for measurement scope validation and audit trail requirements.
  * Added reference documentation to metrics configuration examples.

* **New Features**
  * Introduced scheduled/manual GitHub Actions workflow for recording automation metric snapshots with artifact uploads and automated PR generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->