### PR TITLE
[codex] Add Drata inspector connector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -215,6 +215,12 @@
       "version": "0.1.0"
     },
     {
+      "name": "drata-inspector",
+      "source": "./plugins/connectors/drata-inspector",
+      "description": "GRC connector for Drata: wraps drata-cli workflows and normalizes compliance posture to v1 finding contract",
+      "version": "0.1.0"
+    },
+    {
       "name": "okta-inspector",
       "source": "./plugins/connectors/okta-inspector",
       "description": "GRC connector for Okta: password/MFA/session policies, inactive users, admin factor enrollment \u2192 v1 finding contract",

--- a/plugins/connectors/drata-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/drata-inspector/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "drata-inspector",
+  "version": "0.1.0",
+  "description": "GRC connector for Drata: wraps drata-cli curated workflows and normalizes compliance posture into schemas/finding.schema.json v1.",
+  "author": { "name": "GRC Engineering Club Contributors" },
+  "license": "MIT",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "keywords": ["grc", "compliance", "drata", "drata-cli", "scf", "connector"]
+}

--- a/plugins/connectors/drata-inspector/commands/collect.md
+++ b/plugins/connectors/drata-inspector/commands/collect.md
@@ -1,0 +1,36 @@
+# /drata-inspector:collect
+
+Run curated `drata-cli` workflows and write Finding documents to:
+
+```text
+~/.cache/claude-grc/findings/drata-inspector/<run_id>.json
+```
+
+The collector appends a run manifest to:
+
+```text
+~/.cache/claude-grc/runs.log
+```
+
+## Workflow Source
+
+This connector adapts `drata-cli` workflow commands:
+
+- `drata summary --json --compact`
+- `drata controls failing --json --compact`
+- `drata monitors failing --json --compact`
+- `drata connections list --json --compact`
+- `drata personnel issues --json --compact`
+- `drata evidence expiring --json --compact`
+
+## Options
+
+- `--output=summary|json|silent` controls stdout. Default: `summary`.
+- `--quiet` suppresses progress logs on stderr.
+- `--limit=<n>` passes a display cap through to workflow commands. Default: `50`.
+- `--max-pages=<n>` bounds Drata API pagination. Default: `20`.
+- `--evidence-days=<n>` marks evidence older than this as expiring/stale. Default: `60`.
+
+## Notes
+
+The connector prefers SCF IDs where there is a stable GRC meaning. Drata-native control codes are preserved in metadata and messages so downstream reviewers can trace findings back to Drata.

