### PR TITLE
[codex] Add Vanta bridge normalizer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -47,6 +47,12 @@
       "version": "0.1.0"
     },
     {
+      "name": "vanta-bridge",
+      "source": "./plugins/bridges/vanta-bridge",
+      "description": "Normalize Vanta MCP/plugin outputs into v1 Findings for GRC Engineering workflows.",
+      "version": "0.1.0"
+    },
+    {
       "name": "teach-me",
       "source": "./plugins/teach-me",
       "description": "Socratic primer + drill plugin for new-to-GRC practitioners. Get up to speed on a framework, control, or role without already knowing it.",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -50,7 +50,8 @@
       "name": "vanta-bridge",
       "source": "./plugins/bridges/vanta-bridge",
       "description": "Normalize Vanta MCP/plugin outputs into v1 Findings for GRC Engineering workflows.",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "commands": ["setup", "status", "sync"]
     },
     {
       "name": "teach-me",

--- a/plugins/bridges/vanta-bridge/.claude-plugin/plugin.json
+++ b/plugins/bridges/vanta-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,8 @@
 {
   "name": "vanta-bridge",
   "version": "0.1.0",
+  "namespace": "vanta-bridge",
+  "commands": ["setup", "status", "sync"],
   "description": "Bridge plugin that normalizes Vanta MCP/plugin outputs into schemas/finding.schema.json v1 for downstream GRC Engineering workflows.",
   "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",

--- a/plugins/bridges/vanta-bridge/.claude-plugin/plugin.json
+++ b/plugins/bridges/vanta-bridge/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "vanta-bridge",
+  "version": "0.1.0",
+  "description": "Bridge plugin that normalizes Vanta MCP/plugin outputs into schemas/finding.schema.json v1 for downstream GRC Engineering workflows.",
+  "author": { "name": "GRC Engineering Club Contributors" },
+  "license": "MIT",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "keywords": ["grc", "compliance", "vanta", "mcp", "bridge", "scf"]
+}

--- a/plugins/bridges/vanta-bridge/commands/setup.md
+++ b/plugins/bridges/vanta-bridge/commands/setup.md
@@ -1,0 +1,29 @@
+# /vanta-bridge:setup
+
+Configure the Vanta normalization bridge.
+
+```bash
+plugins/bridges/vanta-bridge/scripts/setup.sh
+```
+
+This bridge does not vendor or replace Vanta's official plugin. Users should install Vanta's plugin directly:
+
+```text
+/plugin marketplace add VantaInc/vanta-mcp-plugin
+/plugin install vanta
+```
+
+The setup command records the expected Vanta region and verifies whether a Claude plugin CLI is available to inspect local plugin state.
+
+## Options
+
+- `--region=us|eu|aus` selects the Vanta MCP region. Default: `us`.
+- `--input=<path>` records the default Vanta MCP/export JSON path for sync.
+
+## Output
+
+Config is written to:
+
+```text
+~/.config/claude-grc/bridges/vanta-bridge.yaml
+```

--- a/plugins/bridges/vanta-bridge/commands/setup.md
+++ b/plugins/bridges/vanta-bridge/commands/setup.md
@@ -17,7 +17,7 @@ The setup command records the expected Vanta region and verifies whether a Claud
 
 ## Options
 
-- `--region=us|eu|aus` selects the Vanta MCP region. Default: `us`.
+- `--region=us|eu|aus` records the Vanta MCP region for operator context and future direct-MCP sync. The current `sync` command normalizes local JSON input and does not make region-specific network calls.
 - `--input=<path>` records the default Vanta MCP/export JSON path for sync.
 
 ## Output

--- a/plugins/bridges/vanta-bridge/commands/status.md
+++ b/plugins/bridges/vanta-bridge/commands/status.md
@@ -1,0 +1,9 @@
+# /vanta-bridge:status
+
+Show bridge config and latest normalized Finding cache freshness.
+
+```bash
+plugins/bridges/vanta-bridge/scripts/status.sh
+```
+
+A cache older than seven days is reported as `stale`.

--- a/plugins/bridges/vanta-bridge/commands/sync.md
+++ b/plugins/bridges/vanta-bridge/commands/sync.md
@@ -1,0 +1,30 @@
+# /vanta-bridge:sync
+
+Normalize Vanta MCP/plugin output into Finding schema v1 documents.
+
+```bash
+node plugins/bridges/vanta-bridge/scripts/sync.js --input=vanta-output.json
+```
+
+Output is written to:
+
+```text
+~/.cache/claude-grc/findings/vanta-bridge/<run_id>.json
+```
+
+The bridge accepts JSON that contains any of these top-level collections:
+
+- `tests`
+- `test_entities`
+- `controls`
+- `control_tests`
+- `control_documents`
+- `vulnerabilities`
+
+It preserves Vanta IDs and URLs in `raw_attributes`, `metadata`, and `evidence_refs`.
+
+## Options
+
+- `--input=<path>` Vanta MCP/export JSON. If omitted, uses configured default input path.
+- `--output=summary|json|silent` controls stdout. Default: `summary`.
+- `--quiet` suppresses stderr progress logs.

--- a/plugins/bridges/vanta-bridge/scripts/setup.sh
+++ b/plugins/bridges/vanta-bridge/scripts/setup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# vanta-bridge:setup
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/bridges"
+CONFIG_FILE="$CONFIG_DIR/vanta-bridge.yaml"
+REGION="us"
+INPUT_FILE=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --region=*) REGION="${arg#*=}" ;;
+    --input=*) INPUT_FILE="${arg#*=}" ;;
+    *) echo "[vanta-bridge:setup] unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+case "$REGION" in
+  us|eu|aus) ;;
+  *) echo "[vanta-bridge:setup] region must be us, eu, or aus." >&2; exit 2 ;;
+esac
+
+VANTA_PLUGIN_STATUS="unknown"
+if command -v claude >/dev/null 2>&1; then
+  if claude plugin list 2>/dev/null | grep -qi 'vanta'; then
+    VANTA_PLUGIN_STATUS="installed"
+  else
+    VANTA_PLUGIN_STATUS="not-detected"
+  fi
+else
+  VANTA_PLUGIN_STATUS="claude-cli-not-found"
+fi
+
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_FILE" <<EOF
+version: 1
+source: vanta-bridge
+source_version: "0.1.0"
+region: "$REGION"
+vanta_plugin_status: "$VANTA_PLUGIN_STATUS"
+default_input: "$INPUT_FILE"
+EOF
+
+mkdir -p "$HOME/.cache/claude-grc/findings/vanta-bridge"
+touch "$HOME/.cache/claude-grc/runs.log"
+
+cat <<EOF
+vanta-bridge:setup ok
+  region:         $REGION
+  vanta plugin:   $VANTA_PLUGIN_STATUS
+  config:         $CONFIG_FILE
+
+Install Vanta's official plugin if needed:
+  /plugin marketplace add VantaInc/vanta-mcp-plugin
+  /plugin install vanta
+
+Next:
+  /vanta-bridge:sync --input=<vanta-mcp-output.json>
+EOF

