### PR TITLE
[codex] Add Splunk inspector connector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -221,6 +221,12 @@
       "version": "0.1.0"
     },
     {
+      "name": "splunk-inspector",
+      "source": "./plugins/connectors/splunk-inspector",
+      "description": "GRC connector for Splunk: index retention, RBAC, audit coverage, search ACLs, and auth posture to v1 finding contract",
+      "version": "0.1.0"
+    },
+    {
       "name": "okta-inspector",
       "source": "./plugins/connectors/okta-inspector",
       "description": "GRC connector for Okta: password/MFA/session policies, inactive users, admin factor enrollment \u2192 v1 finding contract",

--- a/plugins/connectors/splunk-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/splunk-inspector/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "splunk-inspector",
+  "version": "0.1.0",
+  "description": "GRC connector for Splunk: evaluates index retention, RBAC roles, audit-source coverage, saved-search ACLs, and user authentication signals. Emits findings conforming to schemas/finding.schema.json v1.",
+  "author": { "name": "GRC Engineering Club Contributors" },
+  "license": "MIT",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "keywords": ["grc", "compliance", "splunk", "logging", "siem", "scf", "connector"]
+}

--- a/plugins/connectors/splunk-inspector/commands/collect.md
+++ b/plugins/connectors/splunk-inspector/commands/collect.md
@@ -1,0 +1,29 @@
+# /splunk-inspector:collect
+
+Collect Splunk security posture and write Finding documents to:
+
+```text
+~/.cache/claude-grc/findings/splunk-inspector/<run_id>.json
+```
+
+The collector appends a run manifest to:
+
+```text
+~/.cache/claude-grc/runs.log
+```
+
+## Coverage
+
+- Index retention
+- RBAC roles and broad admin capabilities
+- Audit-source coverage
+- Saved-search ACL sharing
+- User authentication method visibility
+
+Unavailable API surfaces are emitted as `inconclusive` evaluations rather than silently passing.
+
+## Options
+
+- `--output=summary|json|silent` controls stdout. Default: `summary`.
+- `--quiet` suppresses progress logs on stderr.
+- `--min-retention-days=<n>` minimum acceptable retention for indexes. Default: `30`.

