### PR TITLE
[codex] Add APRA CPS 234 reference framework plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -291,6 +291,12 @@
       "source": "./plugins/frameworks/sg-mas-trm",
       "description": "Singapore MAS TRM reference plugin with scope, evidence checklist, and SCF-backed gap assessment.",
       "version": "0.1.0"
+    },
+    {
+      "name": "au-apra-cps-234",
+      "source": "./plugins/frameworks/au-apra-cps-234",
+      "description": "APRA CPS 234 reference plugin with scope, evidence checklist, and SCF-backed gap assessment.",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/frameworks/au-apra-cps-234/.claude-plugin/plugin.json
+++ b/plugins/frameworks/au-apra-cps-234/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "au-apra-cps-234",
+  "description": "APRA CPS 234 - Reference plugin with scope determination, evidence checklist, and SCF-backed gap assessment for information security.",
+  "version": "0.1.0",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "framework_metadata": {
+    "scf_framework_id": "apac-aus-ps-cps-234-2019",
+    "display_name": "Australia - Prudential Standard CPS 234 (2019)",
+    "region": "APAC",
+    "country": "AU",
+    "depth": "reference",
+    "scf_controls_mapped": 52,
+    "framework_controls_mapped": 38,
+    "industry": [],
+    "regulator": "Australian Prudential Regulation Authority (APRA)"
+  }
+}

