### PR TITLE
[codex] Add Singapore MAS TRM reference framework plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -285,6 +285,12 @@
       "source": "./plugins/frameworks/jp-appi",
       "description": "Japan APPI reference plugin with scope, evidence checklist, and SCF-backed gap assessment.",
       "version": "0.1.0"
+    },
+    {
+      "name": "sg-mas-trm",
+      "source": "./plugins/frameworks/sg-mas-trm",
+      "description": "Singapore MAS TRM reference plugin with scope, evidence checklist, and SCF-backed gap assessment.",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/frameworks/sg-mas-trm/.claude-plugin/plugin.json
+++ b/plugins/frameworks/sg-mas-trm/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "sg-mas-trm",
+  "description": "Singapore MAS TRM - Reference plugin with scope determination, evidence checklist, and SCF-backed gap assessment for technology risk management.",
+  "version": "0.1.0",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "framework_metadata": {
+    "scf_framework_id": "apac-sgp-mas-trm-2021",
+    "display_name": "Singapore - Monetary Authority of Singapore (MAS) Technology Risk Management (TRM) Guidelines (2021)",
+    "region": "APAC",
+    "country": "SG",
+    "depth": "reference",
+    "scf_controls_mapped": 214,
+    "framework_controls_mapped": 280,
+    "industry": [],
+    "regulator": "Monetary Authority of Singapore (MAS)"
+  }
+}