--- a/plugins/connectors/splunk-inspector/commands/setup.md
+++ b/plugins/connectors/splunk-inspector/commands/setup.md
@@ -1,0 +1,37 @@
+# /splunk-inspector:setup
+
+Configure `splunk-inspector` for a Splunk management API endpoint.
+
+```bash
+plugins/connectors/splunk-inspector/scripts/setup.sh --base-url=https://splunk.example.com:8089 --token=<token>
+```
+
+The setup command validates `/services/server/info` and writes:
+
+```text
+~/.config/claude-grc/connectors/splunk-inspector.yaml
+```
+
+Secrets are stored separately with user-only file permissions at:
+
+```text
+~/.config/claude-grc/connectors/splunk-inspector.env
+```
+
+## Auth
+
+Prefer Splunk bearer tokens. Basic auth is supported for local/admin workflows.
+
+Options:
+
+- `--base-url=<url>` Splunk management API base URL, usually port `8089`.
+- `--token=<token>` or `SPLUNK_TOKEN`.
+- `--username=<user> --password=<password>` or `SPLUNK_USERNAME` / `SPLUNK_PASSWORD`.
+- `--insecure` allows self-signed certificates by setting `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+
+## Next
+
+```text
+/splunk-inspector:collect
+/splunk-inspector:status
+```

--- a/plugins/connectors/splunk-inspector/commands/status.md
+++ b/plugins/connectors/splunk-inspector/commands/status.md
@@ -1,0 +1,9 @@
+# /splunk-inspector:status
+
+Show Splunk API reachability, auth validity, and latest cache freshness.
+
+```bash
+plugins/connectors/splunk-inspector/scripts/status.sh
+```
+
+A cache older than seven days is reported as `stale`.

--- a/plugins/connectors/splunk-inspector/scripts/collect.js
+++ b/plugins/connectors/splunk-inspector/scripts/collect.js
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+
+const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'connectors', 'splunk-inspector.yaml');
+const ENV_FILE = path.join(CONFIG_DIR, 'connectors', 'splunk-inspector.env');
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'splunk-inspector');
+const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
+const SOURCE = 'splunk-inspector';
+const SOURCE_VERSION = '0.1.0';
+const EXIT = { OK: 0, USAGE: 2, AUTH: 2, PARTIAL: 4, NOT_CONFIGURED: 5 };
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  const log = args.quiet ? () => {} : (m) => process.stderr.write(`[${SOURCE}] ${m}\n`);
+  let config;
+  try {
+    config = parseYaml(await fs.readFile(CONFIG_FILE, 'utf8'));
+  } catch {
+    fail(EXIT.NOT_CONFIGURED, `config missing (${CONFIG_FILE}). Run /splunk-inspector:setup first.`);
+  }
+
+  const env = await loadEnv();
+  const auth = {
+    token: process.env.SPLUNK_TOKEN || env.SPLUNK_TOKEN,
+    username: process.env.SPLUNK_USERNAME || env.SPLUNK_USERNAME,
+    password: process.env.SPLUNK_PASSWORD || env.SPLUNK_PASSWORD
+  };
+  const baseUrl = config.base_url || process.env.SPLUNK_BASE_URL;
+  const minRetentionDays = args.minRetentionDays || config.defaults?.min_retention_days || 30;
+  if (!baseUrl) fail(EXIT.NOT_CONFIGURED, 'missing Splunk base_url in config.');
+  if (!auth.token && (!auth.username || !auth.password)) fail(EXIT.AUTH, 'missing Splunk token or username/password.');
+  if (config.insecure === true || config.insecure === 'true') process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+  const startedAt = Date.now();
+  const runId = makeRunId();
+  const collectedAt = new Date().toISOString();
+  const errors = [];
+  const findings = [];
+
+  const server = await probe(baseUrl, '/services/server/info', auth);
+  if (!server.ok) fail(EXIT.AUTH, `Splunk server/info failed: ${server.error}`);
+  log(`connected to ${baseUrl}`);
+
+  const indexes = await probe(baseUrl, '/services/data/indexes', auth);
+  if (indexes.ok) {
+    for (const item of entries(indexes.raw)) findings.push(indexFinding(item, { runId, collectedAt, baseUrl, minRetentionDays }));
+  } else {
+    errors.push({ endpoint: 'indexes', error: indexes.error });
+    findings.push(tenantFinding({ runId, collectedAt, baseUrl, evaluations: [inconclusive('LOG-05', `Splunk index retention could not be evaluated: ${indexes.error}`)], raw: { indexes: indexes.raw } }));
+  }
+
+  const roles = await probe(baseUrl, '/services/authorization/roles', auth);
+  if (roles.ok) {
+    for (const item of entries(roles.raw)) findings.push(roleFinding(item, { runId, collectedAt, baseUrl }));
+  } else {
+    errors.push({ endpoint: 'roles', error: roles.error });
+    findings.push(tenantFinding({ runId, collectedAt, baseUrl, evaluations: [inconclusive('IAC-07', `Splunk RBAC roles could not be evaluated: ${roles.error}`)], raw: { roles: roles.raw } }));
+  }
+
+  const users = await probe(baseUrl, '/services/authentication/users', auth);
+  findings.push(userAuthFinding(users, { runId, collectedAt, baseUrl }));
+  if (!users.ok) errors.push({ endpoint: 'users', error: users.error });
+
+  const savedSearches = await probe(baseUrl, '/servicesNS/-/-/saved/searches', auth);
+  if (savedSearches.ok) {
+    const shared = entries(savedSearches.raw).filter(s => ['global', 'app'].includes(String(s.acl?.sharing || '').toLowerCase()));
+    findings.push(savedSearchAclFinding(shared, { runId, collectedAt, baseUrl, raw: savedSearches.raw }));
+  } else {
+    errors.push({ endpoint: 'saved-searches', error: savedSearches.error });
+    findings.push(tenantFinding({ runId, collectedAt, baseUrl, evaluations: [inconclusive('IAC-07', `Splunk saved-search ACLs could not be evaluated: ${savedSearches.error}`)], raw: { saved_searches: savedSearches.raw } }));
+  }
+
+  const auditIndex = entries(indexes.raw).find(i => i.name === '_audit' || i.name === 'audit');
+  findings.push(auditCoverageFinding(auditIndex, { runId, collectedAt, baseUrl }));
+
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  const cachePath = path.join(CACHE_DIR, `${runId}.json`);
+  await fs.writeFile(cachePath, JSON.stringify(findings, null, 2));
+
+  const counters = { pass: 0, fail: 0, inconclusive: 0, not_applicable: 0, skipped: 0 };
+  const severities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  const failingSeverities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const doc of findings) {
+    for (const ev of doc.evaluations) {
+      counters[ev.status] = (counters[ev.status] || 0) + 1;
+      if (ev.severity) severities[ev.severity] = (severities[ev.severity] || 0) + 1;
+      if (ev.status === 'fail' && ev.severity) failingSeverities[ev.severity] = (failingSeverities[ev.severity] || 0) + 1;
+    }
+  }
+
+  const manifest = {
+    source: SOURCE,
+    run_id: runId,
+    started_at: new Date(startedAt).toISOString(),
+    duration_ms: Date.now() - startedAt,
+    scope: baseUrl,
+    resources: findings.length,
+    evaluations: findings.reduce((n, d) => n + d.evaluations.length, 0),
+    counters,
+    severities,
+    failing_severities: failingSeverities,
+    errors: errors.length
+  };
+  await fs.appendFile(RUNS_LOG, JSON.stringify(manifest) + '\n');
+
+  const summary = `${SOURCE}: ${findings.length} resources, ${manifest.evaluations} evaluations, ${counters.fail || 0} failing (${failingSeverities.high || 0} high, ${failingSeverities.medium || 0} medium).`;
+  if (args.output === 'json') process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, summary: manifest }, null, 2) + '\n');
+  else if (args.output !== 'silent') process.stdout.write(summary + '\n');
+  process.exit(errors.length ? EXIT.PARTIAL : EXIT.OK);
+}
+
+function indexFinding(index, ctx) {
+  const frozenSeconds = Number(index.content?.frozenTimePeriodInSecs ?? index.content?.maxGlobalDataSizeMB ?? 0);
+  const retentionDays = frozenSeconds > 0 ? Math.floor(frozenSeconds / 86400) : null;
+  const evaluation = retentionDays === null
+    ? inconclusive('LOG-05', `Splunk index '${index.name}' does not expose retention seconds.`)
+    : retentionDays < ctx.minRetentionDays
+      ? failHigh('LOG-05', `Splunk index '${index.name}' retention is ${retentionDays} day(s), below ${ctx.minRetentionDays}.`, 'Increase Splunk index retention to meet logging and audit evidence requirements.')
+      : pass('LOG-05', `Splunk index '${index.name}' retention is ${retentionDays} day(s).`);
+  return doc(ctx, 'splunk_index', index.name, [evaluation], { index }, { retention_days: retentionDays });
+}
+
+function roleFinding(role, ctx) {
+  const caps = role.content?.capabilities || [];
+  const highRisk = caps.filter(c => ['admin_all_objects', 'edit_roles', 'edit_user', 'indexes_edit', 'schedule_search'].includes(c));
+  const evaluation = highRisk.length
+    ? failMedium('IAC-07', `Splunk role '${role.name}' has broad capabilities: ${highRisk.join(', ')}.`, 'Review broad Splunk capabilities and restrict administrative permissions to least privilege.')
+    : pass('IAC-07', `Splunk role '${role.name}' does not expose broad administrative capabilities in the inspected set.`);
+  return doc(ctx, 'splunk_role', role.name, [evaluation], { role }, { capabilities: caps });
+}
+
+function userAuthFinding(users, ctx) {
+  if (!users.ok) return tenantFinding({ ...ctx, evaluations: [inconclusive('IAC-04', `Splunk users/auth methods could not be evaluated: ${users.error}`)], raw: { users: users.raw } });
+  const list = entries(users.raw);
+  const localUsers = list.filter(u => String(u.content?.type || u.content?.authType || '').toLowerCase().includes('splunk'));
+  const evaluation = localUsers.length
+    ? failMedium('IAC-04', `${localUsers.length} Splunk user(s) appear to use local/Splunk authentication.`, 'Prefer SAML/LDAP/SSO-backed Splunk authentication and document any local break-glass accounts.')
+    : pass('IAC-04', 'No local/Splunk-authenticated users were detected from the inspected user API response.');
+  return tenantFinding({ ...ctx, evaluations: [evaluation], raw: { users: users.raw }, metadata: { local_user_count: localUsers.length } });
+}
+
+function savedSearchAclFinding(shared, ctx) {
+  const evaluation = shared.length
+    ? failMedium('IAC-07', `${shared.length} saved search(es) are shared at app/global scope.`, 'Review saved-search ACLs and limit write access to approved owners.')
+    : pass('IAC-07', 'No app/global shared saved searches were detected.');
+  return tenantFinding({ ...ctx, evaluations: [evaluation], raw: { saved_searches: ctx.raw }, metadata: { broad_saved_searches: shared.length } });
+}
+
+function auditCoverageFinding(auditIndex, ctx) {
+  const evaluation = auditIndex
+    ? pass('LOG-08', 'Splunk audit index is present for platform activity coverage.')
+    : failHigh('LOG-08', 'No Splunk _audit or audit index was detected.', 'Enable and retain Splunk audit events for administrative activity monitoring.');
+  return tenantFinding({ ...ctx, evaluations: [evaluation], raw: { audit_index: auditIndex || null } });
+}
+
+function tenantFinding({ runId, collectedAt, baseUrl, evaluations, raw, metadata = {} }) {
+  return doc({ runId, collectedAt, baseUrl }, 'splunk_deployment', baseUrl, evaluations, raw, metadata);
+}
+
+function doc(ctx, type, id, evaluations, raw, metadata = {}) {
+  return {
+    schema_version: '1.0.0',
+    source: SOURCE,
+    source_version: SOURCE_VERSION,
+    run_id: ctx.runId,
+    collected_at: ctx.collectedAt,
+    resource: { type, id: String(id), uri: ctx.baseUrl, region: null, account_id: ctx.baseUrl },
+    evaluations,
+    raw_attributes: raw,
+    metadata
+  };
+}
+
+async function probe(baseUrl, endpoint, auth) {
+  try {
+    return { ok: true, raw: await splunk(baseUrl, endpoint, auth), error: null };
+  } catch (err) {
+    return { ok: false, raw: err.body || null, error: err.message };
+  }
+}
+
+async function splunk(baseUrl, endpoint, auth) {
+  const url = `${baseUrl.replace(/\/$/, '')}${endpoint}${endpoint.includes('?') ? '&' : '?'}output_mode=json`;
+  const headers = { Accept: 'application/json' };
+  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
+  else headers.Authorization = `Basic ${Buffer.from(`${auth.username}:${auth.password}`).toString('base64')}`;
+  const response = await fetch(url, { headers });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const err = new Error(body.messages?.[0]?.text || body.error || `http_${response.status}`);
+    err.body = body;
+    throw err;
+  }
+  return body;
+}
+
+function entries(payload) {
+  return Array.isArray(payload?.entry) ? payload.entry : [];
+}
+
+async function loadEnv() {
+  try {
+    const text = await fs.readFile(ENV_FILE, 'utf8');
+    const out = {};
+    for (const line of text.split(/\r?\n/)) {
+      const m = line.match(/^([A-Z0-9_]+)="?(.*?)"?$/);
+      if (m) out[m[1]] = m[2];
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function parseArgs(argv) {
+  const out = { output: 'summary', quiet: false, minRetentionDays: 0 };
+  for (const tok of argv) {
+    if (!tok.startsWith('--')) continue;
+    const [k, v] = tok.slice(2).split('=');
+    switch (k) {
+      case 'output':
+        if (!['summary', 'json', 'silent'].includes(v)) fail(EXIT.USAGE, `Unknown output mode: ${v}`);
+        out.output = v;
+        break;
+      case 'quiet': out.quiet = true; break;
+      case 'min-retention-days': out.minRetentionDays = parseInt(v, 10); break;
+      default: fail(EXIT.USAGE, `Unknown flag: --${k}`);
+    }
+  }
+  return out;
+}
+
+function pass(controlId, message) {
+  return { control_framework: 'SCF', control_id: controlId, status: 'pass', severity: 'info', message };
+}
+
+function inconclusive(controlId, message) {
+  return { control_framework: 'SCF', control_id: controlId, status: 'inconclusive', severity: 'info', message };
+}
+
+function failHigh(controlId, message, summary) {
+  return failEval(controlId, 'high', message, summary);
+}
+
+function failMedium(controlId, message, summary) {
+  return failEval(controlId, 'medium', message, summary);
+}
+
+function failEval(controlId, severity, message, summary) {
+  return {
+    control_framework: 'SCF',
+    control_id: controlId,
+    status: 'fail',
+    severity,
+    message,
+    remediation: {
+      summary,
+      ref: 'grc-engineer://generate-implementation/splunk_logging',
+      effort_hours: severity === 'high' ? 1 : 0.5,
+      automation: 'manual'
+    }
+  };
+}
+
+function parseYaml(text) {
+  const out = {};
+  const stack = [out];
+  const indents = [0];
+  for (const rawLine of text.split(/\r?\n/)) {
+    if (!rawLine.trim() || rawLine.trim().startsWith('#')) continue;
+    const indent = rawLine.match(/^\s*/)[0].length;
+    const line = rawLine.trim();
+    while (indent < indents[indents.length - 1]) { stack.pop(); indents.pop(); }
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    if (rawValue === '') {
+      const child = {};
+      stack[stack.length - 1][key] = child;
+      stack.push(child);
+      indents.push(indent + 2);
+    } else {
+      stack[stack.length - 1][key] = parseYamlValue(rawValue);
+    }
+  }
+  return out;
+}
+
+function parseYamlValue(raw) {
+  const v = raw.trim();
+  if (v.startsWith('"') && v.endsWith('"')) return v.slice(1, -1);
+  if (/^\d+$/.test(v)) return Number(v);
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  return v;
+}
+
+function makeRunId() {
+  return `${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function fail(code, msg) {
+  process.stderr.write(`[${SOURCE}] ${msg}\n`);
+  process.exit(code);
+}
+
+main(process.argv.slice(2)).catch(err => {
+  process.stderr.write(`[${SOURCE}] unhandled error: ${err.stack || err.message}\n`);
+  process.exit(1);
+});

--- a/plugins/connectors/splunk-inspector/scripts/setup.sh
+++ b/plugins/connectors/splunk-inspector/scripts/setup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# splunk-inspector:setup
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors"
+CONFIG_FILE="$CONFIG_DIR/splunk-inspector.yaml"
+ENV_FILE="$CONFIG_DIR/splunk-inspector.env"
+SOURCE="splunk-inspector"
+SOURCE_VERSION="0.1.0"
+
+BASE_URL="${SPLUNK_BASE_URL:-}"
+TOKEN="${SPLUNK_TOKEN:-}"
+USERNAME="${SPLUNK_USERNAME:-}"
+PASSWORD="${SPLUNK_PASSWORD:-}"
+INSECURE="false"
+
+for arg in "$@"; do
+  case "$arg" in
+    --base-url=*) BASE_URL="${arg#*=}" ;;
+    --token=*) TOKEN="${arg#*=}" ;;
+    --username=*) USERNAME="${arg#*=}" ;;
+    --password=*) PASSWORD="${arg#*=}" ;;
+    --insecure) INSECURE="true" ;;
+    *) echo "[$SOURCE:setup] unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$BASE_URL" ]]; then
+  echo "[$SOURCE:setup] missing --base-url or SPLUNK_BASE_URL." >&2
+  exit 2
+fi
+
+if [[ -z "$TOKEN" && ( -z "$USERNAME" || -z "$PASSWORD" ) ]]; then
+  echo "[$SOURCE:setup] provide --token or --username/--password." >&2
+  exit 2
+fi
+
+AUTH_JSON=$(NODE_TLS_REJECT_UNAUTHORIZED=$([[ "$INSECURE" == "true" ]] && echo 0 || echo 1) node - "$BASE_URL" "$TOKEN" "$USERNAME" "$PASSWORD" <<'NODE'
+const [baseUrl, token, username, password] = process.argv.slice(2);
+const headers = { Accept: 'application/json' };
+if (token) headers.Authorization = `Bearer ${token}`;
+else headers.Authorization = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+const url = `${baseUrl.replace(/\/$/, '')}/services/server/info?output_mode=json`;
+const result = await fetch(url, { headers }).then(async r => ({ status: r.status, body: await r.json().catch(() => ({})) })).catch(err => ({ status: 0, body: { error: err.message } }));
+console.log(JSON.stringify(result));
+NODE
+)
+
+STATUS=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.status)" "$AUTH_JSON")
+if [[ "$STATUS" != "200" ]]; then
+  ERR=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.body?.messages?.[0]?.text || d.body?.error || ('http_' + d.status))" "$AUTH_JSON")
+  echo "[$SOURCE:setup] Splunk auth check failed: $ERR" >&2
+  exit 2
+fi
+
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_FILE" <<EOF
+version: 1
+source: $SOURCE
+source_version: "$SOURCE_VERSION"
+base_url: "$BASE_URL"
+insecure: $INSECURE
+defaults:
+  min_retention_days: 30
+EOF
+
+umask 077
+cat > "$ENV_FILE" <<EOF
+SPLUNK_TOKEN="$TOKEN"
+SPLUNK_USERNAME="$USERNAME"
+SPLUNK_PASSWORD="$PASSWORD"
+EOF
+
+CACHE_DIR="$HOME/.cache/claude-grc/findings/splunk-inspector"
+mkdir -p "$CACHE_DIR"
+touch "$HOME/.cache/claude-grc/runs.log"
+
+cat <<EOF
+splunk-inspector:setup ok
+  base_url:  $BASE_URL
+  config:    $CONFIG_FILE
+  secrets:   $ENV_FILE
+
+Next:
+  /splunk-inspector:collect
+EOF

