### PR TITLE
[codex] Add Datadog inspector connector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -209,6 +209,12 @@
       "version": "0.1.0"
     },
     {
+      "name": "datadog-inspector",
+      "source": "./plugins/connectors/datadog-inspector",
+      "description": "GRC connector for Datadog: log retention, audit logs, monitor coverage, SSO, and RBAC to v1 finding contract",
+      "version": "0.1.0"
+    },
+    {
       "name": "okta-inspector",
       "source": "./plugins/connectors/okta-inspector",
       "description": "GRC connector for Okta: password/MFA/session policies, inactive users, admin factor enrollment \u2192 v1 finding contract",

--- a/plugins/connectors/datadog-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/datadog-inspector/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "datadog-inspector",
+  "version": "0.1.0",
+  "description": "GRC connector for Datadog: evaluates log retention, audit log coverage, monitor coverage, SSO visibility, and RBAC roles. Emits findings conforming to schemas/finding.schema.json v1.",
+  "author": { "name": "GRC Engineering Club Contributors" },
+  "license": "MIT",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "keywords": ["grc", "compliance", "datadog", "monitoring", "logs", "scf", "connector"]
+}

--- a/plugins/connectors/datadog-inspector/commands/collect.md
+++ b/plugins/connectors/datadog-inspector/commands/collect.md
@@ -1,0 +1,27 @@
+# /datadog-inspector:collect
+
+Collect Datadog organization posture and write Finding documents to:
+
+```text
+~/.cache/claude-grc/findings/datadog-inspector/<run_id>.json
+```
+
+The collector appends a run manifest to:
+
+```text
+~/.cache/claude-grc/runs.log
+```
+
+## Coverage
+
+- Log index retention and audit log visibility
+- Monitor coverage for critical resources
+- SSO enforcement visibility
+- RBAC role inventory visibility
+
+Unavailable API surfaces are emitted as `inconclusive` evaluations instead of silently passing.
+
+## Options
+
+- `--output=summary|json|silent` controls stdout. Default: `summary`; `silent` suppresses stdout summary.
+- `--quiet` suppresses progress logs on stderr.

--- a/plugins/connectors/datadog-inspector/commands/setup.md
+++ b/plugins/connectors/datadog-inspector/commands/setup.md
@@ -1,0 +1,32 @@
+# /datadog-inspector:setup
+
+Configure `datadog-inspector` with a Datadog API key and application key.
+
+```bash
+plugins/connectors/datadog-inspector/scripts/setup.sh --api-key=<key> --app-key=<key>
+```
+
+The setup command validates credentials against the Datadog API and writes:
+
+```text
+~/.config/claude-grc/connectors/datadog-inspector.yaml
+```
+
+Secrets are stored separately with user-only file permissions at:
+
+```text
+~/.config/claude-grc/connectors/datadog-inspector.env
+```
+
+## Options
+
+- `--api-key=<key>` or `DD_API_KEY`
+- `--app-key=<key>` or `DD_APP_KEY`
+- `--site=<site>` defaults to `datadoghq.com`
+
+## Next
+
+```text
+/datadog-inspector:collect
+/datadog-inspector:status
+```

--- a/plugins/connectors/datadog-inspector/commands/status.md
+++ b/plugins/connectors/datadog-inspector/commands/status.md
@@ -1,0 +1,9 @@
+# /datadog-inspector:status
+
+Show whether Datadog credentials are configured, whether they validate, and whether cached findings are fresh.
+
+```bash
+plugins/connectors/datadog-inspector/scripts/status.sh
+```
+
+A cache older than seven days is reported as `stale`.

