### PR TITLE
[codex] Add Slack inspector connector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -203,6 +203,12 @@
       "version": "0.1.0"
     },
     {
+      "name": "slack-inspector",
+      "source": "./plugins/connectors/slack-inspector",
+      "description": "GRC connector for Slack: workspace 2FA, SSO/session, retention, app approvals, and DLP visibility to v1 finding contract",
+      "version": "0.1.0"
+    },
+    {
       "name": "okta-inspector",
       "source": "./plugins/connectors/okta-inspector",
       "description": "GRC connector for Okta: password/MFA/session policies, inactive users, admin factor enrollment \u2192 v1 finding contract",

--- a/plugins/connectors/slack-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/slack-inspector/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "slack-inspector",
+  "version": "0.1.0",
+  "description": "GRC connector for Slack: evaluates workspace 2FA, SSO/session posture, retention, app approvals, and DLP visibility. Emits findings conforming to schemas/finding.schema.json v1.",
+  "author": { "name": "GRC Engineering Club Contributors" },
+  "license": "MIT",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "keywords": ["grc", "compliance", "slack", "collaboration", "scf", "connector"]
+}

--- a/plugins/connectors/slack-inspector/commands/collect.md
+++ b/plugins/connectors/slack-inspector/commands/collect.md
@@ -1,0 +1,34 @@
+# /slack-inspector:collect
+
+Collect Slack workspace posture and write Finding documents to the shared cache:
+
+```text
+~/.cache/claude-grc/findings/slack-inspector/<run_id>.json
+```
+
+The collector appends a run manifest to:
+
+```text
+~/.cache/claude-grc/runs.log
+```
+
+## Coverage
+
+- Workspace authentication posture: 2FA and SSO signals
+- Session duration policy visibility
+- Message/file retention policy visibility
+- App install approval workflow visibility
+- DLP and discovery visibility
+
+Slack exposes several of these controls only to Enterprise Grid or admin-scoped tokens. Missing privileges are emitted as `inconclusive` evaluations with a clear message.
+
+## Options
+
+- `--output=summary|json|silent` controls stdout. Default: `summary`; `silent` suppresses stdout summary.
+- `--quiet` suppresses progress logs on stderr.
+
+## Example
+
+```bash
+node plugins/connectors/slack-inspector/scripts/collect.js --output=json
+```

--- a/plugins/connectors/slack-inspector/commands/setup.md
+++ b/plugins/connectors/slack-inspector/commands/setup.md
@@ -1,0 +1,40 @@
+# /slack-inspector:setup
+
+Configure `slack-inspector` for a Slack workspace.
+
+```bash
+plugins/connectors/slack-inspector/scripts/setup.sh --token=xoxb-...
+```
+
+The setup command is idempotent. Re-running it validates the active token with `auth.test` and rewrites the same connector config at:
+
+```text
+~/.config/claude-grc/connectors/slack-inspector.yaml
+```
+
+## Required token
+
+Use a Slack OAuth bot token with the least privilege scopes available for your plan. The collector can run with partial coverage and marks unavailable admin-only checks as `inconclusive`.
+
+Recommended scopes:
+
+- `team:read`
+- `users:read`
+- `admin.users.info:read`
+- `admin.apps:read`
+- `admin.conversations:read`
+- `discovery:read`
+
+Enterprise Grid or admin scopes may be required for 2FA, SSO, app approval, retention, and DLP checks.
+
+## Options
+
+- `--token=<xoxb-or-xoxp-token>` Slack OAuth token. If omitted, reads `SLACK_TOKEN`.
+- `--workspace=<name>` optional label stored in config.
+
+## Next
+
+```text
+/slack-inspector:collect
+/slack-inspector:status
+```

