### PR TITLE
[codex] Add Japan APPI reference framework plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -279,6 +279,12 @@
       "source": "./plugins/dashboards/compliance-posture",
       "description": "Localhost compliance posture dashboard for monitor-continuous JSON output. Reference implementation of the Dashboards category from RFC #38.",
       "version": "0.1.0"
+    },
+    {
+      "name": "jp-appi",
+      "source": "./plugins/frameworks/jp-appi",
+      "description": "Japan APPI reference plugin with scope, evidence checklist, and SCF-backed gap assessment.",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/frameworks/jp-appi/.claude-plugin/plugin.json
+++ b/plugins/frameworks/jp-appi/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "jp-appi",
+  "description": "Japan APPI - Reference plugin with evidence checklist, scope determination, and SCF-backed gap assessment. Level up to Full by adding framework-specific workflow commands.",
+  "version": "0.1.0",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "framework_metadata": {
+    "scf_framework_id": "apac-jpn-ppi-2020",
+    "display_name": "Japan - Act on the Protection of Personal Information (2020)",
+    "region": "APAC",
+    "country": "JP",
+    "depth": "reference",
+    "scf_controls_mapped": 58,
+    "framework_controls_mapped": 134,
+    "industry": ["privacy", "data-protection", "cross-border-transfer"],
+    "regulator": "Personal Information Protection Commission (PPC), Japan"
+  }
+}

--- a/plugins/frameworks/jp-appi/.claude-plugin/plugin.json
+++ b/plugins/frameworks/jp-appi/.claude-plugin/plugin.json
@@ -13,7 +13,7 @@
     "depth": "reference",
     "scf_controls_mapped": 58,
     "framework_controls_mapped": 134,
-    "industry": ["privacy", "data-protection", "cross-border-transfer"],
+    "industry": [],
     "regulator": "Personal Information Protection Commission (PPC), Japan"
   }
 }