--- a/plugins/frameworks/au-apra-cps-234/README.md
+++ b/plugins/frameworks/au-apra-cps-234/README.md
@@ -1,0 +1,43 @@
+# au-apra-cps-234 - APRA CPS 234
+
+Reference-depth framework plugin for APRA Prudential Standard CPS 234
+Information Security. Install and run:
+
+```bash
+/plugin install au-apra-cps-234@grc-engineering-suite
+/au-apra-cps-234:scope
+/au-apra-cps-234:evidence-checklist
+/au-apra-cps-234:assess
+```
+
+## Status: Reference
+
+This plugin provides scope determination, evidence checklist, and a
+framework-specific gap assessment, all backed by the SCF crosswalk (52 SCF
+controls to 38 CPS 234 controls).
+
+### Level up to Full
+
+Full depth adds framework-native workflow commands tied to the audit ritual. If
+you have domain expertise for CPS 234, see the
+[Framework Plugin Guide](../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the
+level-up checklist.
+
+## Metadata
+
+| | |
+|---|---|
+| SCF framework ID | `apac-aus-ps-cps-234-2019` |
+| Region | APAC |
+| Country | AU |
+| SCF controls mapped | 52 |
+| Framework controls mapped | 38 |
+| Depth | Reference |
+| Regulator | Australian Prudential Regulation Authority (APRA) |
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com) - crosswalk source (CC BY-ND 4.0)
+- [SCF API entry](https://hackidle.github.io/scf-api/api/crosswalks/apac-aus-ps-cps-234-2019.json)
+- [APRA Prudential Standard CPS 234 Information Security](https://handbook.apra.gov.au/standard/cps-234)
+- [APRA Prudential Practice Guide CPG 234 Information Security](https://handbook.apra.gov.au/ppg/cpg-234)

--- a/plugins/frameworks/au-apra-cps-234/commands/assess.md
+++ b/plugins/frameworks/au-apra-cps-234/commands/assess.md
@@ -1,0 +1,59 @@
+---
+description: APRA CPS 234 compliance gap assessment
+---
+
+# APRA CPS 234 Assessment
+
+Runs a compliance gap assessment against APRA Prudential Standard CPS 234
+Information Security by delegating to `/grc-engineer:gap-assessment` with the
+framework's SCF identifier, then overlays CPS 234-specific context and evidence
+requirements.
+
+## Usage
+
+```bash
+/au-apra-cps-234:assess [--scope=<scope>] [--sources=<connector-list>]
+```
+
+## Arguments
+
+- `--scope=<scope>` (optional) - narrow the assessment to a CPS 234 workstream
+  such as `asset-ownership`, `information-security-capability`,
+  `control-testing`, `incident-management`, `third-party-reliance`, or
+  `board-reporting`.
+- `--sources=<connector-list>` (optional) - comma-separated connector plugins.
+
+## What the assessment produces
+
+1. **Compliance score** - overall CPS 234 readiness percentage, weighted by
+   mapped SCF controls.
+2. **Applicable-requirements summary** - which CPS 234 expectations apply to
+   the organization.
+3. **Control-by-control gap** - all 38 mapped controls, with
+   pass/fail/inconclusive status from connector findings.
+4. **Evidence gaps** - controls where no evidence source is configured.
+5. **Remediation roadmap** - prioritized by severity and effort.
+
+## Delegation
+
+Under the hood:
+
+```bash
+/grc-engineer:gap-assessment "apac-aus-ps-cps-234-2019" [--sources=<connector-list>]
+```
+
+The SCF crosswalk expands 52 SCF controls into the 38 CPS 234 mapped controls.
+
+## Framework-specific notes
+
+- Start with `/au-apra-cps-234:scope` to identify whether the entity is
+  APRA-regulated and which information assets are managed directly, by related
+  parties, or by third parties.
+- Common assessment scopes are information asset ownership, control design,
+  control testing, material incident readiness, third-party assurance, and
+  board or senior management reporting.
+- For ISO 27001, SOC 2, or Essential Eight programs, verify that evidence maps
+  to CPS 234's prudential language: capability, threats, vulnerabilities,
+  criticality, sensitivity, testing, and APRA notification.
+- Treat third-party and cloud evidence as in scope when those providers manage
+  information assets for the regulated entity.

--- a/plugins/frameworks/au-apra-cps-234/commands/evidence-checklist.md
+++ b/plugins/frameworks/au-apra-cps-234/commands/evidence-checklist.md
@@ -1,0 +1,64 @@
+---
+description: Evidence checklist for APRA CPS 234 assessments
+---
+
+# APRA CPS 234 Evidence Checklist
+
+Baseline evidence checklist for an APRA CPS 234 assessment. The SCF crosswalk
+maps 52 SCF controls to the 38 CPS 234 controls; this command enumerates what
+evidence tends to be expected for each SCF family in scope.
+
+## Usage
+
+```bash
+/au-apra-cps-234:evidence-checklist [--family=<SCF_family_code>]
+```
+
+## Arguments
+
+- `--family=<SCF_family_code>` (optional) - restrict to a single SCF family
+  such as `IAC`, `CRY`, `AST`, or `BCD`. Defaults to all families mapped for
+  this framework.
+
+## Output
+
+Markdown checklist grouped by SCF family with:
+
+- SCF control ID to framework-native control ID(s) from the crosswalk.
+- Evidence types typically expected.
+- Which connector plugins can collect each type automatically.
+- Which items require manual upload or narrative.
+
+## Framework-specific evidence
+
+Collect CPS 234 evidence around information assets and operating control
+effectiveness:
+
+- **Governance and accountability**: information security policy, board and
+  senior management reporting, risk appetite, risk acceptance records, and
+  control ownership evidence.
+- **Information asset inventory**: asset owners, sensitivity and criticality
+  ratings, data flows, business services supported, third-party dependencies,
+  and hosting locations.
+- **Information security capability**: threat and vulnerability monitoring,
+  security standards, architecture controls, awareness, staffing, tooling, and
+  capability reviews.
+- **Control implementation**: access controls, logging, encryption,
+  vulnerability management, change management, backup and recovery, endpoint and
+  network controls, and secure configuration evidence.
+- **Control testing**: testing strategy, testing frequency rationale, test
+  plans, penetration tests, control self-assessments, independent assurance,
+  failed-test remediation, and retest results.
+- **Third-party and related-party reliance**: contracts, assurance reports,
+  control test results, service provider risk assessments, cloud evidence, and
+  monitoring of outsourced control operation.
+- **Incident management**: incident response plan, materiality criteria,
+  escalation records, APRA notification analysis, post-incident reviews, and
+  corrective action tracking.
+- **Weakness management**: material control weakness register, remediation
+  plans, risk acceptance, APRA notification analysis, and board reporting.
+
+Prefer structured exports from identity, ticketing, cloud, vulnerability
+management, SIEM, GRC, and vendor-risk systems over screenshots. Where evidence
+is narrative, capture the owner, approval date, asset scope, materiality
+assessment, and link to the underlying operating record.

--- a/plugins/frameworks/au-apra-cps-234/commands/scope.md
+++ b/plugins/frameworks/au-apra-cps-234/commands/scope.md
@@ -1,0 +1,48 @@
+---
+description: Determine whether APRA CPS 234 applies to the organization
+---
+
+# APRA CPS 234 Scope
+
+Determines whether and how APRA Prudential Standard CPS 234 Information Security
+applies to the organization. Reference-depth scope is a decision-tree prompt;
+Full-depth plugins extend this with entity- and asset-aware logic.
+
+## Usage
+
+```bash
+/au-apra-cps-234:scope
+```
+
+## What this produces
+
+- **Applicability verdict**: in-scope, out-of-scope, or partially in-scope.
+- **In-scope entity types**: APRA-regulated entity, RSE licensee, insurer,
+  authorised deposit-taking institution, related party, or third-party service
+  provider supporting regulated operations.
+- **In-scope assets**: information assets classified by sensitivity,
+  criticality, owner, hosting model, and dependency.
+- **Jurisdiction reach**: APRA-regulated Australian operations and supporting
+  offshore, cloud, related-party, or outsourced services.
+- **Next steps**: whether to proceed with `/au-apra-cps-234:assess` or
+  `/au-apra-cps-234:evidence-checklist`.
+
+## Framework-specific scope triggers
+
+Ask the minimum questions needed to classify CPS 234 applicability:
+
+- Is the organization an APRA-regulated entity or part of a regulated group?
+- Does it manage information assets for an APRA-regulated entity?
+- Which information assets are critical or sensitive?
+- Which assets are managed by related parties, outsourced providers, cloud
+  services, or offshore teams?
+- Who owns each information asset and who is accountable for control design,
+  control testing, and incident escalation?
+- Are there materiality thresholds for information security incidents and
+  control weaknesses?
+- Are control testing results, third-party assurance, and incident exercises
+  reported to board or senior management?
+
+Return an applicability verdict, in-scope assets, accountable owners, and the
+follow-up command that should run next. Do not ask users to search CPS 234;
+translate their answers into practical scoping outcomes.

--- a/plugins/frameworks/au-apra-cps-234/skills/au-apra-cps-234-expert/SKILL.md
+++ b/plugins/frameworks/au-apra-cps-234/skills/au-apra-cps-234-expert/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: au-apra-cps-234-expert
+description: APRA CPS 234 expert for Australian prudential information security. Reference-depth framework plugin with scope determination, evidence checklist, and SCF-backed assessment guidance.
+allowed-tools: Read, Glob, Grep, Write
+---
+
+# APRA CPS 234 Expert
+
+Reference-depth expertise for **APRA Prudential Standard CPS 234 Information
+Security**, represented in SCF as `apac-aus-ps-cps-234-2019`. This plugin
+bundles the SCF crosswalk (52 SCF controls to 38 framework controls) with
+CPS 234-specific assessment context.
+
+## Framework Identity
+
+- **SCF framework ID**: `apac-aus-ps-cps-234-2019`
+- **Region**: APAC
+- **Country**: AU
+- **Regulator**: Australian Prudential Regulation Authority (APRA)
+- **Common shorthand**: APRA CPS 234
+- **Current assessment baseline**: Prudential Standard CPS 234 Information
+  Security, effective July 1, 2019
+
+### Framework In Plain Language
+
+CPS 234 is APRA's prudential information security standard for regulated
+financial entities. It requires information security capability that is
+commensurate with threats, vulnerabilities, and the sensitivity and criticality
+of information assets. For GRC work, treat CPS 234 as an accountability and
+resilience framework: the assessor needs to see clear information-asset
+ownership, tested controls, incident response readiness, and board-level
+oversight of material information security risk.
+
+### Territorial Scope And Applicability
+
+CPS 234 applies to APRA-regulated entities, including authorised deposit-taking
+institutions, general insurers, life insurers, private health insurers, RSE
+licensees, and other regulated groups within APRA's prudential perimeter. Scope
+analysis should identify information assets managed directly, by related
+parties, or by third parties, including cloud and outsourced services. Do not
+limit the scope to systems hosted in Australia; assets and service providers are
+in scope when they support APRA-regulated operations.
+
+### Mandatory Artifacts
+
+Evidence usually centers on information security policy, asset classification
+and ownership records, control standards, control testing plans and results,
+incident response plans, board or senior management reporting, vulnerability and
+threat monitoring, third-party assurance, materiality criteria, and notification
+records. CPS 234 does not define a SOC-style report package, but APRA-regulated
+entities should be able to show that control design, operating effectiveness,
+and incident notification obligations are managed and tested.
+
+### Cadence And Timelines
+
+Control testing frequency should be commensurate with vulnerabilities, threats,
+asset criticality, asset sensitivity, and previous test results. CPS 234 also
+requires timely notification to APRA for material information security
+incidents and for material control weaknesses that cannot be remediated quickly.
+Assessment output should preserve both the control-testing cadence rationale and
+the evidence that incidents and weaknesses were escalated under the entity's
+materiality criteria.
+
+### Regulator And Enforcement
+
+APRA supervises regulated entities through prudential standards, reporting,
+reviews, directions, and enforcement action. In assessment output, separate
+CPS 234 control evidence from legal advice about licensing, capital impacts, or
+specific enforcement exposure.
+
+### Interaction With Other Frameworks
+
+CPS 234 commonly overlaps with CPS 220 risk management, CPS 230 operational
+risk, CPS 231 outsourcing for legacy programs, ISO 27001, NIST CSF, SOC 2
+security and availability criteria, PCI DSS for payment environments, and the
+Australian Essential Eight. Use the SCF crosswalk for control mechanics, but
+keep CPS 234 reporting focused on APRA-regulated information assets, control
+testing, materiality, third-party reliance, and notification readiness.
+
+### Common Misinterpretations
+
+- **"CPS 234 only covers cyber tools."** It also covers accountability,
+  information asset ownership, policy, third-party reliance, testing, and
+  incident management.
+- **"Only Australian-hosted systems are in scope."** Related-party,
+  third-party, cloud, and offshore systems are in scope when they manage
+  information assets for an APRA-regulated entity.
+- **"Annual penetration testing is enough."** Testing frequency should match
+  asset criticality, sensitivity, vulnerabilities, threats, and previous test
+  results.
+- **"Third-party certificates transfer accountability."** They help, but the
+  regulated entity still needs assurance that testing nature and frequency are
+  appropriate for its assets.
+
+## Command Routing
+
+- `/au-apra-cps-234:scope` - determine applicability
+- `/au-apra-cps-234:assess` - run a gap assessment
+- `/au-apra-cps-234:evidence-checklist` - enumerate evidence requirements
+
+All three delegate to `/grc-engineer:gap-assessment` with SCF framework ID
+`apac-aus-ps-cps-234-2019` for the control-by-control mechanics, and wrap the
+results in CPS 234-specific terminology.
+
+## Levelling Up To Full
+
+Full-depth plugins add framework-specific workflow commands tied to the audit
+ritual. Candidates for this framework:
+
+- `/au-apra-cps-234:asset-criticality-register` - build or review information
+  asset ownership, sensitivity, criticality, and control coverage.
+- `/au-apra-cps-234:control-testing-plan` - map testing nature and frequency to
+  threats, vulnerabilities, asset criticality, and previous results.
+- `/au-apra-cps-234:material-incident-triage` - classify whether an incident or
+  control weakness likely requires APRA notification.
+- `/au-apra-cps-234:third-party-assurance-review` - assess reliance on related
+  parties and third-party control testing.
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com)
+- [SCF API entry for this framework](https://hackidle.github.io/scf-api/api/crosswalks/apac-aus-ps-cps-234-2019.json)
+- [APRA Prudential Standard CPS 234 Information Security](https://handbook.apra.gov.au/standard/cps-234)
+- [APRA Prudential Practice Guide CPG 234 Information Security](https://handbook.apra.gov.au/ppg/cpg-234)

--- a/plugins/frameworks/au-apra-cps-234/skills/au-apra-cps-234-expert/SKILL.md
+++ b/plugins/frameworks/au-apra-cps-234/skills/au-apra-cps-234-expert/SKILL.md
@@ -98,9 +98,9 @@ testing, materiality, third-party reliance, and notification readiness.
 - `/au-apra-cps-234:assess` - run a gap assessment
 - `/au-apra-cps-234:evidence-checklist` - enumerate evidence requirements
 
-All three delegate to `/grc-engineer:gap-assessment` with SCF framework ID
-`apac-aus-ps-cps-234-2019` for the control-by-control mechanics, and wrap the
-results in CPS 234-specific terminology.
+`/au-apra-cps-234:assess` delegates to `/grc-engineer:gap-assessment` with SCF
+framework ID `apac-aus-ps-cps-234-2019` for the control-by-control mechanics,
+and wraps the results in CPS 234-specific terminology.
 
 ## Levelling Up To Full
 


### PR DESCRIPTION
## Summary
- adds an APRA CPS 234 reference-depth framework plugin for SCF `apac-aus-ps-cps-234-2019`
- includes CPS 234-specific scope, evidence checklist, assessment routing, and expert skill guidance
- registers the plugin in the marketplace

Closes #20.

## Notes
- The issue shorthand was `AU-APRA-CPS-234`; the local SCF canonical ID is `apac-aus-ps-cps-234-2019`.

## Validation
- npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh
- npm run test:contract
- git diff --check

## Reference sources
- APRA CPS 234 handbook page: https://handbook.apra.gov.au/standard/cps-234
- APRA CPG 234 handbook page: https://handbook.apra.gov.au/ppg/cpg-234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added APRA CPS 234 compliance framework plugin with scope determination, evidence checklist generation, and compliance gap assessment against mapped controls.

* **Documentation**
  * Comprehensive guides and expert documentation for CPS 234 compliance workflows and framework implementation included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->