--- a/plugins/bridges/vanta-bridge/scripts/status.sh
+++ b/plugins/bridges/vanta-bridge/scripts/status.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# vanta-bridge:status
+set -uo pipefail
+
+CONFIG_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/bridges/vanta-bridge.yaml"
+CACHE_DIR="$HOME/.cache/claude-grc/findings/vanta-bridge"
+
+printf 'vanta-bridge\n'
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  printf '  status:        not-configured\n'
+  printf '  fix:           run /vanta-bridge:setup\n'
+  exit 2
+fi
+
+REGION=$(awk -F'"' '/^region:/ {print $2; exit}' "$CONFIG_FILE")
+PLUGIN=$(awk -F'"' '/^vanta_plugin_status:/ {print $2; exit}' "$CONFIG_FILE")
+INPUT=$(awk -F'"' '/^default_input:/ {print $2; exit}' "$CONFIG_FILE")
+
+LATEST=$(ls -t "$CACHE_DIR"/*.json 2>/dev/null | head -1 || true)
+if [[ -z "$LATEST" ]]; then
+  printf '  status:        ready\n'
+  printf '  region:        %s\n' "$REGION"
+  printf '  vanta plugin:  %s\n' "$PLUGIN"
+  printf '  default input: %s\n' "${INPUT:-none}"
+  printf '  last sync:     never\n'
+  exit 0
+fi
+
+if stat -f%m "$LATEST" >/dev/null 2>&1; then MTIME=$(stat -f%m "$LATEST"); else MTIME=$(stat -c%Y "$LATEST"); fi
+AGE=$(( $(date +%s) - MTIME ))
+AGE_H=$(( AGE / 3600 ))
+if (( AGE_H < 24 )); then LABEL="${AGE_H}h ago"; STATUS="ready"
+elif (( AGE_H < 168 )); then LABEL="$((AGE_H/24))d ago"; STATUS="ready"
+else LABEL="$((AGE_H/24))d ago"; STATUS="stale"
+fi
+
+RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
+EVS=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const arr=Array.isArray(a)?a:[a];let n=0;for(const d of arr)n+=(d.evaluations||[]).length;console.log(n)}catch{console.log('?')}" "$LATEST")
+
+printf '  status:        %s\n' "$STATUS"
+printf '  region:        %s\n' "$REGION"
+printf '  vanta plugin:  %s\n' "$PLUGIN"
+printf '  default input: %s\n' "${INPUT:-none}"
+printf '  last sync:     %s (%s)\n' "$LABEL" "$(basename "$LATEST" .json)"
+printf '  cached:        %s resources, %s evaluations\n' "$RES" "$EVS"

--- a/plugins/bridges/vanta-bridge/scripts/sync.js
+++ b/plugins/bridges/vanta-bridge/scripts/sync.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+
+const CONFIG_FILE = path.join(process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc'), 'bridges', 'vanta-bridge.yaml');
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'vanta-bridge');
+const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
+const SOURCE = 'vanta-bridge';
+const SOURCE_VERSION = '0.1.0';
+const EXIT = { OK: 0, USAGE: 2, PARTIAL: 4, NOT_CONFIGURED: 5 };
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  const log = args.quiet ? () => {} : (m) => process.stderr.write(`[${SOURCE}] ${m}\n`);
+  let config = {};
+  try {
+    config = parseYaml(await fs.readFile(CONFIG_FILE, 'utf8'));
+  } catch {
+    if (!args.input) fail(EXIT.NOT_CONFIGURED, `config missing (${CONFIG_FILE}). Run /vanta-bridge:setup or pass --input.`);
+  }
+
+  const inputPath = args.input || config.default_input;
+  if (!inputPath) fail(EXIT.USAGE, 'missing --input=<vanta-mcp-output.json>.');
+
+  const startedAt = Date.now();
+  const runId = makeRunId();
+  const collectedAt = new Date().toISOString();
+  const payload = JSON.parse(await fs.readFile(inputPath, 'utf8'));
+  log(`normalizing ${inputPath}`);
+
+  const findings = [
+    ...normalizeTests(payload.tests || payload.test_entities || [], { runId, collectedAt }),
+    ...normalizeControls(payload.controls || [], payload.control_tests || [], payload.control_documents || [], { runId, collectedAt }),
+    ...normalizeVulnerabilities(payload.vulnerabilities || [], { runId, collectedAt })
+  ];
+
+  if (findings.length === 0) {
+    findings.push(doc({ runId, collectedAt }, 'vanta_export', path.basename(inputPath), [{
+      control_framework: 'SCF',
+      control_id: 'GOV-03',
+      status: 'inconclusive',
+      severity: 'info',
+      message: 'Vanta bridge input did not contain tests, controls, or vulnerabilities collections.'
+    }], { input_keys: Object.keys(payload) }, { input_path: inputPath }));
+  }
+
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  const cachePath = path.join(CACHE_DIR, `${runId}.json`);
+  await fs.writeFile(cachePath, JSON.stringify(findings, null, 2));
+
+  const counters = { pass: 0, fail: 0, inconclusive: 0, not_applicable: 0, skipped: 0 };
+  const severities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  const failingSeverities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const finding of findings) {
+    for (const ev of finding.evaluations) {
+      counters[ev.status] = (counters[ev.status] || 0) + 1;
+      if (ev.severity) severities[ev.severity] = (severities[ev.severity] || 0) + 1;
+      if (ev.status === 'fail' && ev.severity) failingSeverities[ev.severity] = (failingSeverities[ev.severity] || 0) + 1;
+    }
+  }
+
+  const manifest = {
+    source: SOURCE,
+    run_id: runId,
+    started_at: new Date(startedAt).toISOString(),
+    duration_ms: Date.now() - startedAt,
+    scope: inputPath,
+    resources: findings.length,
+    evaluations: findings.reduce((n, d) => n + d.evaluations.length, 0),
+    counters,
+    severities,
+    failing_severities: failingSeverities,
+    errors: 0
+  };
+  await fs.appendFile(RUNS_LOG, JSON.stringify(manifest) + '\n');
+
+  const summary = `${SOURCE}: ${findings.length} resources, ${manifest.evaluations} evaluations, ${counters.fail || 0} failing (${failingSeverities.high || 0} high, ${failingSeverities.medium || 0} medium).`;
+  if (args.output === 'json') process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, summary: manifest }, null, 2) + '\n');
+  else if (args.output !== 'silent') process.stdout.write(summary + '\n');
+}
+
+function normalizeTests(tests, ctx) {
+  return asArray(tests).map(test => {
+    const status = normalizeStatus(test.status || test.result || test.outcome);
+    const control = test.scf_control_id || test.control_id || test.framework_control_id || 'GOV-03';
+    return doc(ctx, test.resource_type || 'vanta_test_entity', String(test.entity_id || test.resource_id || test.id || test.name), [{
+      control_framework: test.scf_control_id ? 'SCF' : normalizeFramework(test.framework || test.control_framework),
+      control_id: String(control),
+      status,
+      severity: status === 'fail' ? normalizeSeverity(test.severity, 'high') : 'info',
+      message: test.message || `Vanta test '${test.name || test.id}' normalized as ${status}.`,
+      ...(status === 'fail' ? { remediation: remediation(test.remediation || 'Review the failing Vanta test and remediate the linked control evidence.') } : {})
+    }], { test }, { vanta_test_id: test.id || null, vanta_control_id: test.control_id || null });
+  });
+}
+
+function normalizeControls(controls, controlTests, documents, ctx) {
+  const testsByControl = groupBy(asArray(controlTests), item => String(item.control_id || item.controlId || item.control || ''));
+  const docsByControl = groupBy(asArray(documents), item => String(item.control_id || item.controlId || item.control || ''));
+  return asArray(controls).map(control => {
+    const id = String(control.id || control.control_id || control.code || control.name);
+    const relatedTests = testsByControl.get(id) || [];
+    const relatedDocs = docsByControl.get(id) || [];
+    const failing = relatedTests.filter(t => normalizeStatus(t.status || t.result || t.outcome) === 'fail').length;
+    const status = failing > 0 || String(control.status || '').match(/fail|gap|not[_ -]?ready/i) ? 'fail' : 'pass';
+    const framework = control.scf_control_id ? 'SCF' : normalizeFramework(control.framework || control.control_framework);
+    const controlId = String(control.scf_control_id || control.framework_control_id || control.code || id);
+    return doc(ctx, 'vanta_control', id, [{
+      control_framework: framework,
+      control_id: controlId,
+      status,
+      severity: status === 'fail' ? normalizeSeverity(control.severity, 'high') : 'info',
+      message: status === 'fail' ? `Vanta control '${control.name || id}' has failing or incomplete linked tests.` : `Vanta control '${control.name || id}' has no failing linked tests in the bridge input.`,
+      evidence_refs: relatedDocs.map(d => d.url || d.href || d.id).filter(Boolean),
+      ...(status === 'fail' ? { remediation: remediation(control.remediation || 'Review linked Vanta tests and documents, then refresh evidence or remediate the control gap.') } : {})
+    }], { control, tests: relatedTests, documents: relatedDocs }, { vanta_control_id: id });
+  });
+}
+
+function normalizeVulnerabilities(vulnerabilities, ctx) {
+  return asArray(vulnerabilities).map(vuln => doc(ctx, vuln.asset_type || 'vanta_vulnerability', String(vuln.asset_id || vuln.id || vuln.name), [{
+    control_framework: 'SCF',
+    control_id: 'VPM-04',
+    status: 'fail',
+    severity: normalizeSeverity(vuln.severity, 'high'),
+    message: vuln.message || `Vanta vulnerability '${vuln.name || vuln.id}' is open.`,
+    remediation: remediation(vuln.remediation || 'Remediate or formally accept the vulnerability in the source system.')
+  }], { vulnerability: vuln }, { vanta_vulnerability_id: vuln.id || null }));
+}
+
+function doc(ctx, type, id, evaluations, raw, metadata) {
+  return {
+    schema_version: '1.0.0',
+    source: SOURCE,
+    source_version: SOURCE_VERSION,
+    run_id: ctx.runId,
+    collected_at: ctx.collectedAt,
+    resource: { type, id, uri: null, region: null, account_id: 'vanta' },
+    evaluations,
+    raw_attributes: raw,
+    metadata
+  };
+}
+
+function normalizeStatus(value) {
+  const s = String(value || '').toLowerCase();
+  if (s.match(/pass|ok|success|complete|compliant/)) return 'pass';
+  if (s.match(/fail|error|non[_ -]?compliant|gap/)) return 'fail';
+  if (s.match(/skip/)) return 'skipped';
+  return 'inconclusive';
+}
+
+function normalizeSeverity(value, fallback) {
+  const s = String(value || fallback).toLowerCase();
+  if (['critical', 'high', 'medium', 'low', 'info'].includes(s)) return s;
+  return fallback;
+}
+
+function normalizeFramework(value) {
+  const s = String(value || '').toLowerCase();
+  if (s.includes('soc')) return 'SOC2-TSC-2017';
+  if (s.includes('iso')) return 'ISO-27001-2022';
+  return 'SCF';
+}
+
+function remediation(summary) {
+  return { summary, ref: 'grc-engineer://generate-implementation/vanta_bridge', effort_hours: 1, automation: 'manual' };
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function groupBy(items, keyFn) {
+  const map = new Map();
+  for (const item of items) {
+    const key = keyFn(item);
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(item);
+  }
+  return map;
+}
+
+function parseArgs(argv) {
+  const out = { input: '', output: 'summary', quiet: false };
+  for (const tok of argv) {
+    if (!tok.startsWith('--')) continue;
+    const [k, v] = tok.slice(2).split('=');
+    if (k === 'input') out.input = v;
+    else if (k === 'output' && ['summary', 'json', 'silent'].includes(v)) out.output = v;
+    else if (k === 'quiet') out.quiet = true;
+    else fail(EXIT.USAGE, `Unknown flag: --${k}`);
+  }
+  return out;
+}
+
+function parseYaml(text) {
+  const out = {};
+  for (const line of text.split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*"?([^"]*)"?$/);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+function makeRunId() {
+  return `${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function fail(code, msg) {
+  process.stderr.write(`[${SOURCE}] ${msg}\n`);
+  process.exit(code);
+}
+
+main(process.argv.slice(2)).catch(err => {
+  process.stderr.write(`[${SOURCE}] unhandled error: ${err.stack || err.message}\n`);
+  process.exit(1);
+});

--- a/plugins/bridges/vanta-bridge/scripts/sync.js
+++ b/plugins/bridges/vanta-bridge/scripts/sync.js
@@ -147,8 +147,8 @@ function doc(ctx, type, id, evaluations, raw, metadata) {
 
 function normalizeStatus(value) {
   const s = String(value || '').toLowerCase();
-  if (s.match(/pass|ok|success|complete|compliant/)) return 'pass';
-  if (s.match(/fail|error|non[_ -]?compliant|gap/)) return 'fail';
+  if (s.match(/fail|error|non[_ -]?compliant|not[_ -]?(ok|compliant|complete)|incomplete|broken|gap/)) return 'fail';
+  if (s.match(/^(pass|passed|ok|success|successful|complete|completed|compliant)$/)) return 'pass';
   if (s.match(/skip/)) return 'skipped';
   return 'inconclusive';
 }

--- a/plugins/bridges/vanta-bridge/skills/vanta-bridge-expert/SKILL.md
+++ b/plugins/bridges/vanta-bridge/skills/vanta-bridge-expert/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: vanta-bridge-expert
+description: Interpret vanta-bridge normalized findings and explain the dual-install Vanta plugin plus GRC Engineering bridge workflow.
+license: MIT
+---
+
+# Vanta Bridge Expert
+
+Use this skill when reviewing Findings produced by `vanta-bridge`.
+
+## Bridge Model
+
+`vanta-bridge` does not implement Vanta's MCP server and does not vendor Vanta's Claude Code plugin. Users install Vanta's official plugin, export or provide MCP output, and this bridge normalizes that output into Finding schema v1.
+
+## Output Shape
+
+Findings are written to:
+
+```text
+~/.cache/claude-grc/findings/vanta-bridge/<run_id>.json
+```
+
+Resource types include:
+
+- `vanta_test_entity`
+- `vanta_control`
+- `vanta_vulnerability`
+
+## Review Guidance
+
+- Prefer `SCF` evaluations when the input includes `scf_control_id`.
+- Fall back to framework-native IDs such as `SOC2-TSC-2017` or `ISO-27001-2022` when no SCF mapping is present.
+- Treat missing collections in the input as an export coverage issue, not a Vanta compliance result.
+- Preserve Vanta IDs and URLs in evidence references for audit traceability.

--- a/tests/fixtures/findings/vanta-bridge/001-test-pass.json
+++ b/tests/fixtures/findings/vanta-bridge/001-test-pass.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "vanta-bridge",
+  "source_version": "0.1.0",
+  "run_id": "fixture-vanta-pass",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "vanta_test_entity",
+    "id": "aws-s3-prod",
+    "uri": null,
+    "region": null,
+    "account_id": "vanta"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "DCH-01.2",
+      "status": "pass",
+      "severity": "info",
+      "message": "Vanta test 'S3 public access blocked' normalized as pass."
+    }
+  ]
+}

--- a/tests/fixtures/findings/vanta-bridge/002-control-fail.json
+++ b/tests/fixtures/findings/vanta-bridge/002-control-fail.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "1.0.0",
+  "source": "vanta-bridge",
+  "source_version": "0.1.0",
+  "run_id": "fixture-vanta-fail",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "vanta_control",
+    "id": "ctrl-123",
+    "uri": null,
+    "region": null,
+    "account_id": "vanta"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SOC2-TSC-2017",
+      "control_id": "CC6.1",
+      "status": "fail",
+      "severity": "high",
+      "message": "Vanta control 'Logical access' has failing or incomplete linked tests.",
+      "evidence_refs": ["https://app.vanta.com/documents/doc-1"],
+      "remediation": {
+        "summary": "Review linked Vanta tests and documents, then refresh evidence or remediate the control gap.",
+        "ref": "grc-engineer://generate-implementation/vanta_bridge",
+        "effort_hours": 1,
+        "automation": "manual"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/findings/vanta-bridge/003-empty-inconclusive.json
+++ b/tests/fixtures/findings/vanta-bridge/003-empty-inconclusive.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "vanta-bridge",
+  "source_version": "0.1.0",
+  "run_id": "fixture-vanta-inconclusive",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "vanta_export",
+    "id": "empty.json",
+    "uri": null,
+    "region": null,
+    "account_id": "vanta"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "GOV-03",
+      "status": "inconclusive",
+      "severity": "info",
+      "message": "Vanta bridge input did not contain tests, controls, or vulnerabilities collections."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #44.\n\n## Summary\n- Adds vanta-bridge under plugins/bridges as a normalization layer for Vanta MCP/plugin JSON output.\n- Provides setup/status/sync commands that document the dual-install pattern with Vanta's official plugin and write normalized Findings to the shared cache.\n- Normalizes Vanta tests, controls, documents, and vulnerabilities into Finding schema v1 and adds pass, fail, and inconclusive fixtures.\n\n## Validation\n- git diff --check\n- node --check plugins/bridges/vanta-bridge/scripts/sync.js\n- bash -n plugins/bridges/vanta-bridge/scripts/setup.sh plugins/bridges/vanta-bridge/scripts/status.sh\n- npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh\n- npm run test:contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced vanta-bridge plugin for normalizing Vanta compliance data into standardized formats
  * Added setup command to configure bridge region and verify Vanta plugin availability
  * Added status command to display bridge configuration and cache freshness
  * Added sync command to normalize Vanta tests, controls, and vulnerabilities

* **Documentation**
  * Added command reference guides and expert interpretation guidance

* **Tests**
  * Added validation test fixtures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->