--- a/plugins/connectors/datadog-inspector/scripts/collect.js
+++ b/plugins/connectors/datadog-inspector/scripts/collect.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+
+const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'connectors', 'datadog-inspector.yaml');
+const ENV_FILE = path.join(CONFIG_DIR, 'connectors', 'datadog-inspector.env');
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'datadog-inspector');
+const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
+const SOURCE = 'datadog-inspector';
+const SOURCE_VERSION = '0.1.0';
+const EXIT = { OK: 0, USAGE: 2, AUTH: 2, NOT_CONFIGURED: 5 };
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  const log = args.quiet ? () => {} : (m) => process.stderr.write(`[${SOURCE}] ${m}\n`);
+  let config;
+  try {
+    config = parseYaml(await fs.readFile(CONFIG_FILE, 'utf8'));
+  } catch {
+    fail(EXIT.NOT_CONFIGURED, `config missing (${CONFIG_FILE}). Run /datadog-inspector:setup first.`);
+  }
+
+  const env = await loadEnv();
+  const apiKey = process.env.DD_API_KEY || env.DD_API_KEY;
+  const appKey = process.env.DD_APP_KEY || env.DD_APP_KEY;
+  const site = config.site || 'datadoghq.com';
+  if (!apiKey || !appKey) fail(EXIT.AUTH, 'missing Datadog API/app key. Set DD_API_KEY/DD_APP_KEY or run setup.');
+
+  const startedAt = Date.now();
+  const runId = makeRunId();
+  const evaluations = [];
+  const raw = {};
+
+  try {
+    raw.validate = await dd('/api/v1/validate', { apiKey, appKey, site });
+    if (raw.validate.valid) evaluations.push(pass('GOV-03', 'Datadog API and application keys validated for organization inventory.'));
+    else fail(EXIT.AUTH, 'Datadog credential validation returned invalid.');
+  } catch (err) {
+    fail(EXIT.AUTH, `Datadog credential validation failed: ${err.message}`);
+  }
+
+  const logs = await probe('/api/v1/logs/config/indexes', { apiKey, appKey, site });
+  raw.logs = logs.raw;
+  if (logs.ok) {
+    const indexes = logs.raw?.indexes || [];
+    const missingRetention = indexes.filter(i => !i.retention_days || i.retention_days < 7);
+    if (indexes.length === 0) evaluations.push(inconclusive('DCH-07', 'Datadog log indexes API returned no indexes; verify logging scope manually.'));
+    else if (missingRetention.length) evaluations.push(failHigh('DCH-07', `${missingRetention.length} Datadog log index(es) have less than 7 days of retention or no retention value.`, 'Set retention on Datadog log indexes according to compliance and incident-response requirements.'));
+    else evaluations.push(pass('DCH-07', 'Datadog log indexes expose retention of at least 7 days.'));
+  } else {
+    evaluations.push(inconclusive('DCH-07', `Datadog log index retention could not be evaluated: ${logs.error}`));
+  }
+
+  const monitors = await probe('/api/v1/monitor', { apiKey, appKey, site });
+  raw.monitors = monitors.raw;
+  if (monitors.ok) {
+    const list = Array.isArray(monitors.raw) ? monitors.raw : [];
+    const critical = list.filter(m => String(m.priority || '').toLowerCase() === 'p1' || String(m.name || '').match(/critical|prod|production/i));
+    if (critical.length) evaluations.push(pass('MON-01.2', `Datadog monitor inventory includes ${critical.length} critical or production monitor(s).`));
+    else evaluations.push(failHigh('MON-01.2', 'No critical or production Datadog monitors were detected.', 'Define monitors for critical services and resources, with severity and routing aligned to incident response.'));
+  } else {
+    evaluations.push(inconclusive('MON-01.2', `Datadog monitor coverage could not be evaluated: ${monitors.error}`));
+  }
+
+  const audit = await probe('/api/v2/audit/events?filter[from]=now-1d&page[limit]=1', { apiKey, appKey, site });
+  raw.audit = audit.raw;
+  if (audit.ok) evaluations.push(pass('LOG-08', 'Datadog audit events API is available for review.'));
+  else evaluations.push(inconclusive('LOG-08', `Datadog audit log coverage could not be evaluated: ${audit.error}`));
+
+  const roles = await probe('/api/v2/roles?page[size]=10', { apiKey, appKey, site });
+  raw.roles = roles.raw;
+  if (roles.ok) evaluations.push(pass('IAC-07', 'Datadog RBAC role inventory is available for review.'));
+  else evaluations.push(inconclusive('IAC-07', `Datadog RBAC roles could not be evaluated: ${roles.error}`));
+
+  const authn = await probe('/api/v2/saml_configurations', { apiKey, appKey, site });
+  raw.sso = authn.raw;
+  if (authn.ok) evaluations.push(pass('IAC-04', 'Datadog SAML/SSO configuration endpoint is available for review.'));
+  else evaluations.push(inconclusive('IAC-04', `Datadog SSO enforcement could not be evaluated from available API permissions: ${authn.error}`));
+
+  const findings = [{
+    schema_version: '1.0.0',
+    source: SOURCE,
+    source_version: SOURCE_VERSION,
+    run_id: runId,
+    collected_at: new Date().toISOString(),
+    resource: {
+      type: 'datadog_organization',
+      id: site,
+      uri: `https://app.${site}/`,
+      region: null,
+      account_id: site
+    },
+    evaluations,
+    raw_attributes: raw,
+    metadata: { site, partial_coverage: evaluations.some(e => e.status === 'inconclusive') }
+  }];
+
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  const cachePath = path.join(CACHE_DIR, `${runId}.json`);
+  await fs.writeFile(cachePath, JSON.stringify(findings, null, 2));
+
+  const counters = { pass: 0, fail: 0, inconclusive: 0, not_applicable: 0, skipped: 0 };
+  const severities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  const failingSeverities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const ev of evaluations) {
+    counters[ev.status] = (counters[ev.status] || 0) + 1;
+    if (ev.severity) severities[ev.severity] = (severities[ev.severity] || 0) + 1;
+    if (ev.status === 'fail' && ev.severity) failingSeverities[ev.severity] = (failingSeverities[ev.severity] || 0) + 1;
+  }
+
+  const manifest = {
+    source: SOURCE,
+    run_id: runId,
+    started_at: new Date(startedAt).toISOString(),
+    duration_ms: Date.now() - startedAt,
+    scope: site,
+    resources: findings.length,
+    evaluations: evaluations.length,
+    counters,
+    severities,
+    failing_severities: failingSeverities,
+    errors: evaluations.filter(e => e.status === 'inconclusive').length
+  };
+  await fs.appendFile(RUNS_LOG, JSON.stringify(manifest) + '\n');
+
+  const summary = `${SOURCE}: ${findings.length} resources, ${evaluations.length} evaluations, ${counters.fail || 0} failing (${failingSeverities.high || 0} high).`;
+  if (args.output === 'json') process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, summary: manifest }, null, 2) + '\n');
+  else if (args.output !== 'silent') process.stdout.write(summary + '\n');
+}
+
+function parseArgs(argv) {
+  const out = { output: 'summary', quiet: false };
+  for (const tok of argv) {
+    if (!tok.startsWith('--')) continue;
+    const [k, v] = tok.slice(2).split('=');
+    if (k === 'quiet') out.quiet = true;
+    else if (k === 'output' && ['summary', 'json', 'silent'].includes(v)) out.output = v;
+    else fail(EXIT.USAGE, `Unknown flag: --${k}`);
+  }
+  return out;
+}
+
+async function dd(endpoint, { apiKey, appKey, site }) {
+  const response = await fetch(`https://api.${site}${endpoint}`, {
+    headers: { 'DD-API-KEY': apiKey, 'DD-APPLICATION-KEY': appKey, Accept: 'application/json' }
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(body.errors?.join('; ') || body.error || `http_${response.status}`);
+  return body;
+}
+
+async function probe(endpoint, opts) {
+  try {
+    return { ok: true, raw: await dd(endpoint, opts), error: null };
+  } catch (err) {
+    return { ok: false, raw: null, error: err.message };
+  }
+}
+
+async function loadEnv() {
+  try {
+    const text = await fs.readFile(ENV_FILE, 'utf8');
+    const out = {};
+    for (const line of text.split(/\r?\n/)) {
+      const m = line.match(/^([A-Z0-9_]+)="?(.*?)"?$/);
+      if (m) out[m[1]] = m[2];
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function pass(controlId, message) {
+  return { control_framework: 'SCF', control_id: controlId, status: 'pass', severity: 'info', message };
+}
+
+function inconclusive(controlId, message) {
+  return { control_framework: 'SCF', control_id: controlId, status: 'inconclusive', severity: 'info', message };
+}
+
+function failHigh(controlId, message, summary) {
+  return {
+    control_framework: 'SCF',
+    control_id: controlId,
+    status: 'fail',
+    severity: 'high',
+    message,
+    remediation: {
+      summary,
+      ref: 'grc-engineer://generate-implementation/datadog_monitoring',
+      effort_hours: 1,
+      automation: 'manual'
+    }
+  };
+}
+
+function parseYaml(text) {
+  const out = {};
+  const stack = [out];
+  const indents = [0];
+  for (const rawLine of text.split(/\r?\n/)) {
+    if (!rawLine.trim() || rawLine.trim().startsWith('#')) continue;
+    const indent = rawLine.match(/^\s*/)[0].length;
+    const line = rawLine.trim();
+    while (indent < indents[indents.length - 1]) { stack.pop(); indents.pop(); }
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    if (rawValue === '') {
+      const child = {};
+      stack[stack.length - 1][key] = child;
+      stack.push(child);
+      indents.push(indent + 2);
+    } else {
+      stack[stack.length - 1][key] = parseYamlValue(rawValue);
+    }
+  }
+  return out;
+}
+
+function parseYamlValue(raw) {
+  const v = raw.trim();
+  if (v.startsWith('"') && v.endsWith('"')) return v.slice(1, -1);
+  if (v.startsWith('[') && v.endsWith(']')) return v.slice(1, -1).split(',').map(s => s.trim().replace(/^"|"$/g, '')).filter(Boolean);
+  return v;
+}
+
+function makeRunId() {
+  return `${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function fail(code, msg) {
+  process.stderr.write(`[${SOURCE}] ${msg}\n`);
+  process.exit(code);
+}
+
+main(process.argv.slice(2)).catch(err => {
+  process.stderr.write(`[${SOURCE}] unhandled error: ${err.stack || err.message}\n`);
+  process.exit(1);
+});

--- a/plugins/connectors/datadog-inspector/scripts/setup.sh
+++ b/plugins/connectors/datadog-inspector/scripts/setup.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# datadog-inspector:setup
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors"
+CONFIG_FILE="$CONFIG_DIR/datadog-inspector.yaml"
+ENV_FILE="$CONFIG_DIR/datadog-inspector.env"
+SOURCE="datadog-inspector"
+SOURCE_VERSION="0.1.0"
+
+API_KEY="${DD_API_KEY:-}"
+APP_KEY="${DD_APP_KEY:-}"
+SITE="datadoghq.com"
+
+for arg in "$@"; do
+  case "$arg" in
+    --api-key=*) API_KEY="${arg#*=}" ;;
+    --app-key=*) APP_KEY="${arg#*=}" ;;
+    --site=*)    SITE="${arg#*=}" ;;
+    *) echo "[$SOURCE:setup] unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$API_KEY" || -z "$APP_KEY" ]]; then
+  echo "[$SOURCE:setup] missing --api-key/--app-key or DD_API_KEY/DD_APP_KEY." >&2
+  exit 2
+fi
+
+VALIDATE_JSON=$(node - "$API_KEY" "$APP_KEY" "$SITE" <<'NODE'
+const [apiKey, appKey, site] = process.argv.slice(2);
+const url = `https://api.${site}/api/v1/validate`;
+const body = await fetch(url, {
+  headers: { 'DD-API-KEY': apiKey, 'DD-APPLICATION-KEY': appKey, Accept: 'application/json' }
+}).then(r => r.json().then(j => ({ status: r.status, body: j }))).catch(err => ({ status: 0, body: { valid: false, error: err.message } }));
+console.log(JSON.stringify(body));
+NODE
+)
+
+VALID=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.body?.valid ? 'yes' : 'no')" "$VALIDATE_JSON")
+if [[ "$VALID" != "yes" ]]; then
+  ERR=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.body?.errors?.join('; ') || d.body?.error || ('http_' + d.status))" "$VALIDATE_JSON")
+  echo "[$SOURCE:setup] Datadog credential validation failed: $ERR" >&2
+  exit 2
+fi
+
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_FILE" <<EOF
+version: 1
+source: $SOURCE
+source_version: "$SOURCE_VERSION"
+site: "$SITE"
+defaults:
+  checks: ["logs", "audit", "monitors", "sso", "rbac"]
+EOF
+
+umask 077
+cat > "$ENV_FILE" <<EOF
+DD_API_KEY="$API_KEY"
+DD_APP_KEY="$APP_KEY"
+EOF
+
+CACHE_DIR="$HOME/.cache/claude-grc/findings/datadog-inspector"
+mkdir -p "$CACHE_DIR"
+touch "$HOME/.cache/claude-grc/runs.log"
+
+cat <<EOF
+datadog-inspector:setup ok
+  site:      $SITE
+  config:    $CONFIG_FILE
+  secrets:   $ENV_FILE
+
+Next:
+  /datadog-inspector:collect
+EOF

--- a/plugins/connectors/datadog-inspector/scripts/status.sh
+++ b/plugins/connectors/datadog-inspector/scripts/status.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# datadog-inspector:status
+set -uo pipefail
+
+CONFIG_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors/datadog-inspector.yaml"
+ENV_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors/datadog-inspector.env"
+CACHE_DIR="$HOME/.cache/claude-grc/findings/datadog-inspector"
+
+printf 'datadog-inspector\n'
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  printf '  status:        not-configured\n'
+  printf '  fix:           run /datadog-inspector:setup\n'
+  exit 2
+fi
+
+SITE=$(awk -F'"' '/^site:/ {print $2; exit}' "$CONFIG_FILE")
+[[ -z "$SITE" ]] && SITE="datadoghq.com"
+
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+if [[ -z "${DD_API_KEY:-}" || -z "${DD_APP_KEY:-}" ]]; then
+  printf '  status:        credentials-expired\n'
+  printf '  fix:           set DD_API_KEY/DD_APP_KEY or re-run /datadog-inspector:setup\n'
+  exit 2
+fi
+
+VALIDATE_JSON=$(node - "$DD_API_KEY" "$DD_APP_KEY" "$SITE" <<'NODE'
+const [apiKey, appKey, site] = process.argv.slice(2);
+const body = await fetch(`https://api.${site}/api/v1/validate`, {
+  headers: { 'DD-API-KEY': apiKey, 'DD-APPLICATION-KEY': appKey, Accept: 'application/json' }
+}).then(r => r.json().then(j => ({ status: r.status, body: j }))).catch(err => ({ status: 0, body: { valid: false, error: err.message } }));
+console.log(JSON.stringify(body));
+NODE
+)
+
+VALID=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.body?.valid ? 'yes' : 'no')" "$VALIDATE_JSON")
+if [[ "$VALID" != "yes" ]]; then
+  printf '  status:        credentials-expired\n'
+  exit 2
+fi
+
+LATEST=$(ls -t "$CACHE_DIR"/*.json 2>/dev/null | head -1 || true)
+if [[ -z "$LATEST" ]]; then
+  printf '  status:        ready\n'
+  printf '  site:          %s\n' "$SITE"
+  printf '  config:        %s\n' "$CONFIG_FILE"
+  printf '  last run:      never\n'
+  exit 0
+fi
+
+if stat -f%m "$LATEST" >/dev/null 2>&1; then MTIME=$(stat -f%m "$LATEST"); else MTIME=$(stat -c%Y "$LATEST"); fi
+AGE=$(( $(date +%s) - MTIME ))
+AGE_H=$(( AGE / 3600 ))
+if (( AGE_H < 24 )); then LABEL="${AGE_H}h ago"; STATUS="ready"
+elif (( AGE_H < 168 )); then LABEL="$((AGE_H/24))d ago"; STATUS="ready"
+else LABEL="$((AGE_H/24))d ago"; STATUS="stale"
+fi
+
+RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
+EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}" "$LATEST")
+
+printf '  status:        %s\n' "$STATUS"
+printf '  site:          %s\n' "$SITE"
+printf '  config:        %s\n' "$CONFIG_FILE"
+printf '  last run:      %s (%s)\n' "$LABEL" "$(basename "$LATEST" .json)"
+printf '  cached:        %s resources, %s evaluations\n' "$RES" "$EVS"

--- a/plugins/connectors/datadog-inspector/skills/datadog-inspector-expert/SKILL.md
+++ b/plugins/connectors/datadog-inspector/skills/datadog-inspector-expert/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: datadog-inspector-expert
+description: Interpret datadog-inspector findings and translate Datadog monitoring, audit, log-retention, SSO, and RBAC results into GRC evidence and remediation.
+license: MIT
+---
+
+# Datadog Inspector Expert
+
+Use this skill when reviewing `datadog-inspector` output or planning Datadog control remediation.
+
+## Output Shape
+
+Findings are written to:
+
+```text
+~/.cache/claude-grc/findings/datadog-inspector/<run_id>.json
+```
+
+The connector emits a `datadog_organization` resource with SCF evaluations for:
+
+- `DCH-07`: log retention
+- `LOG-08`: audit log availability
+- `MON-01.2`: critical monitor coverage
+- `IAC-04`: SSO enforcement visibility
+- `IAC-07`: RBAC role inventory visibility
+- `GOV-03`: organization/API inventory
+
+## Review Guidance
+
+- Treat `inconclusive` as a permission or plan-coverage gap, not a pass.
+- Confirm monitor coverage against the user's actual critical service inventory; the collector can only infer criticality from Datadog monitor metadata.
+- Pair API output with Datadog org settings screenshots when SSO or audit APIs are unavailable.
+
+## Remediation Patterns
+
+- Set log index retention according to incident-response and regulatory requirements.
+- Ensure audit events are retained and exportable to long-term evidence storage.
+- Create monitors for production services and route critical alerts to incident response.
+- Enforce SSO and review local-user exceptions.
+- Review custom roles for least privilege.

--- a/tests/fixtures/findings/datadog-inspector/001-org-inventory-pass.json
+++ b/tests/fixtures/findings/datadog-inspector/001-org-inventory-pass.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "datadog-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-datadog-pass",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "datadog_organization",
+    "id": "datadoghq.com",
+    "uri": "https://app.datadoghq.com/",
+    "region": null,
+    "account_id": "datadoghq.com"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "GOV-03",
+      "status": "pass",
+      "severity": "info",
+      "message": "Datadog API and application keys validated for organization inventory."
+    }
+  ]
+}

--- a/tests/fixtures/findings/datadog-inspector/002-monitor-coverage-fail.json
+++ b/tests/fixtures/findings/datadog-inspector/002-monitor-coverage-fail.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "source": "datadog-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-datadog-fail",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "datadog_organization",
+    "id": "datadoghq.com",
+    "uri": "https://app.datadoghq.com/",
+    "region": null,
+    "account_id": "datadoghq.com"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "MON-01.2",
+      "status": "fail",
+      "severity": "high",
+      "message": "No critical or production Datadog monitors were detected.",
+      "remediation": {
+        "summary": "Define monitors for critical services and resources, with severity and routing aligned to incident response.",
+        "ref": "grc-engineer://generate-implementation/datadog_monitoring",
+        "effort_hours": 1,
+        "automation": "manual"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/findings/datadog-inspector/003-sso-inconclusive.json
+++ b/tests/fixtures/findings/datadog-inspector/003-sso-inconclusive.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "datadog-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-datadog-inconclusive",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "datadog_organization",
+    "id": "datadoghq.com",
+    "uri": "https://app.datadoghq.com/",
+    "region": null,
+    "account_id": "datadoghq.com"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "IAC-04",
+      "status": "inconclusive",
+      "severity": "info",
+      "message": "Datadog SSO enforcement could not be evaluated from available API permissions: Forbidden."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #30.\n\n## Summary\n- Adds the datadog-inspector Tier-2 connector scaffold, command docs, setup/status scripts, and Node collector.\n- Emits Datadog organization findings for log retention, audit events, critical monitor coverage, SSO visibility, RBAC roles, and inventory.\n- Registers the connector in the marketplace and adds pass, fail/high, and inconclusive fixtures.\n\n## Validation\n- git diff --check\n- node --check plugins/connectors/datadog-inspector/scripts/collect.js\n- bash -n plugins/connectors/datadog-inspector/scripts/setup.sh plugins/connectors/datadog-inspector/scripts/status.sh\n- npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh\n- npm run test:contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Datadog Inspector connector to assess organization posture across logging retention, monitoring coverage, SSO enforcement, and RBAC configurations.
  * Supports credential setup and posture data collection with comprehensive compliance evaluations.
  * Displays connector status including credential validation and cache freshness.

* **Documentation**
  * Added Datadog Inspector skill guide for interpreting posture findings and remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->