### PR TITLE
[codex] Add pre-commit hook configuration

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD024": false,
+    "MD029": false,
+    "MD031": false,
+    "MD032": false,
+    "MD033": false,
+    "MD034": false,
+    "MD036": false,
+    "MD040": false,
+    "MD041": false,
+    "MD046": false,
+    "MD047": false
+  },
+  "globs": [
+    "**/*.md",
+    "!node_modules/**",
+    "!.claude/**"
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+
+  - repo: local
+    hooks:
+      - id: markdownlint-cli2
+        name: markdownlint-cli2
+        entry: markdownlint-cli2
+        language: node
+        additional_dependencies: ["markdownlint-cli2@0.18.1"]
+        types: [markdown]
+
+      - id: validate-finding-fixtures
+        name: validate finding fixtures
+        entry: tests/pre-commit-validate-findings.sh
+        language: node
+        additional_dependencies: ["ajv-cli@5.0.0", "ajv-formats@3.0.1"]
+        files: ^tests/fixtures/findings/.*\.json$
+        pass_filenames: true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,241 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "^\\.git/"
+      ]
+    }
+  ],
+  "results": {
+    "plugins/connectors/github-inspector/scripts/collect.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/connectors/github-inspector/scripts/collect.js",
+        "hashed_secret": "3ea3f9802accf8817bacd6f3df46a73b93ccddec",
+        "is_verified": false,
+        "line_number": 252
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/connectors/github-inspector/scripts/collect.js",
+        "hashed_secret": "07596f183f5e91b1778d5e47b2752b8d42aa763d",
+        "is_verified": false,
+        "line_number": 254
+      }
+    ],
+    "plugins/frameworks/stateramp/commands/evidence-checklist.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/frameworks/stateramp/commands/evidence-checklist.md",
+        "hashed_secret": "08d2e98e6754af941484848930ccbaddfefe13d6",
+        "is_verified": false,
+        "line_number": 612
+      }
+    ],
+    "plugins/grc-engineer/commands/generate-implementation.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/grc-engineer/commands/generate-implementation.md",
+        "hashed_secret": "08d2e98e6754af941484848930ccbaddfefe13d6",
+        "is_verified": false,
+        "line_number": 456
+      }
+    ],
+    "plugins/grc-engineer/config/frameworks/export-control/pbmm.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/grc-engineer/config/frameworks/export-control/pbmm.yaml",
+        "hashed_secret": "1f6904e1e2636d9c3b07dd87e1c0b9f65678a709",
+        "is_verified": false,
+        "line_number": 125
+      }
+    ],
+    "plugins/grc-engineer/config/frameworks/nist800-53/ac-access-control.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/grc-engineer/config/frameworks/nist800-53/ac-access-control.yaml",
+        "hashed_secret": "1f6904e1e2636d9c3b07dd87e1c0b9f65678a709",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/grc-engineer/config/frameworks/nist800-53/ac-access-control.yaml",
+        "hashed_secret": "a6fdff6f2ad039cef668b071790b3c2383294c9f",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
+    "plugins/grc-engineer/config/frameworks/nist800-53/ia-identification-authentication.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/grc-engineer/config/frameworks/nist800-53/ia-identification-authentication.yaml",
+        "hashed_secret": "1f6904e1e2636d9c3b07dd87e1c0b9f65678a709",
+        "is_verified": false,
+        "line_number": 46
+      }
+    ],
+    "plugins/grc-engineer/config/frameworks/nist800-53/ps-personnel-security.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/grc-engineer/config/frameworks/nist800-53/ps-personnel-security.yaml",
+        "hashed_secret": "a6fdff6f2ad039cef668b071790b3c2383294c9f",
+        "is_verified": false,
+        "line_number": 86
+      }
+    ],
+    "plugins/grc-engineer/config/providers/kubernetes.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/grc-engineer/config/providers/kubernetes.yaml",
+        "hashed_secret": "b13677dd1d3df49753fc88d7bc62e54931ca50e3",
+        "is_verified": false,
+        "line_number": 433
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/grc-engineer/config/providers/kubernetes.yaml",
+        "hashed_secret": "b4a00ca6f07ec7ddb574d8dfd624a94994bbfa03",
+        "is_verified": false,
+        "line_number": 433
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/grc-engineer/config/providers/kubernetes.yaml",
+        "hashed_secret": "dae5497dd616b09cf0978a13022cf0ca0ee85738",
+        "is_verified": false,
+        "line_number": 514
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/grc-engineer/config/providers/kubernetes.yaml",
+        "hashed_secret": "9d29a80abc434864b2485aa502e9012bd846a206",
+        "is_verified": false,
+        "line_number": 555
+      }
+    ]
+  },
+  "generated_at": "2026-04-30T03:26:54Z"
+}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -193,7 +193,15 @@ Everyone who lands a merged PR shows up on the [contributors graph](https://gith
 ## Security
 
 - **Reporting vulnerabilities**: open a [private security advisory](https://github.com/GRCEngClub/claude-grc-engineering/security/advisories/new) on GitHub. Don't file public issues for security problems.
-- **Secrets**: never commit credentials, tokens, org IDs, or internal URLs. Run a local secret scanner before pushing: [`git-secrets`](https://github.com/awslabs/git-secrets), [`detect-secrets`](https://github.com/Yelp/detect-secrets), or [`trufflehog`](https://github.com/trufflesecurity/trufflehog). A shipped pre-commit hook is on the v0.2 roadmap; until then, the only gate is the one you run locally.
+- **Secrets**: never commit credentials, tokens, org IDs, or internal URLs. The repo ships a `pre-commit` configuration that runs [`detect-secrets`](https://github.com/Yelp/detect-secrets), markdown linting, large-file checks, and Finding-schema validation before commits. Install it before opening a PR:
+
+  ```bash
+  pip install pre-commit
+  pre-commit install
+  pre-commit run --all-files
+  ```
+
+  If `pip install pre-commit` is blocked by your Python distribution, install it with `pipx` or a virtual environment instead. Keep `.secrets.baseline` current when intentionally adding low-signal examples, but do not baseline real credentials.
 - **Evidence artifacts**: the evidence-checklist commands write to `evidence/` (gitignored). That directory holds real usernames, credential reports, MFA device states, and privileged-account inventories. Never commit it. If you find it in a PR, reject the PR and ask the contributor to rotate any exposed credentials. For GDPR-scoped work, raw exports may carry personal data subject to Art. 5 minimization and storage-limitation rules: keep only what you need and delete on a schedule.
 
 ## Questions?

--- a/tests/pre-commit-validate-findings.sh
+++ b/tests/pre-commit-validate-findings.sh
@@ -8,7 +8,7 @@ if [[ "$#" -eq 0 ]]; then
 fi
 
 if ! command -v ajv >/dev/null 2>&1; then
-  echo "ajv-cli not found. Run: npm install" >&2
+  echo "ajv-cli not found. Rebuild the hook env with: pre-commit clean && pre-commit install" >&2
   exit 2
 fi
 

--- a/tests/pre-commit-validate-findings.sh
+++ b/tests/pre-commit-validate-findings.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATH="./node_modules/.bin:$PATH"
+
+if [[ "$#" -eq 0 ]]; then
+  exit 0
+fi
+
+if ! command -v ajv >/dev/null 2>&1; then
+  echo "ajv-cli not found. Run: npm install" >&2
+  exit 2
+fi
+
+for finding in "$@"; do
+  ajv validate \
+    --spec=draft2020 \
+    -c ajv-formats \
+    -s schemas/finding.schema.json \
+    -d "$finding" \
+    --errors=line
+done


### PR DESCRIPTION
## Summary
- Adds a root `.pre-commit-config.yaml` with detect-secrets, large-file checks, markdownlint-cli2, and staged Finding-schema validation.
- Commits an initial `.secrets.baseline` for existing low-signal keyword matches.
- Adds contributor setup instructions for installing and running pre-commit.

Closes #35.

## Validation
- `/tmp/grc-precommit-issue35/bin/pre-commit run --all-files`
- `npm run test:contract`
- `git diff --check`

## Notes
- Markdownlint is configured to avoid the legacy noisy rules that caused the prior markdown lint CI gate to be removed in v0.0.3.