--- a/plugins/connectors/slack-inspector/commands/status.md
+++ b/plugins/connectors/slack-inspector/commands/status.md
@@ -1,0 +1,16 @@
+# /slack-inspector:status
+
+Show whether `slack-inspector` is configured, whether the token is still valid, and the freshness of the latest cached run.
+
+```bash
+plugins/connectors/slack-inspector/scripts/status.sh
+```
+
+Output includes:
+
+- top-level status: `ready`, `stale`, `not-configured`, or `credentials-expired`
+- Slack team id and team name from `auth.test`
+- config path
+- latest cache file age and evaluation count
+
+A cache older than seven days is reported as `stale`.

--- a/plugins/connectors/slack-inspector/scripts/collect.js
+++ b/plugins/connectors/slack-inspector/scripts/collect.js
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+
+/**
+ * slack-inspector:collect
+ *
+ * Queries Slack Web API, evaluates workspace-level security posture, and
+ * writes Finding documents to the shared claude-grc cache.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+
+const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'connectors', 'slack-inspector.yaml');
+const TOKEN_FILE = path.join(CONFIG_DIR, 'connectors', 'slack-inspector.token');
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'slack-inspector');
+const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
+const SOURCE = 'slack-inspector';
+const SOURCE_VERSION = '0.1.0';
+const EXIT = { OK: 0, USAGE: 2, AUTH: 2, PARTIAL: 4, NOT_CONFIGURED: 5 };
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  const log = args.quiet ? () => {} : (m) => process.stderr.write(`[${SOURCE}] ${m}\n`);
+  let config;
+  try {
+    config = parseYaml(await fs.readFile(CONFIG_FILE, 'utf8'));
+  } catch {
+    fail(EXIT.NOT_CONFIGURED, `config missing (${CONFIG_FILE}). Run /slack-inspector:setup first.`);
+  }
+
+  const token = await getToken();
+  if (!token) fail(EXIT.AUTH, 'missing Slack token. Set SLACK_TOKEN or run /slack-inspector:setup.');
+
+  const runId = makeRunId();
+  const startedAt = Date.now();
+  const findings = [];
+  const errors = [];
+
+  let auth;
+  try {
+    auth = await slack('auth.test', {}, token);
+  } catch (err) {
+    fail(EXIT.AUTH, `Slack auth.test failed: ${err.message}`);
+  }
+
+  const team = {
+    id: auth.team_id || config.team_id || 'unknown-team',
+    name: auth.team || config.team_name || config.workspace || 'unknown-workspace',
+    url: auth.url || null
+  };
+  log(`team=${team.name} (${team.id})`);
+
+  const workspaceEvaluations = [];
+  const raw = { auth: scrubAuth(auth), team: null, admins: {}, retention: null, apps: null, dlp: null };
+
+  try {
+    raw.team = await slack('team.info', {}, token);
+    workspaceEvaluations.push(pass('GOV-03', 'Slack workspace metadata is readable for this connector run.'));
+  } catch (err) {
+    workspaceEvaluations.push(inconclusive('GOV-03', `Slack team.info was unavailable: ${err.message}`));
+    errors.push({ check: 'team.info', error: err.message });
+  }
+
+  const twoFa = await adminProbe('admin.users.info', { user_id: auth.user_id }, token);
+  raw.admins.user_info = twoFa.raw;
+  if (twoFa.ok && typeof twoFa.raw?.user?.has_2fa === 'boolean') {
+    if (twoFa.raw.user.has_2fa) workspaceEvaluations.push(pass('IAC-02', 'The inspected principal has 2FA enabled.'));
+    else workspaceEvaluations.push(failHigh('IAC-02', 'The inspected Slack principal does not have 2FA enabled.', 'Require 2FA for Slack users and administrators.'));
+  } else {
+    workspaceEvaluations.push(inconclusive('IAC-02', `Slack 2FA enforcement requires admin visibility: ${twoFa.error}`));
+  }
+
+  const retention = await adminProbe('admin.conversations.getConversationPrefs', { channel_id: config.defaults?.retention_channel_id || '' }, token);
+  raw.retention = retention.raw;
+  if (retention.ok && retention.raw?.prefs) {
+    workspaceEvaluations.push(pass('DCH-07', 'Slack retention preferences were available for review.'));
+  } else {
+    workspaceEvaluations.push(inconclusive('DCH-07', `Slack retention policy requires admin or channel-specific visibility: ${retention.error}`));
+  }
+
+  const apps = await adminProbe('admin.apps.approved.list', { limit: 1 }, token);
+  raw.apps = apps.raw;
+  if (apps.ok) {
+    workspaceEvaluations.push(pass('TPM-03', 'Slack app approval data is available for review.'));
+  } else {
+    workspaceEvaluations.push(inconclusive('TPM-03', `Slack app approval data requires admin app scopes: ${apps.error}`));
+  }
+
+  const dlp = await adminProbe('discovery.enterprise.info', {}, token);
+  raw.dlp = dlp.raw;
+  if (dlp.ok) {
+    workspaceEvaluations.push(pass('DLP-01', 'Slack discovery/DLP integration visibility is available.'));
+  } else {
+    workspaceEvaluations.push(inconclusive('DLP-01', `Slack DLP/discovery visibility requires Enterprise Grid or discovery scopes: ${dlp.error}`));
+  }
+
+  workspaceEvaluations.push(inconclusive('IAC-04', 'Slack SSO and session-duration enforcement are not exposed by the standard bot token API; verify in Enterprise Admin settings or provide an admin-scoped integration.'));
+
+  findings.push({
+    schema_version: '1.0.0',
+    source: SOURCE,
+    source_version: SOURCE_VERSION,
+    run_id: runId,
+    collected_at: new Date().toISOString(),
+    resource: {
+      type: 'slack_workspace',
+      id: team.id,
+      uri: team.url,
+      region: null,
+      account_id: team.id
+    },
+    evaluations: workspaceEvaluations,
+    raw_attributes: raw,
+    metadata: {
+      workspace: team.name,
+      token_principal: auth.user_id || null,
+      partial_coverage: workspaceEvaluations.some(e => e.status === 'inconclusive')
+    }
+  });
+
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  const cachePath = path.join(CACHE_DIR, `${runId}.json`);
+  await fs.writeFile(cachePath, JSON.stringify(findings, null, 2));
+
+  const counters = { pass: 0, fail: 0, inconclusive: 0, not_applicable: 0, skipped: 0 };
+  const severities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  const failingSeverities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const doc of findings) {
+    for (const ev of doc.evaluations) {
+      counters[ev.status] = (counters[ev.status] || 0) + 1;
+      if (ev.severity) severities[ev.severity] = (severities[ev.severity] || 0) + 1;
+      if (ev.status === 'fail' && ev.severity) failingSeverities[ev.severity] = (failingSeverities[ev.severity] || 0) + 1;
+    }
+  }
+
+  const manifest = {
+    source: SOURCE,
+    run_id: runId,
+    started_at: new Date(startedAt).toISOString(),
+    duration_ms: Date.now() - startedAt,
+    scope: team.id,
+    resources: findings.length,
+    evaluations: findings.reduce((n, d) => n + d.evaluations.length, 0),
+    counters,
+    severities,
+    failing_severities: failingSeverities,
+    errors: errors.length
+  };
+  await fs.appendFile(RUNS_LOG, JSON.stringify(manifest) + '\n');
+
+  const summary = `${SOURCE}: ${findings.length} resources, ${manifest.evaluations} evaluations, ${counters.fail || 0} failing (${failingSeverities.high || 0} high, ${failingSeverities.medium || 0} medium, ${failingSeverities.low || 0} low).`;
+  if (args.output === 'json') process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, summary: manifest }, null, 2) + '\n');
+  else if (args.output !== 'silent') process.stdout.write(summary + '\n');
+
+  process.exit(errors.length ? EXIT.PARTIAL : EXIT.OK);
+}
+
+function parseArgs(argv) {
+  const out = { output: 'summary', quiet: false };
+  for (const tok of argv) {
+    if (!tok.startsWith('--')) continue;
+    const [k, v] = tok.slice(2).split('=');
+    switch (k) {
+      case 'output':
+        if (!['summary', 'json', 'silent'].includes(v)) fail(EXIT.USAGE, `Unknown output mode: ${v}`);
+        out.output = v;
+        break;
+      case 'quiet':
+        out.quiet = true;
+        break;
+      default:
+        fail(EXIT.USAGE, `Unknown flag: --${k}`);
+    }
+  }
+  return out;
+}
+
+async function getToken() {
+  if (process.env.SLACK_TOKEN) return process.env.SLACK_TOKEN;
+  try {
+    return (await fs.readFile(TOKEN_FILE, 'utf8')).trim();
+  } catch {
+    return '';
+  }
+}
+
+async function slack(method, params, token) {
+  const url = new URL(`https://slack.com/api/${method}`);
+  for (const [key, value] of Object.entries(params || {})) {
+    if (value !== undefined && value !== null && value !== '') url.searchParams.set(key, String(value));
+  }
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' }
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || !body.ok) {
+    const err = new Error(body.error || `http_${response.status}`);
+    err.body = body;
+    throw err;
+  }
+  return body;
+}
+
+async function adminProbe(method, params, token) {
+  try {
+    const raw = await slack(method, params, token);
+    return { ok: true, raw, error: null };
+  } catch (err) {
+    return { ok: false, raw: err.body || null, error: err.message };
+  }
+}
+
+function pass(controlId, message) {
+  return { control_framework: 'SCF', control_id: controlId, status: 'pass', severity: 'info', message };
+}
+
+function inconclusive(controlId, message) {
+  return { control_framework: 'SCF', control_id: controlId, status: 'inconclusive', severity: 'info', message };
+}
+
+function failHigh(controlId, message, summary) {
+  return {
+    control_framework: 'SCF',
+    control_id: controlId,
+    status: 'fail',
+    severity: 'high',
+    message,
+    remediation: {
+      summary,
+      ref: 'grc-engineer://generate-implementation/slack_workspace_security',
+      effort_hours: 1,
+      automation: 'manual'
+    }
+  };
+}
+
+function scrubAuth(auth) {
+  return {
+    team: auth.team,
+    team_id: auth.team_id,
+    url: auth.url,
+    user_id: auth.user_id,
+    bot_id: auth.bot_id,
+    enterprise_id: auth.enterprise_id
+  };
+}
+
+function parseYaml(text) {
+  const out = {};
+  const stack = [out];
+  const indents = [0];
+  for (const rawLine of text.split(/\r?\n/)) {
+    if (!rawLine.trim() || rawLine.trim().startsWith('#')) continue;
+    const indent = rawLine.match(/^\s*/)[0].length;
+    const line = rawLine.trim();
+    while (indent < indents[indents.length - 1]) { stack.pop(); indents.pop(); }
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    if (rawValue === '') {
+      const child = {};
+      stack[stack.length - 1][key] = child;
+      stack.push(child);
+      indents.push(indent + 2);
+    } else {
+      stack[stack.length - 1][key] = parseYamlValue(rawValue);
+    }
+  }
+  return out;
+}
+
+function parseYamlValue(raw) {
+  const v = raw.trim();
+  if (v.startsWith('"') && v.endsWith('"')) return v.slice(1, -1);
+  if (v.startsWith('[') && v.endsWith(']')) {
+    return v.slice(1, -1).split(',').map(s => s.trim().replace(/^"|"$/g, '')).filter(Boolean);
+  }
+  if (/^\d+$/.test(v)) return Number(v);
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  return v;
+}
+
+function makeRunId() {
+  return `${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function fail(code, msg) {
+  process.stderr.write(`[${SOURCE}] ${msg}\n`);
+  process.exit(code);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2)).catch(err => {
+    process.stderr.write(`[${SOURCE}] unhandled error: ${err.stack || err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/plugins/connectors/slack-inspector/scripts/setup.sh
+++ b/plugins/connectors/slack-inspector/scripts/setup.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# slack-inspector:setup
+# Idempotent setup for the slack-inspector connector.
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors"
+CONFIG_FILE="$CONFIG_DIR/slack-inspector.yaml"
+SOURCE="slack-inspector"
+SOURCE_VERSION="0.1.0"
+
+TOKEN="${SLACK_TOKEN:-}"
+WORKSPACE=""
+for arg in "$@"; do
+  case "$arg" in
+    --token=*)     TOKEN="${arg#*=}" ;;
+    --workspace=*) WORKSPACE="${arg#*=}" ;;
+    *) echo "[$SOURCE:setup] unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TOKEN" ]]; then
+  cat >&2 <<'EOF'
+[slack-inspector:setup] Missing Slack OAuth token.
+
+Pass --token=xoxb-... or set SLACK_TOKEN. Recommended scopes include:
+  team:read users:read admin.users.info:read admin.apps:read admin.conversations:read discovery:read
+EOF
+  exit 2
+fi
+
+AUTH_JSON=$(node - "$TOKEN" <<'NODE'
+const token = process.argv[2];
+const body = await fetch('https://slack.com/api/auth.test', {
+  headers: { Authorization: `Bearer ${token}` }
+}).then(r => r.json()).catch(err => ({ ok: false, error: err.message }));
+console.log(JSON.stringify(body));
+NODE
+)
+
+OK=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.ok ? 'yes' : 'no')" "$AUTH_JSON")
+if [[ "$OK" != "yes" ]]; then
+  ERR=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.error || 'unknown_error')" "$AUTH_JSON")
+  echo "[$SOURCE:setup] Slack auth.test failed: $ERR" >&2
+  exit 2
+fi
+
+TEAM_ID=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.team_id || '')" "$AUTH_JSON")
+TEAM_NAME=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.team || '')" "$AUTH_JSON")
+USER_ID=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.user_id || '')" "$AUTH_JSON")
+if [[ -z "$WORKSPACE" ]]; then WORKSPACE="$TEAM_NAME"; fi
+
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_FILE" <<EOF
+version: 1
+source: $SOURCE
+source_version: "$SOURCE_VERSION"
+team_id: "$TEAM_ID"
+team_name: "$TEAM_NAME"
+workspace: "$WORKSPACE"
+token_env: "SLACK_TOKEN"
+defaults:
+  checks: ["auth", "retention", "apps", "dlp"]
+EOF
+
+CRED_FILE="$CONFIG_DIR/slack-inspector.token"
+umask 077
+printf '%s\n' "$TOKEN" > "$CRED_FILE"
+
+CACHE_DIR="$HOME/.cache/claude-grc/findings/slack-inspector"
+mkdir -p "$CACHE_DIR"
+touch "$HOME/.cache/claude-grc/runs.log"
+
+cat <<EOF
+slack-inspector:setup ok
+  team:        $TEAM_NAME ($TEAM_ID)
+  principal:   $USER_ID
+  config:      $CONFIG_FILE
+  token file:  $CRED_FILE
+
+Next:
+  /slack-inspector:collect
+  /grc-engineer:gap-assessment SOC2,NIST-800-53 --sources=slack-inspector
+EOF

