### PR TITLE
[codex] Add Azure inspector connector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -197,6 +197,12 @@
       "version": "0.1.0"
     },
     {
+      "name": "azure-inspector",
+      "source": "./plugins/connectors/azure-inspector",
+      "description": "GRC connector for Azure: Entra ID, Storage, Key Vault, Monitor, and Defender for Cloud to v1 finding contract",
+      "version": "0.1.0"
+    },
+    {
       "name": "okta-inspector",
       "source": "./plugins/connectors/okta-inspector",
       "description": "GRC connector for Okta: password/MFA/session policies, inactive users, admin factor enrollment \u2192 v1 finding contract",

--- a/plugins/connectors/azure-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/azure-inspector/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "azure-inspector",
+  "version": "0.1.0",
+  "description": "GRC connector for Microsoft Azure: evaluates Entra ID, Storage, Key Vault, Monitor, and Defender for Cloud. Emits findings conforming to schemas/finding.schema.json v1.",
+  "author": { "name": "GRC Engineering Club Contributors" },
+  "license": "MIT",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "keywords": ["grc", "compliance", "azure", "entra", "scf", "fedramp", "connector"]
+}

--- a/plugins/connectors/azure-inspector/commands/collect.md
+++ b/plugins/connectors/azure-inspector/commands/collect.md
@@ -1,0 +1,104 @@
+---
+name: Azure Inspector Collect
+description: Query Azure for compliance-relevant configuration across Entra ID, Storage, Key Vault, Monitor, and Defender for Cloud; emit findings conforming to the v1 contract.
+---
+
+# /azure-inspector:collect
+
+Scans an Azure subscription for compliance-relevant resources and configurations.
+
+## How to run
+
+```bash
+node plugins/connectors/azure-inspector/scripts/collect.js [options]
+```
+
+## Arguments
+
+- `--subscription=<id>` - override the configured subscription
+- `--tenant=<id>` - override the configured tenant
+- `--services=<csv>` - subset of `entra,storage,keyvault,monitor,defender` (default: all)
+- `--output=<fmt>` - `silent` | `summary` (default) | `json`
+- `--quiet` - no stderr progress
+
+## What it evaluates
+
+**Entra ID**:
+
+| SCF | Check | Severity |
+|---|---|---|
+| IAC-01.1 | MFA posture requires Graph/authentication-method verification | inconclusive if CLI cannot determine |
+| IAC-04 | Conditional Access policies enabled | high if absent |
+
+**Storage accounts**:
+
+| SCF | Check | Severity |
+|---|---|---|
+| CRY-05 | Blob/file service encryption enabled | high if disabled |
+| DCH-01.2 | Blob public access disabled | critical if allowed |
+| CRY-06 | Minimum TLS version is TLS 1.2 or later | medium |
+
+**Key Vault**:
+
+| SCF | Check | Severity |
+|---|---|---|
+| BCD-11 | Soft delete and purge protection | high/medium if disabled |
+| IAC-07.2 | Azure RBAC authorization preferred over access policies | medium |
+
+**Monitor + Defender for Cloud**:
+
+| SCF | Check | Severity |
+|---|---|---|
+| MON-02 | Subscription Activity Log diagnostic export configured | high |
+| MON-01.2 | Defender for Cloud Standard plan enabled | high |
+
+## Output
+
+- `~/.cache/claude-grc/findings/azure-inspector/<run_id>.json` - array of Findings
+- `~/.cache/claude-grc/runs.log` - run manifest appended
+- stdout summary unless `--quiet`:
+
+  ```
+  azure-inspector: 18 resources, 64 evaluations, 7 failing (1 critical, 3 high, 3 medium).
+  ```
+
+## Exit codes
+
+- `0` success
+- `2` credentials invalid or subscription inaccessible
+- `3` rate-limited (Azure quota exhausted)
+- `4` partial (some services inaccessible; report still written)
+- `5` config missing - run setup
+
+## Minimum Azure role/API access
+
+```
+Reader on the subscription
+Security Reader for Defender for Cloud posture
+Microsoft Graph Policy.Read.All for Conditional Access reads
+```
+
+Managed identity works when the identity has equivalent role assignments.
+
+## Examples
+
+```bash
+# Current subscription, all services
+/azure-inspector:collect
+
+# Multiple subscriptions
+for s in sub-prod sub-stage; do
+  /azure-inspector:collect --subscription=$s
+done
+
+# Storage only
+/azure-inspector:collect --services=storage
+```
+
+## CI/CD usage
+
+```bash
+az login --identity
+node plugins/connectors/azure-inspector/scripts/collect.js --quiet
+node plugins/grc-engineer/scripts/gap-assessment.js FedRAMP-Moderate --sources=azure-inspector --output=sarif --quiet > azure-gap.sarif
+```

--- a/plugins/connectors/azure-inspector/commands/collect.md
+++ b/plugins/connectors/azure-inspector/commands/collect.md
@@ -56,7 +56,7 @@ node plugins/connectors/azure-inspector/scripts/collect.js [options]
 
 - `~/.cache/claude-grc/findings/azure-inspector/<run_id>.json` - array of Findings
 - `~/.cache/claude-grc/runs.log` - run manifest appended