--- a/plugins/frameworks/sg-mas-trm/README.md
+++ b/plugins/frameworks/sg-mas-trm/README.md
@@ -1,0 +1,43 @@
+# sg-mas-trm - Singapore MAS TRM
+
+Reference-depth framework plugin for the Monetary Authority of Singapore (MAS)
+Technology Risk Management Guidelines. Install and run:
+
+```bash
+/plugin install sg-mas-trm@grc-engineering-suite
+/sg-mas-trm:scope
+/sg-mas-trm:evidence-checklist
+/sg-mas-trm:assess
+```
+
+## Status: Reference
+
+This plugin provides scope determination, evidence checklist, and a
+framework-specific gap assessment, all backed by the SCF crosswalk (214 SCF
+controls to 280 MAS TRM controls).
+
+### Level up to Full
+
+Full depth adds framework-native workflow commands tied to the audit ritual. If
+you have domain expertise for MAS TRM, see the
+[Framework Plugin Guide](../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the
+level-up checklist.
+
+## Metadata
+
+| | |
+|---|---|
+| SCF framework ID | `apac-sgp-mas-trm-2021` |
+| Region | APAC |
+| Country | SG |
+| SCF controls mapped | 214 |
+| Framework controls mapped | 280 |
+| Depth | Reference |
+| Regulator | Monetary Authority of Singapore (MAS) |
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com) - crosswalk source (CC BY-ND 4.0)
+- [SCF API entry](https://hackidle.github.io/scf-api/api/crosswalks/apac-sgp-mas-trm-2021.json)
+- [MAS Technology Risk Management Guidelines, January 18 2021](https://www.mas.gov.sg/-/media/MAS/Regulations-and-Financial-Stability/Regulatory-and-Supervisory-Framework/Risk-Management/TRM-Guidelines-18-January-2021.pdf)
+- [Monetary Authority of Singapore](https://www.mas.gov.sg/)

--- a/plugins/frameworks/sg-mas-trm/commands/assess.md
+++ b/plugins/frameworks/sg-mas-trm/commands/assess.md
@@ -1,0 +1,59 @@
+---
+description: Singapore MAS TRM compliance gap assessment
+---
+
+# Singapore MAS TRM Assessment
+
+Runs a compliance gap assessment against the Monetary Authority of Singapore
+(MAS) Technology Risk Management Guidelines by delegating to
+`/grc-engineer:gap-assessment` with the framework's SCF identifier, then
+overlays MAS TRM-specific context and evidence requirements.
+
+## Usage
+
+```bash
+/sg-mas-trm:assess [--scope=<scope>] [--sources=<connector-list>]
+```
+
+## Arguments
+
+- `--scope=<scope>` (optional) - narrow the assessment to a MAS TRM workstream
+  such as `governance`, `critical-systems`, `cyber-security`,
+  `secure-development`, `outsourcing-cloud`, `incident-response`, or
+  `business-continuity`.
+- `--sources=<connector-list>` (optional) - comma-separated connector plugins.
+
+## What the assessment produces
+
+1. **Compliance score** - overall MAS TRM readiness percentage, weighted by
+   mapped SCF controls.
+2. **Applicable-requirements summary** - which MAS TRM expectations apply to
+   the organization.
+3. **Control-by-control gap** - all 280 mapped controls, with
+   pass/fail/inconclusive status from connector findings.
+4. **Evidence gaps** - controls where no evidence source is configured.
+5. **Remediation roadmap** - prioritized by severity and effort.
+
+## Delegation
+
+Under the hood:
+
+```bash
+/grc-engineer:gap-assessment "apac-sgp-mas-trm-2021" [--sources=<connector-list>]
+```
+
+The SCF crosswalk expands 214 SCF controls into the 280 MAS TRM mapped controls.
+
+## Framework-specific notes
+
+- Start with `/sg-mas-trm:scope` to identify whether the entity is MAS-regulated
+  and which technology services support Singapore financial services.
+- Common assessment scopes are board and senior management governance, critical
+  system resilience, cyber operations, secure SDLC, outsourcing, cloud, and
+  incident response.
+- For ISO 27001 or SOC 2 programs, verify that generic security evidence is
+  translated into MAS TRM governance, critical-system, and financial-sector risk
+  language.
+- Treat cloud and outsourced technology as in scope when they support regulated
+  financial services; vendor certifications do not replace the institution's
+  accountability.

--- a/plugins/frameworks/sg-mas-trm/commands/evidence-checklist.md
+++ b/plugins/frameworks/sg-mas-trm/commands/evidence-checklist.md
@@ -1,0 +1,64 @@
+---
+description: Evidence checklist for Singapore MAS TRM assessments
+---
+
+# Singapore MAS TRM Evidence Checklist
+
+Baseline evidence checklist for a Singapore MAS TRM assessment. The SCF
+crosswalk maps 214 SCF controls to the 280 MAS TRM controls; this command
+enumerates what evidence tends to be expected for each SCF family in scope.
+
+## Usage
+
+```bash
+/sg-mas-trm:evidence-checklist [--family=<SCF_family_code>]
+```
+
+## Arguments
+
+- `--family=<SCF_family_code>` (optional) - restrict to a single SCF family
+  such as `IAC`, `CRY`, `AST`, or `BCD`. Defaults to all families mapped for
+  this framework.
+
+## Output
+
+Markdown checklist grouped by SCF family with:
+
+- SCF control ID to framework-native control ID(s) from the crosswalk.
+- Evidence types typically expected.
+- Which connector plugins can collect each type automatically.
+- Which items require manual upload or narrative.
+
+## Framework-specific evidence
+
+Collect MAS TRM evidence around the actual technology risk lifecycle:
+
+- **Governance and accountability**: board and senior management reporting,
+  technology risk appetite, risk acceptance records, policies, committee
+  minutes, and independent assurance reports.
+- **Critical system inventory**: system criticality ratings, owners,
+  dependencies, data classifications, RTO/RPO targets, architecture diagrams,
+  and resilience requirements.
+- **Cyber security operations**: logging, monitoring, alert triage, threat
+  intelligence, vulnerability management, penetration testing, red-team or
+  exercise reports, and remediation tracking.
+- **Identity and privileged access**: joiner/mover/leaver evidence, MFA,
+  privileged account approvals, periodic access reviews, session logging, and
+  emergency access records.
+- **Secure development and change**: SDLC standards, threat models, code review,
+  dependency scanning, release approvals, segregation of duties, rollback
+  plans, and production change records.
+- **Outsourcing and cloud**: due diligence, risk assessments, contractual
+  controls, concentration-risk analysis, monitoring reports, exit plans, and
+  evidence from material service providers.
+- **Business continuity and disaster recovery**: BCP/DR plans, test results,
+  lessons learned, backup and restore evidence, failover exercises, and
+  recovery gap remediation.
+- **Incident response**: incident procedures, severity criteria, escalation
+  logs, post-incident reports, customer and regulator notification analysis,
+  and corrective-action tracking.
+
+Prefer structured exports from identity, ticketing, cloud, CI/CD, vulnerability
+management, SIEM, and vendor-risk systems over screenshots. Where evidence is
+narrative, capture the owner, approval date, scope, affected systems, and link
+to the underlying operating record.

--- a/plugins/frameworks/sg-mas-trm/commands/scope.md
+++ b/plugins/frameworks/sg-mas-trm/commands/scope.md
@@ -1,0 +1,51 @@
+---
+description: Determine whether Singapore MAS TRM applies to the organization
+---
+
+# Singapore MAS TRM Scope
+
+Determines whether and how the Monetary Authority of Singapore (MAS) Technology
+Risk Management Guidelines apply to the organization. Reference-depth scope is a
+decision-tree prompt; Full-depth plugins extend this with jurisdiction-aware
+logic.
+
+## Usage
+
+```bash
+/sg-mas-trm:scope
+```
+
+## What this produces
+
+- **Applicability verdict**: in-scope, out-of-scope, or partially in-scope.
+- **In-scope entity types**: MAS-regulated financial institution, Singapore
+  branch, licensed payment service provider, capital markets intermediary,
+  insurer, bank, outsourced service provider, or shared-service operator.
+- **In-scope systems**: critical systems, customer-facing digital channels,
+  cloud workloads, outsourced technology services, security monitoring, and
+  recovery environments.
+- **Jurisdiction reach**: Singapore-regulated operations and supporting offshore
+  or outsourced technology services.
+- **Next steps**: whether to proceed with `/sg-mas-trm:assess` or
+  `/sg-mas-trm:evidence-checklist`.
+
+## Framework-specific scope triggers
+
+Ask the minimum questions needed to classify MAS TRM applicability:
+
+- Is the organization regulated or licensed by MAS?
+- Does it operate a Singapore branch, subsidiary, or service supporting a
+  Singapore-regulated financial institution?
+- Which systems are critical to financial services, customer access,
+  transaction processing, risk management, or regulatory reporting?
+- Are technology services outsourced, cloud-hosted, or delivered through a
+  regional shared-service model?
+- Are there customer-facing digital channels, APIs, payment systems, trading
+  systems, or high-availability platforms?
+- Does the organization rely on third parties for security monitoring, incident
+  response, disaster recovery, software development, or infrastructure
+  operations?
+
+Return an applicability verdict, in-scope systems, responsible owners, and the
+follow-up command that should run next. Do not ask users to search the MAS
+guidelines; translate their answers into practical MAS TRM scoping outcomes.

--- a/plugins/frameworks/sg-mas-trm/skills/sg-mas-trm-expert/SKILL.md
+++ b/plugins/frameworks/sg-mas-trm/skills/sg-mas-trm-expert/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: sg-mas-trm-expert
+description: Singapore MAS Technology Risk Management Guidelines expert. Reference-depth framework plugin with scope determination, evidence checklist, and SCF-backed assessment guidance for Singapore-regulated financial institutions.
+allowed-tools: Read, Glob, Grep, Write
+---
+
+# Singapore MAS TRM Expert
+
+Reference-depth expertise for the **Monetary Authority of Singapore (MAS)
+Technology Risk Management Guidelines**, represented in SCF as
+`apac-sgp-mas-trm-2021`. This plugin bundles the SCF crosswalk (214 SCF controls
+to 280 framework controls) with MAS TRM-specific assessment context.
+
+## Framework Identity
+
+- **SCF framework ID**: `apac-sgp-mas-trm-2021`
+- **Region**: APAC
+- **Country**: SG
+- **Regulator**: Monetary Authority of Singapore (MAS)
+- **Common shorthand**: MAS TRM / Singapore TRM
+- **Current assessment baseline**: MAS Technology Risk Management Guidelines,
+  revised January 18, 2021
+
+### Framework In Plain Language
+
+MAS TRM is Singapore's supervisory guidance for managing technology and cyber
+risk in financial institutions. It focuses on board and senior management
+oversight, technology risk governance, system resilience, cyber security,
+software development, third-party and cloud risk, incident response, and data
+protection controls. Treat it as a financial-services technology risk framework:
+the assessor needs to see accountable governance, repeatable operational
+controls, and evidence that critical systems are resilient and monitored.
+
+### Territorial Scope And Applicability
+
+MAS TRM applies to financial institutions regulated by MAS, including banks,
+insurers, capital markets intermediaries, payment service providers, and other
+regulated entities that depend on technology to deliver financial services.
+Scope analysis should identify Singapore-regulated entities, critical systems,
+outsourced service providers, cloud-hosted workloads, customer-facing digital
+channels, and regional shared-service platforms supporting Singapore operations.
+Do not treat MAS TRM as a generic ISO 27001 checklist; the Singapore regulatory
+perimeter and criticality of financial services matter.
+
+### Mandatory Artifacts
+
+Evidence usually centers on board-approved technology risk policies, technology
+risk registers, critical system inventories, risk assessments, cyber resilience
+plans, secure SDLC records, vulnerability and penetration test results,
+privileged access reviews, incident response procedures, outsourcing due
+diligence, cloud risk assessments, business continuity and disaster recovery test
+records, and independent assurance reports. MAS TRM is guidance rather than a
+standalone certification package, so map artifacts to supervisory expectations
+instead of inventing a formal certificate deliverable.
+
+### Cadence And Timelines
+
+There is no annual MAS TRM certificate cycle. Assess recurring operating
+evidence on a risk-based cadence, with stronger scrutiny for critical systems:
+access reviews, vulnerability management, penetration testing, resilience tests,
+third-party reviews, and incident exercises should run often enough to support
+board and senior management oversight. MAS-regulated entities should also align
+incident escalation and notification evidence with applicable MAS notices,
+outsourcing requirements, and internal materiality thresholds.
+
+### Regulator And Enforcement
+
+The Monetary Authority of Singapore supervises regulated financial institutions
+and can use inspections, supervisory findings, directions, penalties, and other
+regulatory measures when technology risk management is weak. In assessment
+output, separate MAS TRM control evidence from legal advice about notices,
+licensing, or penalty exposure.
+
+### Interaction With Other Frameworks
+
+MAS TRM commonly overlaps with ISO 27001/27002, SOC 2 security and availability
+criteria, NIST CSF, PCI DSS for payment environments, Singapore PDPA for
+personal data, and outsourcing/cloud risk requirements. Use the SCF crosswalk
+for control mechanics, but keep MAS TRM reporting focused on financial
+institution governance, critical system resilience, cyber operations, secure
+development, outsourcing, and technology incident readiness.
+
+### Common Misinterpretations
+
+- **"MAS TRM only applies to Singapore-hosted systems."** Offshore platforms,
+  shared services, and outsourced providers can be in scope when they support
+  Singapore-regulated financial services.
+- **"ISO 27001 certification is enough."** ISO 27001 helps, but MAS TRM expects
+  Singapore financial-sector governance, critical-system resilience, outsourcing,
+  and supervisory evidence.
+- **"Cloud is out of scope if the provider is certified."** MAS-regulated
+  institutions still need due diligence, risk assessment, monitoring, exit
+  planning, and accountability for outsourced or cloud services.
+- **"TRM is only an IT operations checklist."** Board and senior management
+  accountability, risk acceptance, and independent assurance are central.
+
+## Command Routing
+
+- `/sg-mas-trm:scope` - determine applicability
+- `/sg-mas-trm:assess` - run a gap assessment
+- `/sg-mas-trm:evidence-checklist` - enumerate evidence requirements
+
+All three delegate to `/grc-engineer:gap-assessment` with SCF framework ID
+`apac-sgp-mas-trm-2021` for the control-by-control mechanics, and wrap the
+results in MAS TRM-specific terminology.
+
+## Levelling Up To Full
+
+Full-depth plugins add framework-specific workflow commands tied to the audit
+ritual. Candidates for this framework:
+
+- `/sg-mas-trm:critical-system-register` - build or review the inventory of
+  critical systems, owners, dependencies, RTO/RPO, and resilience evidence.
+- `/sg-mas-trm:outsourcing-cloud-review` - assess cloud and outsourced service
+  providers against due diligence, monitoring, exit, and concentration-risk
+  expectations.
+- `/sg-mas-trm:cyber-resilience-check` - review monitoring, vulnerability,
+  penetration testing, incident response, and recovery exercise evidence.
+- `/sg-mas-trm:board-pack` - summarize technology risk posture and open issues
+  for board or senior management oversight.
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com)
+- [SCF API entry for this framework](https://hackidle.github.io/scf-api/api/crosswalks/apac-sgp-mas-trm-2021.json)
+- [MAS Technology Risk Management Guidelines, January 18 2021](https://www.mas.gov.sg/-/media/MAS/Regulations-and-Financial-Stability/Regulatory-and-Supervisory-Framework/Risk-Management/TRM-Guidelines-18-January-2021.pdf)
+- [Monetary Authority of Singapore](https://www.mas.gov.sg/)


### PR DESCRIPTION
## Summary
- adds a Singapore MAS TRM reference-depth framework plugin for SCF `apac-sgp-mas-trm-2021`
- includes MAS TRM-specific scope, evidence checklist, assessment routing, and expert skill guidance
- registers the plugin in the marketplace

Closes #21.

## Notes
- The issue shorthand was `SG-MAS-TRM`; the local SCF canonical ID is `apac-sgp-mas-trm-2021`.

## Validation
- npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh
- npm run test:contract
- git diff --check

## Reference sources
- MAS Technology Risk Management Guidelines, January 18 2021: https://www.mas.gov.sg/-/media/MAS/Regulations-and-Financial-Stability/Regulatory-and-Supervisory-Framework/Risk-Management/TRM-Guidelines-18-January-2021.pdf
- Monetary Authority of Singapore: https://www.mas.gov.sg/