--- a/plugins/connectors/slack-inspector/scripts/status.sh
+++ b/plugins/connectors/slack-inspector/scripts/status.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# slack-inspector:status
+set -uo pipefail
+
+CONFIG_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors/slack-inspector.yaml"
+TOKEN_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors/slack-inspector.token"
+CACHE_DIR="$HOME/.cache/claude-grc/findings/slack-inspector"
+
+printf 'slack-inspector\n'
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  printf '  status:        not-configured\n'
+  printf '  fix:           run /slack-inspector:setup\n'
+  exit 2
+fi
+
+TOKEN="${SLACK_TOKEN:-}"
+if [[ -z "$TOKEN" && -f "$TOKEN_FILE" ]]; then TOKEN=$(cat "$TOKEN_FILE"); fi
+if [[ -z "$TOKEN" ]]; then
+  printf '  status:        credentials-expired\n'
+  printf '  fix:           set SLACK_TOKEN or re-run /slack-inspector:setup\n'
+  exit 2
+fi
+
+AUTH_JSON=$(node - "$TOKEN" <<'NODE'
+const token = process.argv[2];
+const body = await fetch('https://slack.com/api/auth.test', {
+  headers: { Authorization: `Bearer ${token}` }
+}).then(r => r.json()).catch(err => ({ ok: false, error: err.message }));
+console.log(JSON.stringify(body));
+NODE
+)
+
+OK=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.ok ? 'yes' : 'no')" "$AUTH_JSON")
+if [[ "$OK" != "yes" ]]; then
+  ERR=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.error || 'unknown_error')" "$AUTH_JSON")
+  printf '  status:        credentials-expired\n'
+  printf '  slack error:   %s\n' "$ERR"
+  exit 2
+fi
+
+TEAM_ID=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.team_id || '')" "$AUTH_JSON")
+TEAM_NAME=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.team || '')" "$AUTH_JSON")
+USER_ID=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.user_id || '')" "$AUTH_JSON")
+
+LATEST=$(ls -t "$CACHE_DIR"/*.json 2>/dev/null | head -1 || true)
+if [[ -z "$LATEST" ]]; then
+  printf '  status:        ready\n'
+  printf '  team:          %s (%s)\n' "$TEAM_NAME" "$TEAM_ID"
+  printf '  principal:     %s\n' "$USER_ID"
+  printf '  config:        %s\n' "$CONFIG_FILE"
+  printf '  last run:      never\n'
+  exit 0
+fi
+
+if stat -f%m "$LATEST" >/dev/null 2>&1; then MTIME=$(stat -f%m "$LATEST"); else MTIME=$(stat -c%Y "$LATEST"); fi
+AGE=$(( $(date +%s) - MTIME ))
+AGE_H=$(( AGE / 3600 ))
+if (( AGE_H < 24 )); then LABEL="${AGE_H}h ago"; STATUS="ready"
+elif (( AGE_H < 168 )); then LABEL="$((AGE_H/24))d ago"; STATUS="ready"
+else LABEL="$((AGE_H/24))d ago"; STATUS="stale"
+fi
+
+RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
+EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}" "$LATEST")
+
+printf '  status:        %s\n' "$STATUS"
+printf '  team:          %s (%s)\n' "$TEAM_NAME" "$TEAM_ID"
+printf '  principal:     %s\n' "$USER_ID"
+printf '  config:        %s\n' "$CONFIG_FILE"
+printf '  last run:      %s (%s)\n' "$LABEL" "$(basename "$LATEST" .json)"
+printf '  cached:        %s resources, %s evaluations\n' "$RES" "$EVS"

--- a/plugins/connectors/slack-inspector/skills/slack-inspector-expert/SKILL.md
+++ b/plugins/connectors/slack-inspector/skills/slack-inspector-expert/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: slack-inspector-expert
+description: Interpret slack-inspector findings, explain Slack API coverage limits, and turn Slack workspace posture results into control evidence or remediation.
+license: MIT
+---
+
+# Slack Inspector Expert
+
+Use this skill when reviewing output from `slack-inspector` or planning remediation for Slack workspace security.
+
+## Output Shape
+
+`slack-inspector` writes Finding schema v1 documents to:
+
+```text
+~/.cache/claude-grc/findings/slack-inspector/<run_id>.json
+```
+
+Each run emits a workspace-level `slack_workspace` resource with SCF evaluations for:
+
+- `IAC-02`: MFA / 2FA evidence
+- `IAC-04`: SSO and session-duration evidence
+- `DCH-07`: message and file retention visibility
+- `TPM-03`: app approval workflow visibility
+- `DLP-01`: DLP or discovery visibility
+- `GOV-03`: workspace metadata inventory
+
+## Coverage Limits
+
+Slack exposes many workspace governance controls only through Enterprise Grid or admin-scoped APIs. Treat `inconclusive` as a coverage signal, not as a pass:
+
+- `missing_scope`, `not_allowed_token_type`, or `not_authed`: request an admin-approved token with the listed scope.
+- `feature_not_enabled` or `enterprise_required`: verify manually in Slack Enterprise Admin settings or document plan limitations.
+- `channel_not_found` on retention checks: configure a representative channel for retention policy sampling.
+
+## Review Guidance
+
+- Prefer SCF control IDs already present in the finding.
+- Do not claim Slack-wide 2FA, SSO, retention, app approvals, or DLP are compliant from a bot-token-only run.
+- For audit evidence, pair collector output with Slack admin screenshots or exported policy records when the API returns inconclusive.
+
+## Remediation Patterns
+
+- Require 2FA for all users, especially workspace owners and admins.
+- Enforce SSO and appropriate session duration through Enterprise settings.
+- Enable app approval workflows and periodically review approved applications.
+- Define retention rules for messages and files according to legal and compliance requirements.
+- Enable DLP or discovery integrations where regulated data may appear in Slack.

--- a/tests/fixtures/findings/slack-inspector/001-workspace-inventory-pass.json
+++ b/tests/fixtures/findings/slack-inspector/001-workspace-inventory-pass.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "slack-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-slack-pass",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "slack_workspace",
+    "id": "T0123456789",
+    "uri": "https://example.slack.com/",
+    "region": null,
+    "account_id": "T0123456789"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "GOV-03",
+      "status": "pass",
+      "severity": "info",
+      "message": "Slack workspace metadata is readable for this connector run."
+    }
+  ]
+}

--- a/tests/fixtures/findings/slack-inspector/002-principal-2fa-fail.json
+++ b/tests/fixtures/findings/slack-inspector/002-principal-2fa-fail.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "source": "slack-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-slack-fail",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "slack_workspace",
+    "id": "T0123456789",
+    "uri": "https://example.slack.com/",
+    "region": null,
+    "account_id": "T0123456789"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "IAC-02",
+      "status": "fail",
+      "severity": "high",
+      "message": "The inspected Slack principal does not have 2FA enabled.",
+      "remediation": {
+        "summary": "Require 2FA for Slack users and administrators.",
+        "ref": "grc-engineer://generate-implementation/slack_workspace_security",
+        "effort_hours": 1,
+        "automation": "manual"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/findings/slack-inspector/003-retention-inconclusive.json
+++ b/tests/fixtures/findings/slack-inspector/003-retention-inconclusive.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "slack-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-slack-inconclusive",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "slack_workspace",
+    "id": "T0123456789",
+    "uri": "https://example.slack.com/",
+    "region": null,
+    "account_id": "T0123456789"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "DCH-07",
+      "status": "inconclusive",
+      "severity": "info",
+      "message": "Slack retention policy requires admin or channel-specific visibility: missing_scope."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #29.\n\n## Summary\n- Adds the slack-inspector Tier-2 connector scaffold, commands, setup/status scripts, and Node collector.\n- Emits Slack workspace security posture findings for 2FA, SSO/session visibility, retention, app approvals, DLP/discovery, and workspace inventory.\n- Registers the connector in the marketplace and adds three contract fixtures covering pass, fail/high, and inconclusive cases.\n\n## Validation\n- git diff --check\n- node --check plugins/connectors/slack-inspector/scripts/collect.js\n- bash -n plugins/connectors/slack-inspector/scripts/setup.sh plugins/connectors/slack-inspector/scripts/status.sh\n- npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh\n- npm run test:contract