-- stdout summary unless `--quiet`:
+- stdout summary unless `--output=silent`:
 
   ```
   azure-inspector: 18 resources, 64 evaluations, 7 failing (1 critical, 3 high, 3 medium).

--- a/plugins/connectors/azure-inspector/commands/setup.md
+++ b/plugins/connectors/azure-inspector/commands/setup.md
@@ -1,0 +1,51 @@
+---
+name: Azure Inspector Setup
+description: Verify the azure-inspector connector's prerequisites and write its config. Idempotent.
+---
+
+# /azure-inspector:setup
+
+Prepares the azure-inspector connector. Confirms `az` CLI is installed and authenticated, writes `~/.config/claude-grc/connectors/azure-inspector.yaml`, and runs a read-only subscription health check.
+
+## How to run
+
+```bash
+bash plugins/connectors/azure-inspector/scripts/setup.sh [--subscription=<id>] [--tenant=<id>]
+```
+
+Exits 0 on success, 2 on missing/invalid credentials, 5 on missing `az` binary.
+
+## Credential precedence
+
+Honors the standard Azure CLI credential chain:
+
+1. `--subscription` / `--tenant` flags
+2. `AZURE_SUBSCRIPTION_ID` environment variable for collection
+3. Active `az account show` context
+4. Managed identity after `az login --identity`
+
+The setup script verifies `az account show --subscription <id>` before writing config.
+
+## Config written
+
+```yaml
+version: 1
+source: azure-inspector
+source_version: "0.1.0"
+subscription_id: "<subscription-id>"
+subscription_name: "<name>"
+tenant_id: "<tenant-id>"
+caller: "<user-or-service-principal>"
+defaults:
+  services: ["entra", "storage", "keyvault", "monitor", "defender"]
+```
+
+## Failure modes
+
+- **az not installed**: exit 5. Install Azure CLI.
+- **No active account**: exit 2. Run `az login` or `az login --identity`.
+- **Subscription inaccessible**: exit 2. Grant Reader on the subscription; add Security Reader and Microsoft Graph Policy.Read.All for fuller coverage.
+
+## Safe to re-run
+
+Yes. Re-running verifies the current account and overwrites config without deleting cached findings.

--- a/plugins/connectors/azure-inspector/commands/status.md
+++ b/plugins/connectors/azure-inspector/commands/status.md
@@ -30,7 +30,7 @@ azure-inspector
 
 ## Status values
 
-- `ready` - config exists and Azure CLI can read the subscription
+- `ready` - config exists, Azure CLI can read the subscription, and cached findings are absent or recent
 - `not-configured` - setup has not run
 - `credentials-expired-or-subscription-inaccessible` - `az account show` failed for the configured subscription
 - `stale` - last run is older than 7 days

--- a/plugins/connectors/azure-inspector/commands/status.md
+++ b/plugins/connectors/azure-inspector/commands/status.md
@@ -1,0 +1,36 @@
+---
+name: Azure Inspector Status
+description: Report configuration state, credential validity, and last-run freshness for azure-inspector.
+---
+
+# /azure-inspector:status
+
+Non-destructive health check. Shows whether the connector is configured, whether Azure credentials still work, and when it last produced findings.
+
+## How to run
+
+```bash
+bash plugins/connectors/azure-inspector/scripts/status.sh
+```
+
+## Output
+
+```text
+azure-inspector
+  status:        ready
+  az:            2.72.0
+  subscription:  Prod (00000000-0000-0000-0000-000000000000)
+  tenant:        11111111-1111-1111-1111-111111111111
+  caller:        scanner@example.com
+  config:        ~/.config/claude-grc/connectors/azure-inspector.yaml
+  cache:         ready
+  last run:      4h ago (20260430121212-a1b2c3d4)
+  cached:        18 resources, 64 evaluations
+```
+
+## Status values
+
+- `ready` - config exists and Azure CLI can read the subscription
+- `not-configured` - setup has not run
+- `credentials-expired-or-subscription-inaccessible` - `az account show` failed for the configured subscription
+- `stale` - last run is older than 7 days

--- a/plugins/connectors/azure-inspector/scripts/collect.js
+++ b/plugins/connectors/azure-inspector/scripts/collect.js
@@ -64,9 +64,11 @@ async function main(argv) {
 
   const counters = { pass: 0, fail: 0, inconclusive: 0, not_applicable: 0, skipped: 0 };
   const sev = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  const failSev = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
   for (const d of findings) for (const e of d.evaluations) {
     counters[e.status] = (counters[e.status] || 0) + 1;
     if (e.severity) sev[e.severity] = (sev[e.severity] || 0) + 1;
+    if (e.status === 'fail' && e.severity) failSev[e.severity] = (failSev[e.severity] || 0) + 1;
   }
 
   const manifest = {
@@ -81,11 +83,12 @@ async function main(argv) {
     evaluations: findings.reduce((n, d) => n + d.evaluations.length, 0),
     counters,
     severities: sev,
+    failing_severities: failSev,
     errors: errors.length
   };
   await fs.appendFile(RUNS_LOG, JSON.stringify(manifest) + '\n');
 
-  const summary = `${SOURCE}: ${findings.length} resources, ${manifest.evaluations} evaluations, ${counters.fail || 0} failing (${sev.critical || 0} critical, ${sev.high || 0} high, ${sev.medium || 0} medium).`;
+  const summary = `${SOURCE}: ${findings.length} resources, ${manifest.evaluations} evaluations, ${counters.fail || 0} failing (${failSev.critical || 0} critical, ${failSev.high || 0} high, ${failSev.medium || 0} medium).`;
   if (args.output === 'json') process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, summary: manifest, errors }, null, 2) + '\n');
   else if (args.output !== 'silent') {
     process.stdout.write(summary + '\n');
@@ -108,7 +111,7 @@ const serviceHandlers = {
 
     try {
       const defaults = await azJson(['ad', 'user', 'list', '--filter', "userType eq 'Member' and accountEnabled eq true", '--query', '[0:25].{id:id,userPrincipalName:userPrincipalName}', '--output', 'json']);
-      evaluations.push(defaults.length >= 0
+      evaluations.push(defaults.length > 0
         ? { control_framework: 'SCF', control_id: 'IAC-01.1', status: 'inconclusive', severity: 'medium', message: 'Azure CLI cannot determine per-user MFA or Conditional Access posture from this read-only query. Verify Entra ID authentication methods and Conditional Access policies in Microsoft Graph or the portal.' }
         : { control_framework: 'SCF', control_id: 'IAC-01.1', status: 'inconclusive', severity: 'medium', message: 'No Entra user data returned.' });
     } catch (err) {

--- a/plugins/connectors/azure-inspector/scripts/collect.js
+++ b/plugins/connectors/azure-inspector/scripts/collect.js
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+
+/**
+ * azure-inspector:collect
+ *
+ * Runs Azure CLI read-only queries and emits findings conforming to
+ * schemas/finding.schema.json v1.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+const execFileP = promisify(execFile);
+
+const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'connectors', 'azure-inspector.yaml');
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'azure-inspector');
+const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
+const SOURCE = 'azure-inspector';
+const SOURCE_VERSION = '0.1.0';
+
+const EXIT = { OK: 0, USAGE: 2, AUTH: 2, RATE_LIMITED: 3, PARTIAL: 4, NOT_CONFIGURED: 5 };
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  const log = args.quiet ? () => {} : (m) => process.stderr.write(`[${SOURCE}] ${m}\n`);
+
+  let config;
+  try { config = parseYaml(await fs.readFile(CONFIG_FILE, 'utf8')); }
+  catch { fail(EXIT.NOT_CONFIGURED, `config missing (${CONFIG_FILE}). Run /azure-inspector:setup first.`); }
+
+  const subscriptionId = args.subscription || config.subscription_id || process.env.AZURE_SUBSCRIPTION_ID;
+  const tenantId = args.tenant || config.tenant_id;
+  const services = args.services?.length ? args.services : (config.defaults?.services || ['entra', 'storage', 'keyvault', 'monitor', 'defender']);
+  if (!subscriptionId) fail(EXIT.NOT_CONFIGURED, 'subscription_id missing. Re-run /azure-inspector:setup.');
+
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  const runId = makeRunId();
+  const startedAt = Date.now();
+  log(`subscription=${subscriptionId} services=${services.join(',')}`);
+
+  const findings = [];
+  const errors = [];
+  const ctx = { subscriptionId, tenantId, runId };
+
+  for (const svc of services) {
+    try {
+      const handler = serviceHandlers[svc];
+      if (!handler) throw new Error(`unknown service '${svc}'`);
+      findings.push(...await handler(ctx, log));
+    } catch (err) {
+      errors.push({ service: svc, error: err.message });
+      log(`${svc} failed: ${err.message}`);
+    }
+  }
+
+  const cachePath = path.join(CACHE_DIR, `${runId}.json`);
+  await fs.writeFile(cachePath, JSON.stringify(findings, null, 2));
+
+  const counters = { pass: 0, fail: 0, inconclusive: 0, not_applicable: 0, skipped: 0 };
+  const sev = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const d of findings) for (const e of d.evaluations) {
+    counters[e.status] = (counters[e.status] || 0) + 1;
+    if (e.severity) sev[e.severity] = (sev[e.severity] || 0) + 1;
+  }
+
+  const manifest = {
+    source: SOURCE,
+    run_id: runId,
+    started_at: new Date(startedAt).toISOString(),
+    duration_ms: Date.now() - startedAt,
+    subscription_id: subscriptionId,
+    tenant_id: tenantId || null,
+    services,
+    resources: findings.length,
+    evaluations: findings.reduce((n, d) => n + d.evaluations.length, 0),
+    counters,
+    severities: sev,
+    errors: errors.length
+  };
+  await fs.appendFile(RUNS_LOG, JSON.stringify(manifest) + '\n');
+
+  const summary = `${SOURCE}: ${findings.length} resources, ${manifest.evaluations} evaluations, ${counters.fail || 0} failing (${sev.critical || 0} critical, ${sev.high || 0} high, ${sev.medium || 0} medium).`;
+  if (args.output === 'json') process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, summary: manifest, errors }, null, 2) + '\n');
+  else if (args.output !== 'silent') {
+    process.stdout.write(summary + '\n');
+    if (errors.length) process.stdout.write(`(${errors.length} partial errors - see JSON output for details)\n`);
+  }
+
+  process.exit(errors.length ? EXIT.PARTIAL : EXIT.OK);
+}
+
+const serviceHandlers = {
+  async entra(ctx) {
+    const resource = {
+      type: 'azure_entra_tenant',
+      id: ctx.tenantId || ctx.subscriptionId,
+      uri: ctx.tenantId ? `https://login.microsoftonline.com/${ctx.tenantId}` : null,
+      region: null,
+      account_id: ctx.subscriptionId
+    };
+    const evaluations = [];
+
+    try {
+      const defaults = await azJson(['ad', 'user', 'list', '--filter', "userType eq 'Member' and accountEnabled eq true", '--query', '[0:25].{id:id,userPrincipalName:userPrincipalName}', '--output', 'json']);
+      evaluations.push(defaults.length >= 0
+        ? { control_framework: 'SCF', control_id: 'IAC-01.1', status: 'inconclusive', severity: 'medium', message: 'Azure CLI cannot determine per-user MFA or Conditional Access posture from this read-only query. Verify Entra ID authentication methods and Conditional Access policies in Microsoft Graph or the portal.' }
+        : { control_framework: 'SCF', control_id: 'IAC-01.1', status: 'inconclusive', severity: 'medium', message: 'No Entra user data returned.' });
+    } catch (err) {
+      evaluations.push({ control_framework: 'SCF', control_id: 'IAC-01.1', status: 'inconclusive', severity: 'medium', message: `Could not query Entra users: ${err.message}` });
+    }
+
+    try {
+      const policies = await azJson(['rest', '--method', 'GET', '--url', 'https://graph.microsoft.com/v1.0/identity/conditionalAccess/policies']);
+      const enabled = (policies.value || []).filter(p => String(p.state).toLowerCase() === 'enabled');
+      evaluations.push(enabled.length
+        ? { control_framework: 'SCF', control_id: 'IAC-04', status: 'pass', severity: 'info', message: `${enabled.length} enabled Conditional Access polic${enabled.length === 1 ? 'y' : 'ies'} found.` }
+        : {
+            control_framework: 'SCF', control_id: 'IAC-04', status: 'fail', severity: 'high',
+            message: 'No enabled Conditional Access policies were found.',
+            remediation: { summary: 'Create baseline Conditional Access policies for MFA, risky sign-ins, admin roles, and legacy authentication blocking.', ref: 'grc-engineer://generate-implementation/conditional_access/azure', effort_hours: 3, automation: 'semi_automated' }
+          });
+    } catch (err) {
+      evaluations.push({ control_framework: 'SCF', control_id: 'IAC-04', status: 'inconclusive', severity: 'medium', message: `Could not query Conditional Access policies through Microsoft Graph: ${err.message}` });
+    }
+
+    return [buildDoc(ctx, resource, evaluations)];
+  },
+
+  async storage(ctx, log) {
+    const accounts = await azJson(['storage', 'account', 'list', '--subscription', ctx.subscriptionId, '--output', 'json']);
+    log(`storage: ${accounts.length} accounts`);
+    if (!accounts.length) {
+      return [buildDoc(ctx, { type: 'azure_storage_subscription', id: ctx.subscriptionId, account_id: ctx.subscriptionId }, [
+        { control_framework: 'SCF', control_id: 'CRY-05', status: 'not_applicable', severity: 'info', message: 'No storage accounts found in subscription.' }
+      ])];
+    }
+    return accounts.map(a => {
+      const evaluations = [];
+      const encrypted = a.encryption?.services?.blob?.enabled !== false && a.encryption?.services?.file?.enabled !== false;
+      evaluations.push(encrypted
+        ? { control_framework: 'SCF', control_id: 'CRY-05', status: 'pass', severity: 'info' }
+        : {
+            control_framework: 'SCF', control_id: 'CRY-05', status: 'fail', severity: 'high',
+            message: 'Blob or file service encryption is disabled for this storage account.',
+            remediation: { summary: 'Enable Azure Storage service encryption for blob and file services.', ref: 'grc-engineer://generate-implementation/storage_encryption/azure', effort_hours: 0.5, automation: 'auto_fixable' }
+          });
+
+      evaluations.push(a.allowBlobPublicAccess === false
+        ? { control_framework: 'SCF', control_id: 'DCH-01.2', status: 'pass', severity: 'info' }
+        : {
+            control_framework: 'SCF', control_id: 'DCH-01.2', status: 'fail', severity: 'critical',
+            message: 'Blob public access is allowed at the storage account level.',
+            remediation: { summary: 'Set allowBlobPublicAccess=false and review container ACLs.', ref: 'grc-engineer://generate-implementation/storage_public_access/azure', effort_hours: 0.25, automation: 'auto_fixable' }
+          });
+
+      evaluations.push(a.minimumTlsVersion && a.minimumTlsVersion !== 'TLS1_0' && a.minimumTlsVersion !== 'TLS1_1'
+        ? { control_framework: 'SCF', control_id: 'CRY-06', status: 'pass', severity: 'info' }
+        : {
+            control_framework: 'SCF', control_id: 'CRY-06', status: 'fail', severity: 'medium',
+            message: `Minimum TLS version is ${a.minimumTlsVersion || 'unset'}.`,
+            remediation: { summary: 'Set the storage account minimum TLS version to TLS1_2 or later.', ref: 'grc-engineer://generate-implementation/storage_tls/azure', effort_hours: 0.25, automation: 'auto_fixable' }
+          });
+
+      return buildDoc(ctx, {
+        type: 'azure_storage_account',
+        id: a.name,
+        uri: a.id,
+        region: a.location || null,
+        account_id: ctx.subscriptionId,
+        tags: stringifyTags(a.tags)
+      }, evaluations, { kind: a.kind, sku: a.sku?.name });
+    });
+  },
+
+  async keyvault(ctx, log) {
+    const vaults = await azJson(['keyvault', 'list', '--subscription', ctx.subscriptionId, '--output', 'json']);
+    log(`keyvault: ${vaults.length} vaults`);
+    if (!vaults.length) {
+      return [buildDoc(ctx, { type: 'azure_keyvault_subscription', id: ctx.subscriptionId, account_id: ctx.subscriptionId }, [
+        { control_framework: 'SCF', control_id: 'CRY-04', status: 'not_applicable', severity: 'info', message: 'No Key Vaults found in subscription.' }
+      ])];
+    }
+    return vaults.map(v => {
+      const evaluations = [];
+      const softDelete = v.properties?.enableSoftDelete !== false;
+      evaluations.push(softDelete
+        ? { control_framework: 'SCF', control_id: 'BCD-11', status: 'pass', severity: 'info' }
+        : {
+            control_framework: 'SCF', control_id: 'BCD-11', status: 'fail', severity: 'high',
+            message: 'Key Vault soft delete is disabled.',
+            remediation: { summary: 'Enable soft delete and purge protection for production Key Vaults.', ref: 'grc-engineer://generate-implementation/keyvault_recovery/azure', effort_hours: 0.5, automation: 'auto_fixable' }
+          });
+      evaluations.push(v.properties?.enablePurgeProtection
+        ? { control_framework: 'SCF', control_id: 'BCD-11', status: 'pass', severity: 'info', message: 'Purge protection is enabled.' }
+        : {
+            control_framework: 'SCF', control_id: 'BCD-11', status: 'fail', severity: 'medium',
+            message: 'Key Vault purge protection is disabled.',
+            remediation: { summary: 'Enable purge protection where regulatory retention or ransomware recovery requirements apply.', ref: 'grc-engineer://generate-implementation/keyvault_purge_protection/azure', effort_hours: 0.5, automation: 'semi_automated' }
+          });
+      evaluations.push(v.properties?.enableRbacAuthorization
+        ? { control_framework: 'SCF', control_id: 'IAC-07.2', status: 'pass', severity: 'info' }
+        : {
+            control_framework: 'SCF', control_id: 'IAC-07.2', status: 'fail', severity: 'medium',
+            message: 'Key Vault uses access policies instead of Azure RBAC authorization.',
+            remediation: { summary: 'Migrate Key Vault authorization to Azure RBAC and remove broad access policies.', ref: 'grc-engineer://generate-implementation/keyvault_rbac/azure', effort_hours: 2, automation: 'semi_automated' }
+          });
+      return buildDoc(ctx, {
+        type: 'azure_key_vault',
+        id: v.name,
+        uri: v.id,
+        region: v.location || null,
+        account_id: ctx.subscriptionId,
+        tags: stringifyTags(v.tags)
+      }, evaluations);
+    });
+  },
+
+  async monitor(ctx) {
+    const settings = await azJson(['monitor', 'diagnostic-settings', 'subscription', 'list', '--subscription', ctx.subscriptionId, '--output', 'json']);
+    const values = settings.value || settings || [];
+    const resource = { type: 'azure_subscription_monitor', id: ctx.subscriptionId, uri: `/subscriptions/${ctx.subscriptionId}`, region: null, account_id: ctx.subscriptionId };
+    const evaluations = [values.length
+      ? { control_framework: 'SCF', control_id: 'MON-02', status: 'pass', severity: 'info', message: `${values.length} subscription diagnostic setting(s) found.` }
+      : {
+          control_framework: 'SCF', control_id: 'MON-02', status: 'fail', severity: 'high',
+          message: 'No subscription diagnostic settings were found for activity log export.',
+          remediation: { summary: 'Create subscription diagnostic settings to export Activity Logs to Log Analytics, Event Hub, or Storage.', ref: 'grc-engineer://generate-implementation/activity_log_export/azure', effort_hours: 1, automation: 'auto_fixable' }
+        }];
+    return [buildDoc(ctx, resource, evaluations)];
+  },
+
+  async defender(ctx) {
+    const plans = await azJson(['security', 'pricing', 'list', '--subscription', ctx.subscriptionId, '--output', 'json']);
+    const values = plans.value || plans || [];
+    const enabled = values.filter(p => String(p.pricingTier).toLowerCase() === 'standard');
+    const resource = { type: 'azure_defender_for_cloud', id: ctx.subscriptionId, uri: `/subscriptions/${ctx.subscriptionId}/providers/Microsoft.Security/pricings`, region: null, account_id: ctx.subscriptionId };
+    const evaluations = [enabled.length
+      ? { control_framework: 'SCF', control_id: 'MON-01.2', status: 'pass', severity: 'info', message: `${enabled.length} Defender for Cloud plan(s) are Standard.` }
+      : {
+          control_framework: 'SCF', control_id: 'MON-01.2', status: 'fail', severity: 'high',
+          message: 'No Defender for Cloud plans are set to Standard.',
+          remediation: { summary: 'Enable Microsoft Defender for Cloud Standard plans for regulated workload resource types.', ref: 'grc-engineer://generate-implementation/defender_for_cloud/azure', effort_hours: 1, automation: 'semi_automated' }
+        }];
+    return [buildDoc(ctx, resource, evaluations)];
+  }
+};
+
+function buildDoc(ctx, resource, evaluations, rawAttributes = undefined) {
+  const doc = {
+    schema_version: '1.0.0',
+    source: SOURCE,
+    source_version: SOURCE_VERSION,
+    run_id: ctx.runId,
+    collected_at: new Date().toISOString(),
+    resource,
+    evaluations
+  };
+  if (rawAttributes) doc.raw_attributes = rawAttributes;
+  return doc;
+}
+
+async function azJson(args) {
+  const outArgs = args.includes('--output') || args.includes('-o') ? args : [...args, '--output', 'json'];
+  const { stdout } = await az([...outArgs, '--only-show-errors']);
+  return JSON.parse(stdout || '[]');
+}
+
+async function az(args) {
+  try {
+    return await execFileP('az', args, { timeout: 60000, maxBuffer: 20 * 1024 * 1024 });
+  } catch (err) {
+    const msg = (err.stderr || err.stdout || err.message || '').trim();
+    if (/Please run 'az login'|az login|AADSTS|expired|not logged in/i.test(msg)) fail(EXIT.AUTH, msg || 'Azure authentication is invalid.');
+    if (/Too many requests|throttl|rate/i.test(msg)) fail(EXIT.RATE_LIMITED, msg);
+    throw new Error(msg || err.message);
+  }
+}
+
+function parseArgs(argv) {
+  const args = { services: [], output: 'summary', quiet: false };
+  for (const a of argv) {
+    if (a === '--quiet') args.quiet = true;
+    else if (a.startsWith('--services=')) args.services = csv(a);
+    else if (a.startsWith('--subscription=')) args.subscription = a.slice('--subscription='.length);
+    else if (a.startsWith('--tenant=')) args.tenant = a.slice('--tenant='.length);
+    else if (a.startsWith('--output=')) args.output = a.slice('--output='.length);
+    else fail(EXIT.USAGE, `unknown argument: ${a}`);
+  }
+  if (!['summary', 'silent', 'json'].includes(args.output)) fail(EXIT.USAGE, '--output must be summary, silent, or json');
+  return args;
+}
+
+function csv(arg) {
+  return arg.split('=')[1].split(',').map(s => s.trim()).filter(Boolean);
+}
+
+function parseYaml(src) {
+  const out = {};
+  let section = null;
+  for (const line of src.split(/\r?\n/)) {
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    const m = line.match(/^([a-zA-Z0-9_]+):\s*(.*)$/);
+    if (m) {
+      section = null;
+      const [, k, raw] = m;
+      out[k] = parseScalar(raw);
+      if (raw === '') section = k;
+      continue;
+    }
+    const sm = line.match(/^\s+([a-zA-Z0-9_]+):\s*(.*)$/);
+    if (sm && section) {
+      out[section] ||= {};
+      out[section][sm[1]] = parseScalar(sm[2]);
+    }
+  }
+  return out;
+}
+
+function parseScalar(raw) {
+  const s = String(raw).trim();
+  if (s.startsWith('[')) return s.slice(1, -1).split(',').map(x => x.trim().replace(/^"|"$/g, '')).filter(Boolean);
+  return s.replace(/^"|"$/g, '');
+}
+
+function stringifyTags(tags) {
+  if (!tags || typeof tags !== 'object') return undefined;
+  return Object.fromEntries(Object.entries(tags).map(([k, v]) => [k, String(v)]));
+}
+
+function makeRunId() {
+  const ts = new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+  return `${ts}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function fail(code, msg) {
+  process.stderr.write(`[${SOURCE}] ${msg}\n`);
+  process.exit(code);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch(err => fail(EXIT.PARTIAL, err.stack || err.message));
+}

--- a/plugins/connectors/azure-inspector/scripts/collect.js
+++ b/plugins/connectors/azure-inspector/scripts/collect.js
@@ -186,7 +186,8 @@ const serviceHandlers = {
     log(`keyvault: ${vaults.length} vaults`);
     if (!vaults.length) {
       return [buildDoc(ctx, { type: 'azure_keyvault_subscription', id: ctx.subscriptionId, account_id: ctx.subscriptionId }, [
-        { control_framework: 'SCF', control_id: 'CRY-04', status: 'not_applicable', severity: 'info', message: 'No Key Vaults found in subscription.' }
+        { control_framework: 'SCF', control_id: 'BCD-11', status: 'not_applicable', severity: 'info', message: 'No Key Vaults found in subscription.' },
+        { control_framework: 'SCF', control_id: 'IAC-07.2', status: 'not_applicable', severity: 'info', message: 'No Key Vaults found in subscription.' }
       ])];
     }
     return vaults.map(v => {

--- a/plugins/connectors/azure-inspector/scripts/setup.sh
+++ b/plugins/connectors/azure-inspector/scripts/setup.sh
@@ -33,12 +33,14 @@ EOF
 fi
 
 AZ_VERSION=$(az version --query '"azure-cli"' -o tsv 2>/dev/null || az --version 2>/dev/null | head -1 | awk '{print $NF}')
+ERR_FILE=$(mktemp "${TMPDIR:-/tmp}/azure-inspector-setup.XXXXXX")
+trap 'rm -f "$ERR_FILE"' EXIT
 
-if ! ACCOUNT_JSON=$(az account show --only-show-errors -o json 2>/tmp/azure-setup.err); then
+if ! ACCOUNT_JSON=$(az account show --only-show-errors -o json 2>"$ERR_FILE"); then
   cat >&2 <<EOF
 [azure-inspector:setup] No active Azure account.
 
-$(cat /tmp/azure-setup.err)
+$(cat "$ERR_FILE")
 
 Fix:
   az login

--- a/plugins/connectors/azure-inspector/scripts/setup.sh
+++ b/plugins/connectors/azure-inspector/scripts/setup.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# azure-inspector:setup
+# Idempotent setup for the azure-inspector connector.
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors"
+CONFIG_FILE="$CONFIG_DIR/azure-inspector.yaml"
+SOURCE="azure-inspector"
+SOURCE_VERSION="0.1.0"
+
+SUBSCRIPTION=""
+TENANT=""
+for arg in "$@"; do
+  case "$arg" in
+    --subscription=*) SUBSCRIPTION="${arg#*=}" ;;
+    --tenant=*)       TENANT="${arg#*=}" ;;
+    *) echo "[$SOURCE:setup] unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v az >/dev/null 2>&1; then
+  cat <<'EOF' >&2
+[azure-inspector:setup] Azure CLI not found on PATH.
+
+Install:
+  macOS:  brew install azure-cli
+  Linux:  https://learn.microsoft.com/cli/azure/install-azure-cli
+
+Then: az login
+Finally re-run /azure-inspector:setup.
+EOF
+  exit 5
+fi
+
+AZ_VERSION=$(az version --query '"azure-cli"' -o tsv 2>/dev/null || az --version 2>/dev/null | head -1 | awk '{print $NF}')
+
+if ! ACCOUNT_JSON=$(az account show --only-show-errors -o json 2>/tmp/azure-setup.err); then
+  cat >&2 <<EOF
+[azure-inspector:setup] No active Azure account.
+
+$(cat /tmp/azure-setup.err)
+
+Fix:
+  az login
+  az account set --subscription <subscription-id>
+EOF
+  exit 2
+fi
+
+if [[ -z "$SUBSCRIPTION" ]]; then
+  SUBSCRIPTION=$(node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).id || ''))" <<<"$ACCOUNT_JSON")
+fi
+if [[ -z "$TENANT" ]]; then
+  TENANT=$(node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).tenantId || ''))" <<<"$ACCOUNT_JSON")
+fi
+SUBSCRIPTION_NAME=$(node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).name || ''))" <<<"$ACCOUNT_JSON")
+CALLER=$(node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).user?.name || ''))" <<<"$ACCOUNT_JSON")
+
+if [[ -z "$SUBSCRIPTION" ]]; then
+  echo "[azure-inspector:setup] Could not determine subscription. Re-run with --subscription=<subscription-id>." >&2
+  exit 2
+fi
+
+if ! az account show --subscription "$SUBSCRIPTION" --only-show-errors -o json >/dev/null 2>&1; then
+  echo "[azure-inspector:setup] Cannot access subscription '$SUBSCRIPTION'. Check Reader access for the active principal." >&2
+  exit 2
+fi
+
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_FILE" <<EOF
+version: 1
+source: $SOURCE
+source_version: "$SOURCE_VERSION"
+subscription_id: "$SUBSCRIPTION"
+subscription_name: "$SUBSCRIPTION_NAME"
+tenant_id: "$TENANT"
+caller: "$CALLER"
+defaults:
+  services: ["entra", "storage", "keyvault", "monitor", "defender"]
+EOF
+
+CACHE_DIR="$HOME/.cache/claude-grc/findings/azure-inspector"
+mkdir -p "$CACHE_DIR"
+touch "$HOME/.cache/claude-grc/runs.log"
+
+cat <<EOF
+azure-inspector:setup ok
+  az:             $AZ_VERSION
+  subscription:   $SUBSCRIPTION_NAME ($SUBSCRIPTION)
+  tenant:         $TENANT
+  caller:         $CALLER
+  config:         $CONFIG_FILE
+
+Next:
+  /azure-inspector:collect
+  /grc-engineer:gap-assessment FedRAMP-Moderate,SOC2 --sources=azure-inspector
+EOF

--- a/plugins/connectors/azure-inspector/scripts/status.sh
+++ b/plugins/connectors/azure-inspector/scripts/status.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# azure-inspector:status
+set -uo pipefail
+
+CONFIG_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors/azure-inspector.yaml"
+CACHE_DIR="$HOME/.cache/claude-grc/findings/azure-inspector"
+
+printf 'azure-inspector\n'
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  printf '  status:        not-configured\n'
+  printf '  fix:           run /azure-inspector:setup\n'
+  exit 2
+fi
+
+if ! command -v az >/dev/null 2>&1; then
+  printf '  status:        az-not-installed\n'
+  exit 5
+fi
+
+AZ_VERSION=$(az version --query '"azure-cli"' -o tsv 2>/dev/null || az --version 2>/dev/null | head -1 | awk '{print $NF}')
+printf '  az:            %s\n' "$AZ_VERSION"
+
+SUBSCRIPTION=$(awk -F'"' '/^subscription_id:/ {print $2; exit}' "$CONFIG_FILE")
+TENANT=$(awk -F'"' '/^tenant_id:/ {print $2; exit}' "$CONFIG_FILE")
+
+if ! ACCOUNT_JSON=$(az account show --subscription "$SUBSCRIPTION" --only-show-errors -o json 2>/dev/null); then
+  printf '  status:        credentials-expired-or-subscription-inaccessible\n'
+  printf '  subscription:  %s\n' "$SUBSCRIPTION"
+  printf '  fix:           az login && az account set --subscription %s\n' "$SUBSCRIPTION"
+  exit 2
+fi
+
+CALLER=$(node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).user?.name || ''))" <<<"$ACCOUNT_JSON")
+NAME=$(node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).name || ''))" <<<"$ACCOUNT_JSON")
+
+printf '  status:        ready\n'
+printf '  subscription:  %s (%s)\n' "$NAME" "$SUBSCRIPTION"
+printf '  tenant:        %s\n' "$TENANT"
+printf '  caller:        %s\n' "$CALLER"
+printf '  config:        %s\n' "$CONFIG_FILE"
+
+LATEST=$(ls -t "$CACHE_DIR"/*.json 2>/dev/null | head -1 || true)
+if [[ -z "$LATEST" ]]; then
+  printf '  last run:      never\n'
+  exit 0
+fi
+
+if stat -f%m "$LATEST" >/dev/null 2>&1; then MTIME=$(stat -f%m "$LATEST"); else MTIME=$(stat -c%Y "$LATEST"); fi
+AGE=$(( $(date +%s) - MTIME ))
+AGE_H=$(( AGE / 3600 ))
+if (( AGE_H < 24 )); then LABEL="${AGE_H}h ago"; STATUS="ready"
+elif (( AGE_H < 168 )); then LABEL="$((AGE_H/24))d ago"; STATUS="ready"
+else LABEL="$((AGE_H/24))d ago"; STATUS="stale"
+fi
+
+RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
+EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}" "$LATEST")
+
+printf '  cache:         %s\n' "$STATUS"
+printf '  last run:      %s (%s)\n' "$LABEL" "$(basename "$LATEST" .json)"
+printf '  cached:        %s resources, %s evaluations\n' "$RES" "$EVS"

--- a/plugins/connectors/azure-inspector/scripts/status.sh
+++ b/plugins/connectors/azure-inspector/scripts/status.sh
@@ -34,14 +34,13 @@ fi
 CALLER=$(node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).user?.name || ''))" <<<"$ACCOUNT_JSON")
 NAME=$(node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).name || ''))" <<<"$ACCOUNT_JSON")
 
-printf '  status:        ready\n'
-printf '  subscription:  %s (%s)\n' "$NAME" "$SUBSCRIPTION"
-printf '  tenant:        %s\n' "$TENANT"
-printf '  caller:        %s\n' "$CALLER"
-printf '  config:        %s\n' "$CONFIG_FILE"
-
 LATEST=$(ls -t "$CACHE_DIR"/*.json 2>/dev/null | head -1 || true)
 if [[ -z "$LATEST" ]]; then
+  printf '  status:        ready\n'
+  printf '  subscription:  %s (%s)\n' "$NAME" "$SUBSCRIPTION"
+  printf '  tenant:        %s\n' "$TENANT"
+  printf '  caller:        %s\n' "$CALLER"
+  printf '  config:        %s\n' "$CONFIG_FILE"
   printf '  last run:      never\n'
   exit 0
 fi
@@ -54,9 +53,14 @@ elif (( AGE_H < 168 )); then LABEL="$((AGE_H/24))d ago"; STATUS="ready"
 else LABEL="$((AGE_H/24))d ago"; STATUS="stale"
 fi
 
+printf '  status:        %s\n' "$STATUS"
+printf '  subscription:  %s (%s)\n' "$NAME" "$SUBSCRIPTION"
+printf '  tenant:        %s\n' "$TENANT"
+printf '  caller:        %s\n' "$CALLER"
+printf '  config:        %s\n' "$CONFIG_FILE"
+
 RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
 EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}" "$LATEST")
 
-printf '  cache:         %s\n' "$STATUS"
 printf '  last run:      %s (%s)\n' "$LABEL" "$(basename "$LATEST" .json)"
 printf '  cached:        %s resources, %s evaluations\n' "$RES" "$EVS"

--- a/plugins/connectors/azure-inspector/skills/azure-inspector-expert/SKILL.md
+++ b/plugins/connectors/azure-inspector/skills/azure-inspector-expert/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: azure-inspector-expert
+description: Expertise in evaluating Azure subscription findings from azure-inspector and mapping them to SCF controls.
+---
+
+# azure-inspector expert
+
+Use this skill when interpreting `azure-inspector` findings or explaining Azure control gaps.
+
+## Checks This Connector Runs
+
+**Entra ID**
+
+| SCF | Check | Typical outcome |
+|---|---|---|
+| IAC-01.1 | MFA posture needs Graph/authentication-method verification | inconclusive when Azure CLI cannot prove coverage |
+| IAC-04 | Enabled Conditional Access policies exist | high fail if none found |
+
+**Storage accounts**
+
+| SCF | Check | Severity |
+|---|---|---|
+| CRY-05 | Blob/file encryption enabled | high if disabled |
+| DCH-01.2 | Blob public access disabled | critical if allowed |
+| CRY-06 | Minimum TLS version is TLS 1.2 or later | medium |
+
+**Key Vault**
+
+| SCF | Check | Severity |
+|---|---|---|
+| BCD-11 | Soft delete and purge protection | high/medium |
+| IAC-07.2 | Azure RBAC authorization preferred over access policies | medium |
+
+**Monitor + Defender for Cloud**
+
+| SCF | Check | Severity |
+|---|---|---|
+| MON-02 | Subscription Activity Log diagnostic export configured | high |
+| MON-01.2 | Defender for Cloud Standard plan enabled | high |
+
+## Interpretation Rules
+
+- Prefer SCF control IDs already emitted by the connector. Do not remap to Azure-native benchmark IDs unless the user asks for a CIS Azure Benchmark view.
+- Treat `inconclusive` as an evidence gap, not a pass. Entra MFA coverage often needs Microsoft Graph permissions beyond basic Azure Reader.
+- Treat a subscription-level `not_applicable` document as a scope signal, not a security defect. Example: no Key Vaults found.
+- For Key Vault, soft delete and purge protection are recovery controls. They do not prove key rotation.
+- For Storage, `allowBlobPublicAccess=true` is a high-risk configuration even when no container is currently public because it permits future public ACLs.
+
+## Common Failure Modes
+
+- `az login` is valid but the principal lacks subscription Reader.
+- Conditional Access queries require Microsoft Graph permissions such as `Policy.Read.All`.
+- Defender pricing reads require Security Reader or equivalent permissions in some tenants.
+- Diagnostic settings can exist at resource scope even if subscription Activity Log export is missing. The connector checks subscription-level export for v0.1.0.
+
+## Remediation Guidance
+
+- Entra ID: baseline Conditional Access for admins, all users MFA, risky sign-ins, and legacy authentication blocking.
+- Storage: set `allowBlobPublicAccess=false`, enforce TLS 1.2+, and keep service encryption enabled.
+- Key Vault: enable soft delete, enable purge protection for production vaults, and migrate broad access policies to Azure RBAC.
+- Monitor: export Activity Logs to Log Analytics, Event Hub, or Storage with retention aligned to the compliance program.
+- Defender: enable Standard plans for regulated resource types and verify alert routing into the incident workflow.
+
+## Roadmap Boundaries
+
+v0.1.0 does not inspect network security groups, Azure Policy assignments, VM disk encryption, AKS, SQL, Sentinel analytics, or Defender recommendations. Mark those as future connector coverage unless separate evidence is supplied.

--- a/tests/fixtures/findings/azure-inspector/001-storage-encrypted-pass.json
+++ b/tests/fixtures/findings/azure-inspector/001-storage-encrypted-pass.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0.0",
+  "source": "azure-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-azure-pass",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "azure_storage_account",
+    "id": "prodstorage001",
+    "uri": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Storage/storageAccounts/prodstorage001",
+    "region": "eastus",
+    "account_id": "00000000-0000-0000-0000-000000000000"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "CRY-05",
+      "status": "pass",
+      "severity": "info"
+    }
+  ]
+}

--- a/tests/fixtures/findings/azure-inspector/002-storage-public-access-fail.json
+++ b/tests/fixtures/findings/azure-inspector/002-storage-public-access-fail.json
@@ -16,7 +16,7 @@
       "control_framework": "SCF",
       "control_id": "DCH-01.2",
       "status": "fail",
-      "severity": "high",
+      "severity": "critical",
       "message": "Blob public access is allowed at the storage account level.",
       "remediation": {
         "summary": "Set allowBlobPublicAccess=false and review container ACLs.",

--- a/tests/fixtures/findings/azure-inspector/002-storage-public-access-fail.json
+++ b/tests/fixtures/findings/azure-inspector/002-storage-public-access-fail.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "source": "azure-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-azure-fail",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "azure_storage_account",
+    "id": "publicstorage001",
+    "uri": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Storage/storageAccounts/publicstorage001",
+    "region": "eastus",
+    "account_id": "00000000-0000-0000-0000-000000000000"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "DCH-01.2",
+      "status": "fail",
+      "severity": "high",
+      "message": "Blob public access is allowed at the storage account level.",
+      "remediation": {
+        "summary": "Set allowBlobPublicAccess=false and review container ACLs.",
+        "ref": "grc-engineer://generate-implementation/storage_public_access/azure",
+        "effort_hours": 0.25,
+        "automation": "auto_fixable"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/findings/azure-inspector/003-entra-mfa-inconclusive.json
+++ b/tests/fixtures/findings/azure-inspector/003-entra-mfa-inconclusive.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "azure-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-azure-inconclusive",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "azure_entra_tenant",
+    "id": "11111111-1111-1111-1111-111111111111",
+    "uri": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111",
+    "region": null,
+    "account_id": "00000000-0000-0000-0000-000000000000"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "IAC-01.1",
+      "status": "inconclusive",
+      "severity": "medium",
+      "message": "Azure CLI cannot determine per-user MFA or Conditional Access posture from this read-only query."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `azure-inspector`, a Tier-2 connector for Azure subscription posture.
- Covers Entra ID, Storage, Key Vault, Monitor diagnostic export, and Defender for Cloud plan posture.
- Registers the connector in the marketplace and adds required finding contract fixtures.
- Adds a lychee exclusion inherited from main for the decorative CodeRabbit badge timeout fix.

## Validation
- `git diff --check`
- `node --check plugins/connectors/azure-inspector/scripts/collect.js`
- `bash -n plugins/connectors/azure-inspector/scripts/setup.sh plugins/connectors/azure-inspector/scripts/status.sh`
- `npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh`
- `npm run test:contract`

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure Inspector connector for evaluating Azure services against compliance controls
  * Marketplace manifest updated to include the new connector
  * Includes setup, collect, and status commands for configuration and execution

* **Documentation**
  * Added setup, collect, and status command documentation with examples and troubleshooting guidance
  * Added skill guide with control mappings and remediation instructions

* **Tests**
  * Added sample finding fixtures demonstrating pass, fail, and inconclusive evaluation scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->