--- a/plugins/connectors/splunk-inspector/scripts/status.sh
+++ b/plugins/connectors/splunk-inspector/scripts/status.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# splunk-inspector:status
+set -uo pipefail
+
+CONFIG_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors/splunk-inspector.yaml"
+ENV_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors/splunk-inspector.env"
+CACHE_DIR="$HOME/.cache/claude-grc/findings/splunk-inspector"
+
+printf 'splunk-inspector\n'
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  printf '  status:        not-configured\n'
+  printf '  fix:           run /splunk-inspector:setup\n'
+  exit 2
+fi
+
+BASE_URL=$(awk -F'"' '/^base_url:/ {print $2; exit}' "$CONFIG_FILE")
+INSECURE=$(awk '/^insecure:/ {print $2; exit}' "$CONFIG_FILE")
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+if [[ -z "${SPLUNK_TOKEN:-}" && ( -z "${SPLUNK_USERNAME:-}" || -z "${SPLUNK_PASSWORD:-}" ) ]]; then
+  printf '  status:        credentials-expired\n'
+  printf '  fix:           set SPLUNK_TOKEN or re-run /splunk-inspector:setup\n'
+  exit 2
+fi
+
+AUTH_JSON=$(NODE_TLS_REJECT_UNAUTHORIZED=$([[ "$INSECURE" == "true" ]] && echo 0 || echo 1) node - "$BASE_URL" "${SPLUNK_TOKEN:-}" "${SPLUNK_USERNAME:-}" "${SPLUNK_PASSWORD:-}" <<'NODE'
+const [baseUrl, token, username, password] = process.argv.slice(2);
+const headers = { Accept: 'application/json' };
+if (token) headers.Authorization = `Bearer ${token}`;
+else headers.Authorization = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+const result = await fetch(`${baseUrl.replace(/\/$/, '')}/services/server/info?output_mode=json`, { headers }).then(async r => ({ status: r.status, body: await r.json().catch(() => ({})) })).catch(err => ({ status: 0, body: { error: err.message } }));
+console.log(JSON.stringify(result));
+NODE
+)
+
+STATUS_CODE=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.status)" "$AUTH_JSON")
+if [[ "$STATUS_CODE" != "200" ]]; then
+  printf '  status:        credentials-expired\n'
+  printf '  base_url:      %s\n' "$BASE_URL"
+  exit 2
+fi
+
+LATEST=$(ls -t "$CACHE_DIR"/*.json 2>/dev/null | head -1 || true)
+if [[ -z "$LATEST" ]]; then
+  printf '  status:        ready\n'
+  printf '  base_url:      %s\n' "$BASE_URL"
+  printf '  config:        %s\n' "$CONFIG_FILE"
+  printf '  last run:      never\n'
+  exit 0
+fi
+
+if stat -f%m "$LATEST" >/dev/null 2>&1; then MTIME=$(stat -f%m "$LATEST"); else MTIME=$(stat -c%Y "$LATEST"); fi
+AGE=$(( $(date +%s) - MTIME ))
+AGE_H=$(( AGE / 3600 ))
+if (( AGE_H < 24 )); then LABEL="${AGE_H}h ago"; STATUS="ready"
+elif (( AGE_H < 168 )); then LABEL="$((AGE_H/24))d ago"; STATUS="ready"
+else LABEL="$((AGE_H/24))d ago"; STATUS="stale"
+fi
+
+RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
+EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}" "$LATEST")
+
+printf '  status:        %s\n' "$STATUS"
+printf '  base_url:      %s\n' "$BASE_URL"
+printf '  config:        %s\n' "$CONFIG_FILE"
+printf '  last run:      %s (%s)\n' "$LABEL" "$(basename "$LATEST" .json)"
+printf '  cached:        %s resources, %s evaluations\n' "$RES" "$EVS"

--- a/plugins/connectors/splunk-inspector/skills/splunk-inspector-expert/SKILL.md
+++ b/plugins/connectors/splunk-inspector/skills/splunk-inspector-expert/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: splunk-inspector-expert
+description: Interpret splunk-inspector findings and translate Splunk retention, RBAC, audit, search ACL, and auth posture into compliance evidence and remediation.
+license: MIT
+---
+
+# Splunk Inspector Expert
+
+Use this skill when reviewing `splunk-inspector` output or planning Splunk logging and access-control remediation.
+
+## Output Shape
+
+Findings are written to:
+
+```text
+~/.cache/claude-grc/findings/splunk-inspector/<run_id>.json
+```
+
+Resource types:
+
+- `splunk_deployment`
+- `splunk_index`
+- `splunk_role`
+
+## Control Focus
+
+- `LOG-05`: log retention
+- `LOG-08`: audit event coverage
+- `IAC-07`: role and saved-search access control
+- `IAC-04`: SSO / authentication method visibility
+
+## Review Guidance
+
+- Treat missing API permissions as coverage gaps, not passes.
+- Confirm retention expectations with the user's regulatory and incident-response needs before accepting short retention.
+- Broad capabilities such as `admin_all_objects`, `edit_roles`, and `indexes_edit` require owner review.
+- Local authentication may be valid for break-glass accounts, but should be documented and monitored.
+
+## Remediation Patterns
+
+- Increase retention on regulated or security-relevant indexes.
+- Preserve `_audit` data and export it where long-term retention is required.
+- Restrict broad role capabilities and review inherited roles.
+- Limit saved-search sharing and write access.
+- Prefer SAML/LDAP/SSO-backed authentication for normal users.

--- a/tests/fixtures/findings/splunk-inspector/001-index-retention-pass.json
+++ b/tests/fixtures/findings/splunk-inspector/001-index-retention-pass.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "splunk-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-splunk-pass",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "splunk_index",
+    "id": "main",
+    "uri": "https://splunk.example.com:8089",
+    "region": null,
+    "account_id": "https://splunk.example.com:8089"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "LOG-05",
+      "status": "pass",
+      "severity": "info",
+      "message": "Splunk index 'main' retention is 90 day(s)."
+    }
+  ]
+}

--- a/tests/fixtures/findings/splunk-inspector/002-audit-index-fail.json
+++ b/tests/fixtures/findings/splunk-inspector/002-audit-index-fail.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "source": "splunk-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-splunk-fail",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "splunk_deployment",
+    "id": "https://splunk.example.com:8089",
+    "uri": "https://splunk.example.com:8089",
+    "region": null,
+    "account_id": "https://splunk.example.com:8089"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "LOG-08",
+      "status": "fail",
+      "severity": "high",
+      "message": "No Splunk _audit or audit index was detected.",
+      "remediation": {
+        "summary": "Enable and retain Splunk audit events for administrative activity monitoring.",
+        "ref": "grc-engineer://generate-implementation/splunk_logging",
+        "effort_hours": 1,
+        "automation": "manual"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/findings/splunk-inspector/003-users-inconclusive.json
+++ b/tests/fixtures/findings/splunk-inspector/003-users-inconclusive.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "splunk-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-splunk-inconclusive",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "splunk_deployment",
+    "id": "https://splunk.example.com:8089",
+    "uri": "https://splunk.example.com:8089",
+    "region": null,
+    "account_id": "https://splunk.example.com:8089"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "IAC-04",
+      "status": "inconclusive",
+      "severity": "info",
+      "message": "Splunk users/auth methods could not be evaluated: insufficient permissions."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #31.\n\n## Summary\n- Adds splunk-inspector as a Tier-2 connector over the Splunk REST API.\n- Evaluates index retention, audit index coverage, RBAC capabilities, saved-search ACLs, and user authentication visibility.\n- Registers the connector in the marketplace and adds pass, fail/high, and inconclusive contract fixtures.\n\n## Validation\n- git diff --check\n- node --check plugins/connectors/splunk-inspector/scripts/collect.js\n- bash -n plugins/connectors/splunk-inspector/scripts/setup.sh plugins/connectors/splunk-inspector/scripts/status.sh\n- npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh\n- npm run test:contract