--- a/plugins/frameworks/jp-appi/README.md
+++ b/plugins/frameworks/jp-appi/README.md
@@ -1,0 +1,38 @@
+# jp-appi - Japan APPI
+
+Reference-depth framework plugin. Install and run:
+
+```bash
+/plugin install jp-appi@grc-engineering-suite
+/jp-appi:scope                    # determine applicability first
+/jp-appi:evidence-checklist       # see what to collect
+/jp-appi:assess                   # run the gap assessment
+```
+
+## Status: Reference
+
+This plugin is at **Reference depth** - it provides scope determination, evidence checklist, and a framework-specific gap assessment, all backed by the SCF crosswalk (58 SCF controls -> 134 APPI/PPI controls).
+
+### Level up to Full
+
+Full depth adds framework-native workflow commands tied to the audit ritual. If you have domain expertise for Japan APPI, see the [Framework Plugin Guide](../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the level-up checklist.
+
+## Metadata
+
+| | |
+|---|---|
+| SCF framework ID | `apac-jpn-ppi-2020` |
+| Region | APAC |
+| Country | JP |
+| SCF controls mapped | 58 |
+| Framework controls mapped | 134 |
+| Depth | Reference |
+| Regulator | Personal Information Protection Commission (PPC), Japan |
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com) - crosswalk source (CC BY-ND 4.0)
+- [SCF API entry](https://hackidle.github.io/scf-api/api/crosswalks/apac-jpn-ppi-2020.json)
+- [Personal Information Protection Commission, Japan](https://www.ppc.go.jp/en/)
+- [PPC English APPI translation](https://www.ppc.go.jp/files/pdf/APPI_english.pdf)
+- [Japanese Law Translation: Act on the Protection of Personal Information](https://www.japaneselawtranslation.go.jp/en/laws/view/4241/en)

--- a/plugins/frameworks/jp-appi/commands/assess.md
+++ b/plugins/frameworks/jp-appi/commands/assess.md
@@ -1,0 +1,44 @@
+---
+description: Japan - Act on the Protection of Personal Information (2020) compliance gap assessment
+---
+
+# Japan APPI Assessment
+
+Runs a compliance gap assessment against **Japan's Act on the Protection of Personal Information (APPI)** by delegating to `/grc-engineer:gap-assessment` with the framework's SCF identifier, then overlays APPI-specific context and evidence requirements.
+
+## Usage
+
+```
+/jp-appi:assess [--scope=<scope>] [--sources=<connector-list>]
+```
+
+## Arguments
+
+- `--scope=<scope>` (optional) - narrow the assessment to an APPI workstream such as `purpose-use`, `security-controls`, `third-party-transfer`, `cross-border-transfer`, `breach-response`, `data-subject-rights`, or `entrustee-management`.
+- `--sources=<connector-list>` (optional) - comma-separated connector plugins.
+
+## What the assessment produces
+
+1. **Compliance score** - overall APPI readiness percentage, weighted by mapped SCF controls.
+2. **Applicable-requirements summary** - which parts of the framework apply to the organization (see `/jp-appi:scope` to narrow this down first).
+3. **Control-by-control gap** - every 134 mapped control, with pass/fail/inconclusive status from connector findings.
+4. **Evidence gaps** - controls where no evidence source is configured.
+5. **Remediation roadmap** - prioritized by severity and effort.
+
+## Delegation
+
+Under the hood:
+
+```
+/grc-engineer:gap-assessment "apac-jpn-ppi-2020" [--sources=<connector-list>]
+```
+
+The SCF crosswalk expands 58 SCF controls into the 134 APPI/PPI mapped controls.
+
+## Framework-specific notes
+
+- Start with `/jp-appi:scope` when the organization is outside Japan, because APPI can still apply through Japan-facing goods or services.
+- Common assessment scopes are cross-border transfer, breach readiness, vendor/entrustee supervision, privacy notice and purpose-of-use governance, and retained personal data rights handling.
+- For GDPR-adjacent programs, verify that EU adequacy analysis does not obscure APPI-specific onward transfer, third-party provision, and affected-person notification requirements.
+- There is no APPI certification cycle equivalent to SOC 2 Type II or PCI ROC. Use recurring privacy governance, incident exercises, vendor reviews, and data-flow changes as cadence drivers.
+- Treat the SCF ID `apac-jpn-ppi-2020` as canonical for tooling even when stakeholders refer to the law as APPI or Japan PPI.

--- a/plugins/frameworks/jp-appi/commands/assess.md
+++ b/plugins/frameworks/jp-appi/commands/assess.md
@@ -21,7 +21,7 @@ Runs a compliance gap assessment against **Japan's Act on the Protection of Pers
 
 1. **Compliance score** - overall APPI readiness percentage, weighted by mapped SCF controls.
 2. **Applicable-requirements summary** - which parts of the framework apply to the organization (see `/jp-appi:scope` to narrow this down first).
-3. **Control-by-control gap** - every 134 mapped control, with pass/fail/inconclusive status from connector findings.
+3. **Control-by-control gap** - all 134 mapped controls, with pass/fail/inconclusive status from connector findings.
 4. **Evidence gaps** - controls where no evidence source is configured.
 5. **Remediation roadmap** - prioritized by severity and effort.
 

--- a/plugins/frameworks/jp-appi/commands/evidence-checklist.md
+++ b/plugins/frameworks/jp-appi/commands/evidence-checklist.md
@@ -1,0 +1,41 @@
+---
+description: Evidence checklist for Japan - Act on the Protection of Personal Information (2020), organized by control family
+---
+
+# Japan APPI Evidence Checklist
+
+Baseline evidence checklist for a Japan APPI assessment. The SCF crosswalk maps 58 SCF controls to the 134 APPI/PPI controls; this command enumerates what evidence tends to be expected for each SCF family that's in scope.
+
+## Usage
+
+```
+/jp-appi:evidence-checklist [--family=<SCF_family_code>]
+```
+
+## Arguments
+
+- `--family=<SCF_family_code>` (optional) - restrict to a single SCF family (e.g. `IAC`, `CRY`, `AST`, `BCD`). Defaults to all families mapped for this framework.
+
+## Output
+
+Markdown checklist grouped by SCF family with:
+
+- SCF control ID -> framework-native control ID(s) (from crosswalk)
+- Evidence types typically expected (logs, configs, policy documents, tickets, training records)
+- Which connector plugins can collect each type automatically
+- Which items require manual upload / narrative
+
+## Framework-specific evidence
+
+Collect APPI evidence around the actual Japanese personal-data lifecycle:
+
+- **Purpose of use and notices**: published privacy notices, internal purpose-of-use register, collection forms, consent language, and change approvals.
+- **Data inventory and retained personal data**: systems holding Japanese personal data, data categories, retention/deletion rules, and request-handling logs for disclosure, correction, suspension of use, or deletion.
+- **Third-party provision**: recipient lists, legal basis/consent or opt-out records, joint-use notices, transfer logs, and approval records.
+- **Cross-border transfer**: destination countries, recipient safeguards, consent/disclosure records, equivalent-measures monitoring, and onward-transfer review.
+- **Security controls**: access reviews, encryption/key management, logging, vulnerability management, endpoint controls, and incident response evidence for personal-data systems.
+- **Entrustee supervision**: processor/entrustee contracts, due diligence, security questionnaires, sub-entrustee approvals, and periodic oversight results.
+- **Breach response**: incident intake, triage criteria, PPC reporting analysis, notification records, final incident report, and lessons learned.
+- **Pseudonymously or anonymously processed information**: generation rules, separation of re-identification keys, access controls, use restrictions, and disclosure controls.
+
+Prefer structured exports from identity, ticketing, DLP, logging, vendor-management, and data-inventory systems over screenshots. Where evidence is narrative, capture the owner, approval date, scope, and affected processing activity.

--- a/plugins/frameworks/jp-appi/commands/scope.md
+++ b/plugins/frameworks/jp-appi/commands/scope.md
@@ -1,0 +1,36 @@
+---
+description: Determine which parts of Japan - Act on the Protection of Personal Information (2020) apply to the organization
+---
+
+# Japan APPI Scope
+
+Determines whether and how **Japan's Act on the Protection of Personal Information (APPI)** applies to the organization. Reference-depth scope is a decision-tree prompt; Full-depth plugins extend this with jurisdiction-aware logic.
+
+## Usage
+
+```
+/jp-appi:scope
+```
+
+## What this produces
+
+- **Applicability verdict**: In-scope / out-of-scope / partially in-scope, with the triggers that led there
+- **In-scope APPI roles**: personal information handling business operator, entrustee, joint-use participant, or third-party recipient
+- **In-scope data/systems**: personal information, personal data, retained personal data, personal-related information, and pseudonymously or anonymously processed information
+- **Jurisdiction reach**: Japan operations and qualifying offshore goods or services offered to individuals in Japan
+- **Carve-outs**: statutory exclusions or low-risk populations the organization can document
+- **Next steps**: whether to proceed with `/jp-appi:assess` or `/jp-appi:evidence-checklist`
+
+## Framework-specific scope triggers
+
+Ask the minimum questions needed to classify APPI applicability:
+
+- Does the organization handle personal information about individuals in Japan?
+- Does it provide goods or services to individuals in Japan, even from outside Japan?
+- Is the organization acting as a personal information handling business operator, an entrusted processor, or both?
+- Does it handle retained personal data used for access, correction, suspension of use, or deletion requests?
+- Are there third-party provisions, joint-use arrangements, outsourced processing, or cross-border transfers?
+- Are there pseudonymously processed information, anonymously processed information, or personal-related information flows?
+- Are sector rules also relevant, such as finance, healthcare, telecom, public-sector, or critical infrastructure obligations?
+
+Return an applicability verdict, the data populations in scope, the APPI roles involved, and which follow-up command should run next. Do not ask users to search the Act; translate answers into practical APPI scoping outcomes.

--- a/plugins/frameworks/jp-appi/skills/jp-appi-expert/SKILL.md
+++ b/plugins/frameworks/jp-appi/skills/jp-appi-expert/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: jp-appi-expert
+description: Japan APPI expert for the Act on the Protection of Personal Information. Reference-depth framework plugin with scope determination, evidence checklist, and SCF-backed assessment guidance for Japanese personal data.
+allowed-tools: Read, Glob, Grep, Write
+---
+
+# Japan APPI Expert
+
+Reference-depth expertise for **Japan's Act on the Protection of Personal Information (APPI)**, represented in SCF as `apac-jpn-ppi-2020`. This plugin bundles the SCF crosswalk (58 SCF controls -> 134 framework controls) with APPI-specific assessment context.
+
+## Framework Identity
+
+- **SCF framework ID**: `apac-jpn-ppi-2020`
+- **Region**: APAC
+- **Country**: JP
+- **Regulator**: Personal Information Protection Commission (PPC), Japan
+- **Common shorthand**: APPI / Japan PPI
+- **Current assessment baseline**: amended APPI fully in effect from April 1, 2022
+
+### Framework In Plain Language
+
+APPI is Japan's national privacy law for organizations that handle personal information and retained personal data. It focuses on purpose specification, fair collection and use, security safeguards, third-party disclosure, cross-border transfer, breach response, and individual rights. For GRC work, treat APPI as both a privacy governance framework and an operational evidence framework: the assessor needs to see where Japanese personal data is collected, how it is used, who receives it, how incidents are escalated, and whether transfer and consent records match actual system flows.
+
+### Territorial Scope And Applicability
+
+APPI applies to business operators handling personal information in Japan and can reach foreign operators that provide goods or services to individuals in Japan and handle their personal information. Scope analysis should identify whether the organization is a personal information handling business operator, whether it handles retained personal data, and whether it transfers personal data to third parties or recipients outside Japan. Do not assume APPI is only for Japan-incorporated entities; customer location, service targeting, and Japan data flows matter.
+
+### Mandatory Artifacts
+
+Evidence usually centers on documented purposes of use, privacy notices, consent and opt-out records, third-party transfer records, cross-border transfer disclosures, processor or entrustee management, security-control policies, breach response procedures, and data subject request handling records. APPI does not mirror GDPR's Article 30 ROPA or DPIA terminology, but mature programs should maintain equivalent data inventories, transfer registers, incident logs, and vendor oversight files so APPI obligations can be demonstrated.
+
+### Cadence And Timelines
+
+There is no SOC-style annual certification cycle in APPI. Assess recurring operating evidence on a risk-based cadence: access reviews, vendor reviews, privacy notice updates, transfer records, consent changes, and breach exercises should be refreshed when systems or purposes change and at least during annual privacy governance review. Breach reporting under the amended APPI is mandatory for specified incident categories; teams should preserve both the initial triage timeline and final report package to the PPC, plus affected-individual notification analysis.
+
+### Regulator And Enforcement
+
+The Personal Information Protection Commission (PPC) is Japan's data protection regulator. PPC oversight can involve guidance, recommendations, orders, reporting demands, and administrative or criminal consequences for serious non-compliance. In assessment output, separate legal penalty analysis from technical control evidence: this plugin should identify likely gaps and evidence needs, not provide a penalty calculation.
+
+### Interaction With Other Frameworks
+
+APPI commonly overlaps with GDPR for EU-Japan transfers, especially because Japan has an EU adequacy decision with supplementary rules. It also overlaps with ISO 27001/27002, SOC 2 privacy/security criteria, NIST privacy and security controls, and sectoral Japanese obligations for finance, healthcare, telecom, and government suppliers. Use the SCF crosswalk for control mechanics, but keep APPI-specific reporting focused on Japanese personal-data purpose, disclosure, transfer, and breach obligations.
+
+### Common Misinterpretations
+
+- **"APPI only applies to companies incorporated in Japan."** Foreign operators can be in scope when they provide goods or services to people in Japan and handle their personal information.
+- **"EU adequacy means no APPI transfer work is needed."** Adequacy helps EU-to-Japan transfers, but APPI still requires evidence for onward transfer, third-party provision, purpose limitation, and security safeguards.
+- **"Breach notification is voluntary guidance."** The amended APPI made PPC reporting and affected-person notification mandatory for specified breach categories; assessors should request incident triage and notification evidence.
+- **"Pseudonymized information is unregulated."** APPI introduced specific handling rules for pseudonymously processed information; teams still need governance over creation, separation, access, and downstream use.
+
+## Command Routing
+
+- `/jp-appi:scope` - determine applicability
+- `/jp-appi:assess` - run a gap assessment
+- `/jp-appi:evidence-checklist` - enumerate evidence requirements
+
+All three delegate to `/grc-engineer:gap-assessment` with SCF framework ID `apac-jpn-ppi-2020` for the control-by-control mechanics, and wrap the results in APPI-specific terminology.
+
+## Levelling Up To Full
+
+Full-depth plugins add framework-specific workflow commands tied to the audit ritual. Candidates for this framework:
+
+- `/jp-appi:breach-triage` - classify whether an incident likely triggers PPC reporting and affected-person notification.
+- `/jp-appi:cross-border-transfer-check` - review recipient country, consent/disclosure basis, equivalent-measures monitoring, and onward-transfer records.
+- `/jp-appi:purpose-use-register` - build or review the purpose-of-use inventory for Japanese personal data.
+- `/jp-appi:entrustee-review` - assess outsourced processing, sub-entrustee controls, and supervision evidence.
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com)
+- [SCF API entry for this framework](https://hackidle.github.io/scf-api/api/crosswalks/apac-jpn-ppi-2020.json)
+- [Personal Information Protection Commission, Japan](https://www.ppc.go.jp/en/)
+- [PPC English APPI translation](https://www.ppc.go.jp/files/pdf/APPI_english.pdf)
+- [Japanese Law Translation: Act on the Protection of Personal Information](https://www.japaneselawtranslation.go.jp/en/laws/view/4241/en)


### PR DESCRIPTION
## Summary
- adds a Japan APPI reference-depth framework plugin for SCF `apac-jpn-ppi-2020`
- includes APPI-specific scope, evidence checklist, assessment routing, and expert skill guidance
- registers the plugin in the marketplace

Closes #26.

## Validation
- npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh
- npm run test:contract
- git diff --check

## Reference sources
- Personal Information Protection Commission, Japan: https://www.ppc.go.jp/en/
- PPC English APPI translation: https://www.ppc.go.jp/files/pdf/APPI_english.pdf
- Japanese Law Translation APPI text: https://www.japaneselawtranslation.go.jp/en/laws/view/4241/en