### PR TITLE
[codex] Derive automation totals from framework metadata

### DIFF
--- a/docs/GRC-DATA.md
+++ b/docs/GRC-DATA.md
@@ -111,6 +111,19 @@ To seed the reporting workflow with real automation history, use:
 node plugins/grc-engineer/scripts/record-automation-metrics.js soc2 --controls-total=64 --controls-automated=22 --window-label=2026-W16
 ```
 
+For framework plugins that publish `framework_metadata.framework_controls_mapped`,
+operators can skip hand-counting the total and provide only the observed
+automated count:
+
+```bash
+node plugins/grc-engineer/scripts/record-automation-metrics.js soc2 --controls-automated=22 --from-framework-metadata --window-label=2026-W16
+```
+
+Rows from this path still use `measurement_scope=operator-observed`. Their
+metadata records the plugin manifest used as the source for `controls_total`, so
+reports can distinguish it from both fully manual snapshots and FedRAMP
+tooling-capability baselines.
+
 If you want a tooling-capability baseline for FedRAMP evidence coverage, the
 writer can derive it from the evidence collector config:
 

--- a/plugins/grc-engineer/commands/record-automation-metrics.md
+++ b/plugins/grc-engineer/commands/record-automation-metrics.md
@@ -22,7 +22,10 @@ Use it in one of three modes:
    proof that your program is already running every automation in production.
 2. **Manual mode** for any framework alias, where you provide the total and
    automated counts directly. Use this for operator-observed reporting.
-3. **Batch mode** with `--config=<path>`, where a scheduler can write multiple
+3. **Framework metadata total mode** for framework plugins that publish
+   `framework_metadata.framework_controls_mapped`, where you provide only the
+   operator-observed automated count and the command derives the total.
+4. **Batch mode** with `--config=<path>`, where a scheduler can write multiple
    framework snapshots in one run.
 
 Metric rows follow [`docs/GRC-DATA.md`](../../../docs/GRC-DATA.md) and
@@ -45,6 +48,8 @@ Metric rows follow [`docs/GRC-DATA.md`](../../../docs/GRC-DATA.md) and
   `--controls-manual`
 - `--controls-automated=<n>` - Required for manual mode
 - `--controls-manual=<n>` - Optional manual count override
+- `--from-framework-metadata` - Derive `controls_total` from the framework
+  plugin manifest, leaving `controls_automated` operator-observed
 - `--recorded-at=<iso8601>` - Observation timestamp (defaults to now)
 - `--window-start=<iso8601>` - Optional reporting window start
 - `--window-end=<iso8601>` - Optional reporting window end
@@ -89,6 +94,9 @@ Metric rows follow [`docs/GRC-DATA.md`](../../../docs/GRC-DATA.md) and
 
 # Record an operator-observed SOC 2 snapshot
 /grc-engineer:record-automation-metrics soc2 --controls-total=64 --controls-automated=22 --window-label=2026-W16
+
+# Derive the total from SOC 2 plugin metadata, but keep the automated count observed
+/grc-engineer:record-automation-metrics soc2 --controls-automated=22 --from-framework-metadata --window-label=2026-W16
 
 # Add an extra business-unit dimension
 /grc-engineer:record-automation-metrics iso27001 --controls-total=93 --controls-automated=40 --dimension=business_unit=platform --window-label=2026-W16

--- a/plugins/grc-engineer/examples/automation-metrics.yaml
+++ b/plugins/grc-engineer/examples/automation-metrics.yaml
@@ -9,11 +9,11 @@ entries:
     provider: aws
 
   - framework: soc2
-    controls_total: 64
     controls_automated: 22
+    from_framework_metadata: true
     dimensions:
       business_unit: platform
 
   - framework: iso27001
-    controls_total: 93
     controls_automated: 40
+    from_framework_metadata: true

--- a/plugins/grc-engineer/scripts/record-automation-metrics.js
+++ b/plugins/grc-engineer/scripts/record-automation-metrics.js
@@ -268,7 +268,14 @@ export function parseArgs(argv) {
 
 async function readJsonFile(filePath) {
   const raw = await fs.readFile(filePath, 'utf8');
-  return JSON.parse(raw);
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      fail(`Could not parse JSON in ${path.relative(REPO_ROOT, filePath)}: ${err.message}`);
+    }
+    throw err;
+  }
 }
 
 async function loadFrameworkMetadata(frameworkAlias) {
@@ -458,7 +465,7 @@ export async function deriveCounts(opts) {
   if (total === null && opts.fromFrameworkMetadata) {
     const framework = await loadFrameworkMetadata(opts.framework);
     const frameworkTotal = Number(framework.metadata.framework_controls_mapped);
-    if (!Number.isFinite(frameworkTotal) || frameworkTotal < 0) {
+    if (!Number.isFinite(frameworkTotal) || !Number.isInteger(frameworkTotal) || frameworkTotal < 0) {
       fail(`framework_metadata.framework_controls_mapped is missing or invalid for ${opts.framework}`);
     }
     total = frameworkTotal;

--- a/plugins/grc-engineer/scripts/record-automation-metrics.js
+++ b/plugins/grc-engineer/scripts/record-automation-metrics.js
@@ -40,6 +40,7 @@ Manual mode (any framework alias):
   --controls-total=<n>             Total in-scope controls
   --controls-automated=<n>         Controls with automated evidence
   --controls-manual=<n>            Optional manual count (otherwise derived)
+  --from-framework-metadata        Derive controls-total from plugin framework_metadata
 
 Shared options:
   --config=<path>                  YAML or JSON batch config
@@ -65,12 +66,13 @@ Batch config shape:
     - framework: fedramp-moderate
       provider: aws
     - framework: soc2
-      controls_total: 64
       controls_automated: 22
+      from_framework_metadata: true
 
 Examples:
   node plugins/grc-engineer/scripts/record-automation-metrics.js fedramp-moderate aws --window-label=2026-W16
   node plugins/grc-engineer/scripts/record-automation-metrics.js soc2 --controls-total=64 --controls-automated=22 --window-label=2026-W16
+  node plugins/grc-engineer/scripts/record-automation-metrics.js soc2 --controls-automated=22 --from-framework-metadata --window-label=2026-W16
   node plugins/grc-engineer/scripts/record-automation-metrics.js --config=plugins/grc-engineer/examples/automation-metrics.yaml --window-label=current-week`;
 }
 