--- a/plugins/connectors/drata-inspector/commands/setup.md
+++ b/plugins/connectors/drata-inspector/commands/setup.md
@@ -1,0 +1,37 @@
+# /drata-inspector:setup
+
+Configure `drata-inspector`, a workflow wrapper over [`drata-cli`](https://github.com/ethanolivertroy/drata-cli).
+
+```bash
+plugins/connectors/drata-inspector/scripts/setup.sh
+```
+
+The setup command verifies that `drata` is available, checks read-only auth, and writes:
+
+```text
+~/.config/claude-grc/connectors/drata-inspector.yaml
+```
+
+## Auth
+
+`drata-inspector` uses `drata-cli` auth directly. Configure one of:
+
+- `drata auth login --api-key-stdin`
+- `DRATA_API_KEY`
+- `DRATA_API_KEY_CMD`
+- `DRATA_REGION=us|eu|apac`
+- `DRATA_BASE_URL`
+
+The connector runs Drata collection commands with `DRATA_READ_ONLY=1`.
+
+## Options
+
+- `--region=us|eu|apac` records the expected Drata region. Default: `DRATA_REGION` or `us`.
+- `--command=<path>` records a custom `drata` executable path.
+
+## Next
+
+```text
+/drata-inspector:collect
+/drata-inspector:status
+```

--- a/plugins/connectors/drata-inspector/commands/status.md
+++ b/plugins/connectors/drata-inspector/commands/status.md
@@ -1,0 +1,9 @@
+# /drata-inspector:status
+
+Show `drata-cli` availability, auth state, and latest cache freshness.
+
+```bash
+plugins/connectors/drata-inspector/scripts/status.sh
+```
+
+A cache older than seven days is reported as `stale`.

--- a/plugins/connectors/drata-inspector/scripts/collect.js
+++ b/plugins/connectors/drata-inspector/scripts/collect.js
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'connectors', 'drata-inspector.yaml');
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'drata-inspector');
+const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
+const SOURCE = 'drata-inspector';
+const SOURCE_VERSION = '0.1.0';
+const EXIT = { OK: 0, USAGE: 2, AUTH: 2, PARTIAL: 4, NOT_CONFIGURED: 5 };
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  const log = args.quiet ? () => {} : (m) => process.stderr.write(`[${SOURCE}] ${m}\n`);
+  let config;
+  try {
+    config = parseYaml(await fs.readFile(CONFIG_FILE, 'utf8'));
+  } catch {
+    fail(EXIT.NOT_CONFIGURED, `config missing (${CONFIG_FILE}). Run /drata-inspector:setup first.`);
+  }
+
+  const drata = config.drata_command || process.env.DRATA_CMD || 'drata';
+  const region = config.region || process.env.DRATA_REGION || 'us';
+  const limit = args.limit || config.defaults?.limit || 50;
+  const maxPages = args.maxPages || config.defaults?.max_pages || 20;
+  const evidenceDays = args.evidenceDays || config.defaults?.evidence_days || 60;
+  const env = { ...process.env, DRATA_READ_ONLY: '1', DRATA_REGION: region };
+
+  const startedAt = Date.now();
+  const runId = makeRunId();
+  const collectedAt = new Date().toISOString();
+  const errors = [];
+  const outputs = {};
+
+  const workflows = [
+    ['summary', ['summary', '--json', '--compact', '--limit', String(limit), '--max-pages', String(maxPages)]],
+    ['controls_failing', ['controls', 'failing', '--json', '--compact', '--limit', String(limit), '--max-pages', String(maxPages)]],
+    ['monitors_failing', ['monitors', 'failing', '--json', '--compact', '--limit', String(limit), '--max-pages', String(maxPages)]],
+    ['connections', ['connections', 'list', '--json', '--compact', '--limit', String(limit), '--max-pages', String(maxPages)]],
+    ['personnel', ['personnel', 'issues', '--json', '--compact', '--limit', String(limit), '--max-pages', String(maxPages)]],
+    ['evidence', ['evidence', 'expiring', '--json', '--compact', '--days', String(evidenceDays), '--limit', String(limit), '--max-pages', String(maxPages)]]
+  ];
+
+  for (const [name, commandArgs] of workflows) {
+    try {
+      log(`drata ${commandArgs.join(' ')}`);
+      outputs[name] = await runDrataJson(drata, commandArgs, env);
+    } catch (err) {
+      if (String(err.message).match(/Missing Drata API key|auth|unauthorized|forbidden/i)) fail(EXIT.AUTH, err.message);
+      errors.push({ workflow: name, error: err.message });
+      outputs[name] = null;
+    }
+  }
+
+  const findings = buildFindings({ outputs, runId, collectedAt, region, errors });
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  const cachePath = path.join(CACHE_DIR, `${runId}.json`);
+  await fs.writeFile(cachePath, JSON.stringify(findings, null, 2));
+
+  const counters = { pass: 0, fail: 0, inconclusive: 0, not_applicable: 0, skipped: 0 };
+  const severities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  const failingSeverities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const doc of findings) {
+    for (const ev of doc.evaluations) {
+      counters[ev.status] = (counters[ev.status] || 0) + 1;
+      if (ev.severity) severities[ev.severity] = (severities[ev.severity] || 0) + 1;
+      if (ev.status === 'fail' && ev.severity) failingSeverities[ev.severity] = (failingSeverities[ev.severity] || 0) + 1;
+    }
+  }
+
+  const manifest = {
+    source: SOURCE,
+    run_id: runId,
+    started_at: new Date(startedAt).toISOString(),
+    duration_ms: Date.now() - startedAt,
+    scope: region,
+    resources: findings.length,
+    evaluations: findings.reduce((n, d) => n + d.evaluations.length, 0),
+    counters,
+    severities,
+    failing_severities: failingSeverities,
+    errors: errors.length
+  };
+  await fs.appendFile(RUNS_LOG, JSON.stringify(manifest) + '\n');
+
+  const summary = `${SOURCE}: ${findings.length} resources, ${manifest.evaluations} evaluations, ${counters.fail || 0} failing (${failingSeverities.high || 0} high, ${failingSeverities.medium || 0} medium).`;
+  if (args.output === 'json') process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, summary: manifest }, null, 2) + '\n');
+  else if (args.output !== 'silent') process.stdout.write(summary + '\n');
+  process.exit(errors.length ? EXIT.PARTIAL : EXIT.OK);
+}
+
+function buildFindings({ outputs, runId, collectedAt, region, errors }) {
+  const docs = [];
+  const orgEvaluations = [];
+  const summary = outputs.summary;
+  if (summary) {
+    orgEvaluations.push(summary.status === 'COMPLIANT'
+      ? pass('GOV-03', 'Drata summary reports compliant status.')
+      : failHigh('GOV-03', `Drata summary reports ${summary.status || 'NEEDS_ATTENTION'} status.`, 'Review Drata summary recommendations and remediate failing controls, monitors, personnel issues, and disconnected integrations.'));
+    const failedMonitors = Number(summary.monitors?.failed || 0);
+    orgEvaluations.push(failedMonitors > 0
+      ? failHigh('MON-01.2', `Drata reports ${failedMonitors} failing monitor(s).`, 'Investigate failing Drata monitors and restore automated control checks.')
+      : pass('MON-01.2', 'Drata reports no failing monitors in the summary workflow.'));
+    const disconnected = Number(summary.connections?.disconnected || 0) + Number(summary.connections?.failed || 0) + Number(summary.connections?.never_connected || 0);
+    orgEvaluations.push(disconnected > 0
+      ? failMedium('DCH-04', `Drata reports ${disconnected} integration connection(s) disconnected, failed, or never connected.`, 'Reconnect Drata integrations used for automated evidence collection.')
+      : pass('DCH-04', 'Drata reports integration connections are active in the summary workflow.'));
+  } else {
+    orgEvaluations.push(inconclusive('GOV-03', 'Drata summary workflow did not complete.'));
+  }
+
+  for (const err of errors) {
+    orgEvaluations.push(inconclusive('GOV-03', `Drata workflow ${err.workflow} did not complete: ${err.error}`));
+  }
+
+  docs.push(doc({
+    runId,
+    collectedAt,
+    type: 'drata_tenant',
+    id: `drata-${region}`,
+    uri: null,
+    accountId: region,
+    evaluations: orgEvaluations,
+    raw: { summary },
+    metadata: { region, workflows: Object.keys(outputs).filter(k => outputs[k]) }
+  }));
+
+  for (const control of outputs.controls_failing?.controls || []) {
+    const status = control.status || 'NEEDS_ATTENTION';
+    docs.push(doc({
+      runId,
+      collectedAt,
+      type: 'drata_control',
+      id: String(control.code || control.id),
+      uri: null,
+      accountId: region,
+      evaluations: [controlEvaluation(status, control)],
+      raw: { control },
+      metadata: { drata_control_code: control.code || null, drata_control_id: control.id || null }
+    }));
+  }
+
+  for (const monitor of outputs.monitors_failing?.monitors || []) {
+    docs.push(doc({
+      runId,
+      collectedAt,
+      type: 'drata_monitor',
+      id: String(monitor.id),
+      uri: null,
+      accountId: region,
+      evaluations: [failHigh('MON-01.2', `Drata monitor '${monitor.name || monitor.id}' is failing.`, 'Investigate the failed Drata monitor and restore the underlying automated evidence check.')],
+      raw: { monitor },
+      metadata: { related_controls: monitor.controls || [] }
+    }));
+  }
+
+  for (const connection of outputs.connections?.connections || []) {
+    if (!['FAILED', 'DISCONNECTED', 'NEVER_CONNECTED'].includes(connection.status)) continue;
+    docs.push(doc({
+      runId,
+      collectedAt,
+      type: 'drata_connection',
+      id: String(connection.id || connection.alias || connection.clientType),
+      uri: null,
+      accountId: region,
+      evaluations: [failMedium('DCH-04', `Drata connection '${connection.alias || connection.clientType || connection.id}' is ${connection.status}.`, 'Reconnect or retire stale Drata integrations so evidence automation remains reliable.')],
+      raw: { connection },
+      metadata: { provider_types: connection.providers || [] }
+    }));
+  }
+
+  for (const person of outputs.personnel?.personnel || []) {
+    docs.push(doc({
+      runId,
+      collectedAt,
+      type: 'drata_personnel',
+      id: String(person.id || person.email),
+      uri: null,
+      accountId: region,
+      evaluations: [failMedium('IAC-02', `Drata personnel record has ${person.failing_devices || 0} failing device compliance check(s).`, 'Resolve personnel device compliance issues or document approved exceptions.')],
+      raw: { personnel: person },
+      metadata: { email_present: Boolean(person.email), employment_status: person.status || null }
+    }));
+  }
+
+  for (const evidence of outputs.evidence?.evidence || []) {
+    docs.push(doc({
+      runId,
+      collectedAt,
+      type: 'drata_evidence',
+      id: String(evidence.id),
+      uri: null,
+      accountId: region,
+      evaluations: [failMedium('GOV-08', `Drata evidence '${evidence.name || evidence.id}' appears stale or expiring.`, 'Refresh the evidence artifact and verify linked controls still have current support.')],
+      raw: { evidence },
+      metadata: { updated_at: evidence.updatedAt || null, versions: evidence.versions || 0 }
+    }));
+  }
+
+  return docs;
+}
+
+function controlEvaluation(status, control) {
+  switch (status) {
+    case 'NO_OWNER':
+      return failMedium('GOV-01', `Drata control ${control.code || control.id} has no owner.`, 'Assign a control owner in Drata and document accountability.');
+    case 'NEEDS_EVIDENCE':
+      return failHigh('GOV-08', `Drata control ${control.code || control.id} needs evidence.`, 'Attach current evidence or fix the automated evidence source.');
+    case 'NOT_READY':
+      return failHigh('GOV-03', `Drata control ${control.code || control.id} is not ready.`, 'Review control implementation status and close missing readiness tasks.');
+    default:
+      return failMedium('GOV-03', `Drata control ${control.code || control.id} needs attention (${status}).`, 'Review the Drata control and update implementation, evidence, and ownership.');
+  }
+}
+
+function doc({ runId, collectedAt, type, id, uri, accountId, evaluations, raw, metadata }) {
+  return {
+    schema_version: '1.0.0',
+    source: SOURCE,
+    source_version: SOURCE_VERSION,
+    run_id: runId,
+    collected_at: collectedAt,
+    resource: { type, id, uri, region: null, account_id: accountId },
+    evaluations,
+    raw_attributes: raw,
+    metadata
+  };
+}
+
+async function runDrataJson(drata, args, env) {
+  const { stdout, stderr } = await execFileP(drata, args, { env, maxBuffer: 20 * 1024 * 1024 });
+  try {
+    return JSON.parse(stdout);
+  } catch (err) {
+    throw new Error(`Could not parse drata JSON for '${args.join(' ')}': ${err.message}; stderr=${stderr.trim()}`);
+  }
+}
+
+function parseArgs(argv) {
+  const out = { output: 'summary', quiet: false, limit: 0, maxPages: 0, evidenceDays: 0 };
+  for (const tok of argv) {
+    if (!tok.startsWith('--')) continue;
+    const [k, v] = tok.slice(2).split('=');
+    switch (k) {
+      case 'output':
+        if (!['summary', 'json', 'silent'].includes(v)) fail(EXIT.USAGE, `Unknown output mode: ${v}`);
+        out.output = v;
+        break;
+      case 'quiet': out.quiet = true; break;
+      case 'limit': out.limit = parseInt(v, 10); break;
+      case 'max-pages': out.maxPages = parseInt(v, 10); break;
+      case 'evidence-days': out.evidenceDays = parseInt(v, 10); break;
+      default: fail(EXIT.USAGE, `Unknown flag: --${k}`);
+    }
+  }
+  return out;
+}
+
+function pass(controlId, message) {
+  return { control_framework: 'SCF', control_id: controlId, status: 'pass', severity: 'info', message };
+}
+
+function inconclusive(controlId, message) {
+  return { control_framework: 'SCF', control_id: controlId, status: 'inconclusive', severity: 'info', message };
+}
+
+function failHigh(controlId, message, summary) {
+  return failEval(controlId, 'high', message, summary);
+}
+
+function failMedium(controlId, message, summary) {
+  return failEval(controlId, 'medium', message, summary);
+}
+
+function failEval(controlId, severity, message, summary) {
+  return {
+    control_framework: 'SCF',
+    control_id: controlId,
+    status: 'fail',
+    severity,
+    message,
+    remediation: {
+      summary,
+      ref: 'grc-engineer://generate-implementation/drata_compliance_workflow',
+      effort_hours: severity === 'high' ? 1 : 0.5,
+      automation: 'manual'
+    }
+  };
+}
+
+function parseYaml(text) {
+  const out = {};
+  const stack = [out];
+  const indents = [0];
+  for (const rawLine of text.split(/\r?\n/)) {
+    if (!rawLine.trim() || rawLine.trim().startsWith('#')) continue;
+    const indent = rawLine.match(/^\s*/)[0].length;
+    const line = rawLine.trim();
+    while (indent < indents[indents.length - 1]) { stack.pop(); indents.pop(); }
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    if (rawValue === '') {
+      const child = {};
+      stack[stack.length - 1][key] = child;
+      stack.push(child);
+      indents.push(indent + 2);
+    } else {
+      stack[stack.length - 1][key] = parseYamlValue(rawValue);
+    }
+  }
+  return out;
+}
+
+function parseYamlValue(raw) {
+  const v = raw.trim();
+  if (v.startsWith('"') && v.endsWith('"')) return v.slice(1, -1);
+  if (v.startsWith('[') && v.endsWith(']')) return v.slice(1, -1).split(',').map(s => s.trim().replace(/^"|"$/g, '')).filter(Boolean);
+  if (/^\d+$/.test(v)) return Number(v);
+  return v;
+}
+
+function makeRunId() {
+  return `${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function fail(code, msg) {
+  process.stderr.write(`[${SOURCE}] ${msg}\n`);
+  process.exit(code);
+}
+
+main(process.argv.slice(2)).catch(err => {
+  process.stderr.write(`[${SOURCE}] unhandled error: ${err.stack || err.message}\n`);
+  process.exit(1);
+});

--- a/plugins/connectors/drata-inspector/scripts/setup.sh
+++ b/plugins/connectors/drata-inspector/scripts/setup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# drata-inspector:setup
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors"
+CONFIG_FILE="$CONFIG_DIR/drata-inspector.yaml"
+SOURCE="drata-inspector"
+SOURCE_VERSION="0.1.0"
+DRATA_CMD="${DRATA_CMD:-drata}"
+REGION="${DRATA_REGION:-us}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --command=*) DRATA_CMD="${arg#*=}" ;;
+    --region=*)  REGION="${arg#*=}" ;;
+    *) echo "[$SOURCE:setup] unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v "$DRATA_CMD" >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+[drata-inspector:setup] drata CLI not found.
+
+Install:
+  npm install -g drata-cli
+
+Then configure auth:
+  drata auth login --api-key-stdin
+EOF
+  exit 5
+fi
+
+VERSION=$("$DRATA_CMD" --version 2>/dev/null || echo unknown)
+if ! AUTH_JSON=$(DRATA_READ_ONLY=1 DRATA_REGION="$REGION" "$DRATA_CMD" auth check --json 2>/dev/null); then
+  cat >&2 <<EOF
+[drata-inspector:setup] Drata auth check failed.
+
+Configure drata-cli auth with one of:
+  drata auth login --api-key-stdin
+  export DRATA_API_KEY=...
+  export DRATA_API_KEY_CMD='op read op://vault/drata/api-key'
+EOF
+  exit 2
+fi
+
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_FILE" <<EOF
+version: 1
+source: $SOURCE
+source_version: "$SOURCE_VERSION"
+drata_command: "$DRATA_CMD"
+drata_cli_version: "$VERSION"
+region: "$REGION"
+defaults:
+  workflows: ["summary", "controls_failing", "monitors_failing", "connections", "personnel", "evidence"]
+  limit: 50
+  max_pages: 20
+  evidence_days: 60
+EOF
+
+CACHE_DIR="$HOME/.cache/claude-grc/findings/drata-inspector"
+mkdir -p "$CACHE_DIR"
+touch "$HOME/.cache/claude-grc/runs.log"
+
+cat <<EOF
+drata-inspector:setup ok
+  drata:   $VERSION
+  region:  $REGION
+  config:  $CONFIG_FILE
+
+Next:
+  /drata-inspector:collect
+EOF

--- a/plugins/connectors/drata-inspector/scripts/status.sh
+++ b/plugins/connectors/drata-inspector/scripts/status.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# drata-inspector:status
+set -uo pipefail
+
+CONFIG_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors/drata-inspector.yaml"
+CACHE_DIR="$HOME/.cache/claude-grc/findings/drata-inspector"
+
+printf 'drata-inspector\n'
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  printf '  status:        not-configured\n'
+  printf '  fix:           run /drata-inspector:setup\n'
+  exit 2
+fi
+
+DRATA_CMD=$(awk -F'"' '/^drata_command:/ {print $2; exit}' "$CONFIG_FILE")
+REGION=$(awk -F'"' '/^region:/ {print $2; exit}' "$CONFIG_FILE")
+[[ -z "$DRATA_CMD" ]] && DRATA_CMD="drata"
+[[ -z "$REGION" ]] && REGION="${DRATA_REGION:-us}"
+
+if ! command -v "$DRATA_CMD" >/dev/null 2>&1; then
+  printf '  status:        drata-not-installed\n'
+  printf '  fix:           npm install -g drata-cli\n'
+  exit 5
+fi
+
+VERSION=$("$DRATA_CMD" --version 2>/dev/null || echo unknown)
+if ! DRATA_READ_ONLY=1 DRATA_REGION="$REGION" "$DRATA_CMD" auth check --json >/dev/null 2>&1; then
+  printf '  status:        credentials-expired\n'
+  printf '  drata:         %s\n' "$VERSION"
+  printf '  fix:           drata auth login --api-key-stdin\n'
+  exit 2
+fi
+
+LATEST=$(ls -t "$CACHE_DIR"/*.json 2>/dev/null | head -1 || true)
+if [[ -z "$LATEST" ]]; then
+  printf '  status:        ready\n'
+  printf '  drata:         %s\n' "$VERSION"
+  printf '  region:        %s\n' "$REGION"
+  printf '  config:        %s\n' "$CONFIG_FILE"
+  printf '  last run:      never\n'
+  exit 0
+fi
+
+if stat -f%m "$LATEST" >/dev/null 2>&1; then MTIME=$(stat -f%m "$LATEST"); else MTIME=$(stat -c%Y "$LATEST"); fi
+AGE=$(( $(date +%s) - MTIME ))
+AGE_H=$(( AGE / 3600 ))
+if (( AGE_H < 24 )); then LABEL="${AGE_H}h ago"; STATUS="ready"
+elif (( AGE_H < 168 )); then LABEL="$((AGE_H/24))d ago"; STATUS="ready"
+else LABEL="$((AGE_H/24))d ago"; STATUS="stale"
+fi
+
+RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
+EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}" "$LATEST")
+
+printf '  status:        %s\n' "$STATUS"
+printf '  drata:         %s\n' "$VERSION"
+printf '  region:        %s\n' "$REGION"
+printf '  config:        %s\n' "$CONFIG_FILE"
+printf '  last run:      %s (%s)\n' "$LABEL" "$(basename "$LATEST" .json)"
+printf '  cached:        %s resources, %s evaluations\n' "$RES" "$EVS"

--- a/plugins/connectors/drata-inspector/skills/drata-inspector-expert/SKILL.md
+++ b/plugins/connectors/drata-inspector/skills/drata-inspector-expert/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: drata-inspector-expert
+description: Interpret drata-inspector findings generated from drata-cli workflows and turn Drata control, monitor, evidence, personnel, and integration posture into GRC action.
+license: MIT
+---
+
+# Drata Inspector Expert
+
+Use this skill when reviewing `drata-inspector` output or planning remediation from Drata workflow findings.
+
+## Source
+
+`drata-inspector` wraps the MIT-licensed [`drata-cli`](https://github.com/ethanolivertroy/drata-cli) workflow commands. It does not reimplement Drata APIs and does not require Drata MCP.
+
+## Output Shape
+
+Findings are written to:
+
+```text
+~/.cache/claude-grc/findings/drata-inspector/<run_id>.json
+```
+
+Resource types:
+
+- `drata_tenant`: summary status across controls, monitors, personnel, and integrations
+- `drata_control`: failing or incomplete controls from `drata controls failing`
+- `drata_monitor`: failed automated checks from `drata monitors failing`
+- `drata_connection`: disconnected, failed, or never-connected integrations
+- `drata_personnel`: personnel/device compliance issues
+- `drata_evidence`: stale or expiring evidence from `drata evidence expiring`
+
+## Review Guidance
+
+- Treat Drata-native control codes as source metadata. The connector emits SCF IDs for normalized downstream reporting.
+- Keep Drata as the evidence source of record; use these Findings for cross-framework gap analysis and engineering remediation.
+- `inconclusive` means a `drata-cli` workflow failed or permissions were insufficient.
+
+## Remediation Patterns
+
+- Assign owners for ownerless controls.
+- Refresh stale evidence and repair disconnected evidence sources.
+- Investigate failed monitors before assuming a control is ineffective.
+- Resolve personnel device compliance failures or document approved exceptions.
+- Reconnect Drata integrations that feed automated evidence.

--- a/tests/fixtures/findings/drata-inspector/001-summary-pass.json
+++ b/tests/fixtures/findings/drata-inspector/001-summary-pass.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "drata-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-drata-pass",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "drata_tenant",
+    "id": "drata-us",
+    "uri": null,
+    "region": null,
+    "account_id": "us"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "GOV-03",
+      "status": "pass",
+      "severity": "info",
+      "message": "Drata summary reports compliant status."
+    }
+  ]
+}

--- a/tests/fixtures/findings/drata-inspector/002-control-evidence-fail.json
+++ b/tests/fixtures/findings/drata-inspector/002-control-evidence-fail.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "source": "drata-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-drata-fail",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "drata_control",
+    "id": "DCF-71",
+    "uri": null,
+    "region": null,
+    "account_id": "us"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "GOV-08",
+      "status": "fail",
+      "severity": "high",
+      "message": "Drata control DCF-71 needs evidence.",
+      "remediation": {
+        "summary": "Attach current evidence or fix the automated evidence source.",
+        "ref": "grc-engineer://generate-implementation/drata_compliance_workflow",
+        "effort_hours": 1,
+        "automation": "manual"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/findings/drata-inspector/003-workflow-inconclusive.json
+++ b/tests/fixtures/findings/drata-inspector/003-workflow-inconclusive.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "drata-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-drata-inconclusive",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "drata_tenant",
+    "id": "drata-us",
+    "uri": null,
+    "region": null,
+    "account_id": "us"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "GOV-03",
+      "status": "inconclusive",
+      "severity": "info",
+      "message": "Drata workflow controls_failing did not complete: insufficient permissions."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #45.\n\n## Summary\n- Adds drata-inspector as a connector workflow wrapper over ethanolivertroy/drata-cli rather than a bespoke MCP bridge.\n- Runs curated read-only drata-cli workflows and normalizes controls, monitors, integrations, personnel issues, stale evidence, and summary posture into Finding schema v1.\n- Registers the connector in the marketplace and adds pass, fail/high, and inconclusive fixtures.\n\n## Validation\n- git diff --check\n- node --check plugins/connectors/drata-inspector/scripts/collect.js\n- bash -n plugins/connectors/drata-inspector/scripts/setup.sh plugins/connectors/drata-inspector/scripts/status.sh\n- npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh\n- npm run test:contract