@@ -140,6 +142,7 @@ export function parseArgs(argv) {
     outDir: DEFAULT_OUT_DIR,
     dryRun: false,
     fromFedRAMP: null,
+    fromFrameworkMetadata: false,
     configPath: null,
     help: false,
     provided: new Set()
@@ -238,6 +241,10 @@ export function parseArgs(argv) {
         provided.add('fromFedRAMP');
         break;
       }
+      case 'from-framework-metadata':
+        opts.fromFrameworkMetadata = true;
+        provided.add('fromFrameworkMetadata');
+        break;
       case 'help':
       case 'h':
         opts.help = true;
@@ -257,6 +264,59 @@ export function parseArgs(argv) {
   }
 
   return opts;
+}
+
+async function readJsonFile(filePath) {
+  const raw = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function loadFrameworkMetadata(frameworkAlias) {
+  const normalized = normalizeFrameworkAlias(frameworkAlias);
+  const marketplacePath = path.join(REPO_ROOT, '.claude-plugin', 'marketplace.json');
+  const marketplace = await readJsonFile(marketplacePath);
+  const plugins = Array.isArray(marketplace.plugins) ? marketplace.plugins : [];
+
+  for (const entry of plugins) {
+    const entryName = normalizeFrameworkAlias(entry.name);
+    const source = entry.source ? path.resolve(REPO_ROOT, entry.source) : null;
+    if (!source) {
+      continue;
+    }
+
+    const manifestPath = path.join(source, '.claude-plugin', 'plugin.json');
+    let manifest;
+    try {
+      manifest = await readJsonFile(manifestPath);
+    } catch (err) {
+      if (err && err.code === 'ENOENT') {
+        continue;
+      }
+      throw err;
+    }
+
+    const metadata = manifest.framework_metadata;
+    if (!metadata || typeof metadata !== 'object') {
+      continue;
+    }
+
+    const candidates = [
+      entryName,
+      normalizeFrameworkAlias(manifest.name),
+      normalizeFrameworkAlias(metadata.scf_framework_id),
+      normalizeFrameworkAlias(metadata.display_name)
+    ].filter(Boolean);
+
+    if (candidates.includes(normalized)) {
+      return {
+        marketplaceName: entry.name,
+        manifestPath,
+        metadata
+      };
+    }
+  }
+
+  fail(`No framework plugin metadata found for ${frameworkAlias}`);
 }
 
 function getIsoWeekData(isoString) {
@@ -393,9 +453,27 @@ export async function deriveCounts(opts) {
 
   let total = opts.controlsTotal;
   let manual = opts.controlsManual;
+  let metadataDerivation = null;
+
+  if (total === null && opts.fromFrameworkMetadata) {
+    const framework = await loadFrameworkMetadata(opts.framework);
+    const frameworkTotal = Number(framework.metadata.framework_controls_mapped);
+    if (!Number.isFinite(frameworkTotal) || frameworkTotal < 0) {
+      fail(`framework_metadata.framework_controls_mapped is missing or invalid for ${opts.framework}`);
+    }
+    total = frameworkTotal;
+    metadataDerivation = {
+      derivation: 'framework-metadata',
+      marketplace_plugin: framework.marketplaceName,
+      manifest_path: path.relative(REPO_ROOT, framework.manifestPath),
+      scf_framework_id: framework.metadata.scf_framework_id,
+      framework_display_name: framework.metadata.display_name,
+      framework_controls_mapped: frameworkTotal
+    };
+  }
 
   if (total === null && manual === null) {
-    fail('Manual mode requires either --controls-total=<n> or --controls-manual=<n>');
+    fail('Manual mode requires --controls-total=<n>, --controls-manual=<n>, or --from-framework-metadata');
   }
   if (total === null) {
     total = opts.controlsAutomated + manual;
@@ -419,12 +497,13 @@ export async function deriveCounts(opts) {
     manual,
     coveragePercent: total > 0 ? Math.round((opts.controlsAutomated / total) * 100) : 0,
     measurementScope: 'operator-observed',
-    defaultSource: `${DEFAULT_SOURCE}/manual`,
+    defaultSource: metadataDerivation ? `${DEFAULT_SOURCE}/framework-metadata` : `${DEFAULT_SOURCE}/manual`,
     metadata: {
-      derivation: 'manual',
+      derivation: metadataDerivation ? 'operator-observed-with-framework-metadata-total' : 'manual',
       total_controls: total,
       automated_controls: opts.controlsAutomated,
-      manual_controls: manual
+      manual_controls: manual,
+      ...(metadataDerivation ? { total_source: metadataDerivation } : {})
     }
   };
 }
@@ -571,6 +650,7 @@ function normalizeConfigOptions(input, baseDir) {
     outDir: resolveConfigPath(baseDir, getConfigValue(input, 'outDir', 'out_dir')),
     dryRun: getConfigValue(input, 'dryRun', 'dry_run'),
     fromFedRAMP: normalizeFromFedRAMPValue(getConfigValue(input, 'fromFedRAMP', 'from_fedramp_baseline')),
+    fromFrameworkMetadata: getConfigValue(input, 'fromFrameworkMetadata', 'from_framework_metadata'),
     dimensions: { ...dimensions }
   };
 
@@ -600,6 +680,9 @@ function normalizeConfigOptions(input, baseDir) {
   }
   if (normalized.dryRun !== undefined) {
     normalized.dryRun = Boolean(normalized.dryRun);
+  }
+  if (normalized.fromFrameworkMetadata !== undefined) {
+    normalized.fromFrameworkMetadata = Boolean(normalized.fromFrameworkMetadata);
   }
 
   return normalized;
@@ -646,7 +729,8 @@ function extractCliOverrides(opts) {
     'subjectId',
     'outDir',
     'dryRun',
-    'fromFedRAMP'
+    'fromFedRAMP',
+    'fromFrameworkMetadata'
   ];
 
   for (const key of keys) {
@@ -714,7 +798,8 @@ function buildBatchEntries(cliOpts, batchConfig) {
         dimensions: {},
         outDir: DEFAULT_OUT_DIR,
         dryRun: false,
-        fromFedRAMP: null
+        fromFedRAMP: null,
+        fromFrameworkMetadata: false
       }, defaults),
       normalizedEntry
     );


### PR DESCRIPTION
## Summary
- adds `--from-framework-metadata` to `record-automation-metrics` so non-FedRAMP snapshots can derive `controls_total` from plugin manifests
- keeps generated rows as `operator-observed` and records the manifest source in metric metadata
- updates the command docs, GRC data docs, and example batch config

Closes #58.

## Validation
- node --check plugins/grc-engineer/scripts/record-automation-metrics.js
- node plugins/grc-engineer/scripts/record-automation-metrics.js soc2 --controls-automated=22 --from-framework-metadata --recorded-at=2026-04-30T00:00:00Z --window-label=2026-W18 --dry-run
- npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 ajv validate --spec=draft2020 -s schemas/metric.schema.json -d /tmp/issue58-metrics/*.json -c ajv-formats
- npm run test:contract
- git diff --check