### PR TITLE
[codex] Add CrowdStrike inspector connector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -215,6 +215,12 @@
       "version": "0.1.0"
     },
     {
+      "name": "crowdstrike-inspector",
+      "source": "./plugins/connectors/crowdstrike-inspector",
+      "description": "GRC connector for CrowdStrike Falcon: sensor coverage, policies, and host-group scoping to v1 finding contract",
+      "version": "0.1.0"
+    },
+    {
       "name": "drata-inspector",
       "source": "./plugins/connectors/drata-inspector",
       "description": "GRC connector for Drata: wraps drata-cli workflows and normalizes compliance posture to v1 finding contract",

--- a/plugins/connectors/crowdstrike-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/crowdstrike-inspector/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "crowdstrike-inspector",
+  "version": "0.1.0",
+  "description": "GRC connector for CrowdStrike Falcon: evaluates sensor coverage, detection/prevention policy visibility, and host-group scoping. Emits findings conforming to schemas/finding.schema.json v1.",
+  "author": { "name": "GRC Engineering Club Contributors" },
+  "license": "MIT",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "keywords": ["grc", "compliance", "crowdstrike", "falcon", "endpoint", "scf", "connector"]
+}

--- a/plugins/connectors/crowdstrike-inspector/commands/collect.md
+++ b/plugins/connectors/crowdstrike-inspector/commands/collect.md
@@ -1,0 +1,20 @@
+# /crowdstrike-inspector:collect
+
+Collect CrowdStrike Falcon endpoint posture and write Finding documents to:
+
+```text
+~/.cache/claude-grc/findings/crowdstrike-inspector/<run_id>.json
+```
+
+Coverage:
+
+- Sensor coverage and stale/offline hosts
+- Detection policy visibility
+- Prevention policy visibility
+- Host-group scoping visibility
+
+Options:
+
+- `--output=summary|json|silent`
+- `--quiet`
+- `--limit=<n>` host ID cap for the first release. Default: `100`

--- a/plugins/connectors/crowdstrike-inspector/commands/setup.md
+++ b/plugins/connectors/crowdstrike-inspector/commands/setup.md
@@ -1,0 +1,28 @@
+# /crowdstrike-inspector:setup
+
+Configure `crowdstrike-inspector` for CrowdStrike Falcon API access.
+
+```bash
+plugins/connectors/crowdstrike-inspector/scripts/setup.sh --client-id=<id> --client-secret=<secret>
+```
+
+Config is written to:
+
+```text
+~/.config/claude-grc/connectors/crowdstrike-inspector.yaml
+```
+
+Secrets are stored separately with user-only file permissions.
+
+## Options
+
+- `--client-id=<id>` or `FALCON_CLIENT_ID`
+- `--client-secret=<secret>` or `FALCON_CLIENT_SECRET`
+- `--base-url=<url>` defaults to `https://api.crowdstrike.com`
+
+## Next
+
+```text
+/crowdstrike-inspector:collect
+/crowdstrike-inspector:status
+```

--- a/plugins/connectors/crowdstrike-inspector/commands/status.md
+++ b/plugins/connectors/crowdstrike-inspector/commands/status.md
@@ -1,0 +1,7 @@
+# /crowdstrike-inspector:status
+
+Show Falcon API auth validity and latest cache freshness.
+
+```bash
+plugins/connectors/crowdstrike-inspector/scripts/status.sh
+```

--- a/plugins/connectors/crowdstrike-inspector/scripts/collect.js
+++ b/plugins/connectors/crowdstrike-inspector/scripts/collect.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+
+const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'connectors', 'crowdstrike-inspector.yaml');
+const ENV_FILE = path.join(CONFIG_DIR, 'connectors', 'crowdstrike-inspector.env');
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'crowdstrike-inspector');
+const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
+const SOURCE = 'crowdstrike-inspector';
+const SOURCE_VERSION = '0.1.0';
+const EXIT = { OK: 0, USAGE: 2, AUTH: 2, PARTIAL: 4, NOT_CONFIGURED: 5 };
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  let config;
+  try { config = parseYaml(await fs.readFile(CONFIG_FILE, 'utf8')); }
+  catch { fail(EXIT.NOT_CONFIGURED, `config missing (${CONFIG_FILE}). Run /crowdstrike-inspector:setup first.`); }
+  const env = await loadEnv();
+  const baseUrl = config.base_url || process.env.FALCON_BASE_URL || 'https://api.crowdstrike.com';
+  const clientId = process.env.FALCON_CLIENT_ID || env.FALCON_CLIENT_ID;
+  const clientSecret = process.env.FALCON_CLIENT_SECRET || env.FALCON_CLIENT_SECRET;
+  const limit = args.limit || config.defaults?.limit || 100;
+  if (!clientId || !clientSecret) fail(EXIT.AUTH, 'missing Falcon client id/secret.');
+
+  const token = await getToken(baseUrl, clientId, clientSecret);
+  const runId = makeRunId();
+  const collectedAt = new Date().toISOString();
+  const startedAt = Date.now();
+  const errors = [];
+  const findings = [];
+
+  const hostIds = await probe(baseUrl, `/devices/queries/devices/v1?limit=${limit}`, token);
+  if (hostIds.ok) {
+    const ids = hostIds.raw?.resources || [];
+    const details = ids.length ? await probe(baseUrl, `/devices/entities/devices/v2?ids=${ids.map(encodeURIComponent).join('&ids=')}`, token) : { ok: true, raw: { resources: [] } };
+    if (details.ok) {
+      for (const host of details.raw?.resources || []) findings.push(hostFinding(host, { runId, collectedAt, baseUrl }));
+    } else {
+      errors.push({ endpoint: 'host-details', error: details.error });
+      findings.push(tenantFinding({ runId, collectedAt, baseUrl }, [inconclusive('END-03', `Falcon host details could not be read: ${details.error}`)], { hostIds: ids }));
+    }
+  } else {
+    errors.push({ endpoint: 'host-ids', error: hostIds.error });
+    findings.push(tenantFinding({ runId, collectedAt, baseUrl }, [inconclusive('END-03', `Falcon host inventory could not be read: ${hostIds.error}`)], { hostIds: hostIds.raw }));
+  }
+
+  for (const [name, endpoint, control] of [
+    ['prevention policies', '/policy/queries/prevention/v1?limit=1', 'CFG-02'],
+    ['detection policies', '/policy/queries/detection-suppression/v1?limit=1', 'MON-01.2'],
+    ['host groups', '/devices/queries/host-groups/v1?limit=1', 'AST-02']
+  ]) {
+    const res = await probe(baseUrl, endpoint, token);
+    findings.push(tenantFinding({ runId, collectedAt, baseUrl }, [
+      res.ok ? pass(control, `CrowdStrike ${name} endpoint is available for review.`) : inconclusive(control, `CrowdStrike ${name} could not be evaluated: ${res.error}`)
+    ], { [name.replaceAll(' ', '_')]: res.raw }));
+    if (!res.ok) errors.push({ endpoint: name, error: res.error });
+  }
+
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  const cachePath = path.join(CACHE_DIR, `${runId}.json`);
+  await fs.writeFile(cachePath, JSON.stringify(findings, null, 2));
+  const counters = { pass: 0, fail: 0, inconclusive: 0, not_applicable: 0, skipped: 0 };
+  const severities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  const failingSeverities = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const doc of findings) for (const ev of doc.evaluations) {
+    counters[ev.status] = (counters[ev.status] || 0) + 1;
+    if (ev.severity) severities[ev.severity] = (severities[ev.severity] || 0) + 1;
+    if (ev.status === 'fail' && ev.severity) failingSeverities[ev.severity] = (failingSeverities[ev.severity] || 0) + 1;
+  }
+  const manifest = { source: SOURCE, run_id: runId, started_at: new Date(startedAt).toISOString(), duration_ms: Date.now() - startedAt, scope: baseUrl, resources: findings.length, evaluations: findings.reduce((n, d) => n + d.evaluations.length, 0), counters, severities, failing_severities: failingSeverities, errors: errors.length };
+  await fs.appendFile(RUNS_LOG, JSON.stringify(manifest) + '\n');
+  if (args.output === 'json') process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, summary: manifest }, null, 2) + '\n');
+  else if (args.output !== 'silent') process.stdout.write(`${SOURCE}: ${findings.length} resources, ${manifest.evaluations} evaluations, ${counters.fail || 0} failing.\n`);
+  process.exit(errors.length ? EXIT.PARTIAL : EXIT.OK);
+}
+
+function hostFinding(host, ctx) {
+  const stale = host.last_seen ? (Date.now() - Date.parse(host.last_seen)) / 86400000 > 7 : true;
+  const status = String(host.status || '').toLowerCase();
+  const ev = stale || status.includes('offline')
+    ? failHigh('END-03', `Falcon host '${host.hostname || host.device_id}' has stale/offline sensor telemetry.`, 'Restore Falcon sensor coverage or formally retire the endpoint from inventory.')
+    : pass('END-03', `Falcon host '${host.hostname || host.device_id}' has recent sensor telemetry.`);
+  return doc(ctx, 'crowdstrike_host', host.device_id || host.id || host.hostname, [ev], { host }, { hostname: host.hostname || null, platform: host.platform_name || null });
+}
+
+function tenantFinding(ctx, evaluations, raw) {
+  return doc(ctx, 'crowdstrike_tenant', ctx.baseUrl, evaluations, raw, {});
+}
+
+function doc(ctx, type, id, evaluations, raw, metadata) {
+  return { schema_version: '1.0.0', source: SOURCE, source_version: SOURCE_VERSION, run_id: ctx.runId, collected_at: ctx.collectedAt, resource: { type, id: String(id), uri: ctx.baseUrl, region: null, account_id: ctx.baseUrl }, evaluations, raw_attributes: raw, metadata };
+}
+
+async function getToken(baseUrl, clientId, clientSecret) {
+  const body = new URLSearchParams({ client_id: clientId, client_secret: clientSecret });
+  const response = await fetch(`${baseUrl.replace(/\/$/, '')}/oauth2/token`, { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || !json.access_token) fail(EXIT.AUTH, json.errors?.[0]?.message || json.error || `Falcon auth failed: ${response.status}`);
+  return json.access_token;
+}
+
+async function probe(baseUrl, endpoint, token) {
+  try {
+    const response = await fetch(`${baseUrl.replace(/\/$/, '')}${endpoint}`, { headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' } });
+    const raw = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(raw.errors?.[0]?.message || raw.error || `http_${response.status}`);
+    return { ok: true, raw, error: null };
+  } catch (err) {
+    return { ok: false, raw: null, error: err.message };
+  }
+}
+
+async function loadEnv() {
+  try {
+    const text = await fs.readFile(ENV_FILE, 'utf8');
+    return Object.fromEntries(text.split(/\r?\n/).map(l => l.match(/^([A-Z0-9_]+)="?(.*?)"?$/)).filter(Boolean).map(m => [m[1], m[2]]));
+  } catch { return {}; }
+}
+
+function parseArgs(argv) {
+  const out = { output: 'summary', quiet: false, limit: 0 };
+  for (const tok of argv) {
+    if (!tok.startsWith('--')) continue;
+    const [k, v] = tok.slice(2).split('=');
+    if (k === 'output' && ['summary', 'json', 'silent'].includes(v)) out.output = v;
+    else if (k === 'quiet') out.quiet = true;
+    else if (k === 'limit') out.limit = parseInt(v, 10);
+    else fail(EXIT.USAGE, `Unknown flag: --${k}`);
+  }
+  return out;
+}
+
+function pass(controlId, message) { return { control_framework: 'SCF', control_id: controlId, status: 'pass', severity: 'info', message }; }
+function inconclusive(controlId, message) { return { control_framework: 'SCF', control_id: controlId, status: 'inconclusive', severity: 'info', message }; }
+function failHigh(controlId, message, summary) { return { control_framework: 'SCF', control_id: controlId, status: 'fail', severity: 'high', message, remediation: { summary, ref: 'grc-engineer://generate-implementation/crowdstrike_sensor_coverage', effort_hours: 1, automation: 'manual' } }; }
+function parseYaml(text) {
+  const out = {};
+  for (const line of text.split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*"?([^"]*)"?$/);
+    if (m) out[m[1]] = /^\d+$/.test(m[2]) ? Number(m[2]) : m[2];
+  }
+  return out;
+}
+function makeRunId() { return `${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}-${crypto.randomBytes(4).toString('hex')}`; }
+function fail(code, msg) { process.stderr.write(`[${SOURCE}] ${msg}\n`); process.exit(code); }
+main(process.argv.slice(2)).catch(err => { process.stderr.write(`[${SOURCE}] unhandled error: ${err.stack || err.message}\n`); process.exit(1); });

--- a/plugins/connectors/crowdstrike-inspector/scripts/setup.sh
+++ b/plugins/connectors/crowdstrike-inspector/scripts/setup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors"
+CONFIG_FILE="$CONFIG_DIR/crowdstrike-inspector.yaml"
+ENV_FILE="$CONFIG_DIR/crowdstrike-inspector.env"
+BASE_URL="${FALCON_BASE_URL:-https://api.crowdstrike.com}"
+CLIENT_ID="${FALCON_CLIENT_ID:-}"
+CLIENT_SECRET="${FALCON_CLIENT_SECRET:-}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --base-url=*) BASE_URL="${arg#*=}" ;;
+    --client-id=*) CLIENT_ID="${arg#*=}" ;;
+    --client-secret=*) CLIENT_SECRET="${arg#*=}" ;;
+    *) echo "[crowdstrike-inspector:setup] unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]; then
+  echo "[crowdstrike-inspector:setup] missing client id/secret." >&2
+  exit 2
+fi
+
+AUTH_JSON=$(node - "$BASE_URL" "$CLIENT_ID" "$CLIENT_SECRET" <<'NODE'
+const [baseUrl, id, secret] = process.argv.slice(2);
+const body = new URLSearchParams({ client_id: id, client_secret: secret });
+const result = await fetch(`${baseUrl.replace(/\/$/, '')}/oauth2/token`, {
+  method: 'POST',
+  headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
+  body
+}).then(async r => ({ status: r.status, body: await r.json().catch(() => ({})) })).catch(err => ({ status: 0, body: { error: err.message } }));
+console.log(JSON.stringify(result));
+NODE
+)
+
+STATUS=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.status)" "$AUTH_JSON")
+if [[ "$STATUS" != "201" && "$STATUS" != "200" ]]; then
+  ERR=$(node -e "const d=JSON.parse(process.argv[1]); console.log(d.body?.errors?.[0]?.message || d.body?.error || ('http_' + d.status))" "$AUTH_JSON")
+  echo "[crowdstrike-inspector:setup] Falcon auth failed: $ERR" >&2
+  exit 2
+fi
+
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_FILE" <<EOF
+version: 1
+source: crowdstrike-inspector
+source_version: "0.1.0"
+base_url: "$BASE_URL"
+defaults:
+  limit: 100
+EOF
+umask 077
+cat > "$ENV_FILE" <<EOF
+FALCON_CLIENT_ID="$CLIENT_ID"
+FALCON_CLIENT_SECRET="$CLIENT_SECRET"
+EOF
+mkdir -p "$HOME/.cache/claude-grc/findings/crowdstrike-inspector"
+touch "$HOME/.cache/claude-grc/runs.log"
+printf 'crowdstrike-inspector:setup ok\n  base_url: %s\n  config:   %s\n' "$BASE_URL" "$CONFIG_FILE"

--- a/plugins/connectors/crowdstrike-inspector/scripts/status.sh
+++ b/plugins/connectors/crowdstrike-inspector/scripts/status.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+CONFIG_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors/crowdstrike-inspector.yaml"
+ENV_FILE="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors/crowdstrike-inspector.env"
+CACHE_DIR="$HOME/.cache/claude-grc/findings/crowdstrike-inspector"
+printf 'crowdstrike-inspector\n'
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  printf '  status:        not-configured\n'
+  exit 2
+fi
+
+BASE_URL=$(awk -F'"' '/^base_url:/ {print $2; exit}' "$CONFIG_FILE")
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+if [[ -z "${FALCON_CLIENT_ID:-}" || -z "${FALCON_CLIENT_SECRET:-}" ]]; then
+  printf '  status:        credentials-expired\n'
+  exit 2
+fi
+
+AUTH_STATUS=$(node - "$BASE_URL" "$FALCON_CLIENT_ID" "$FALCON_CLIENT_SECRET" <<'NODE'
+const [baseUrl, id, secret] = process.argv.slice(2);
+const body = new URLSearchParams({ client_id: id, client_secret: secret });
+const result = await fetch(`${baseUrl.replace(/\/$/, '')}/oauth2/token`, { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body }).then(r => r.status).catch(() => 0);
+console.log(result);
+NODE
+)
+if [[ "$AUTH_STATUS" != "201" && "$AUTH_STATUS" != "200" ]]; then
+  printf '  status:        credentials-expired\n'
+  exit 2
+fi
+
+LATEST=$(ls -t "$CACHE_DIR"/*.json 2>/dev/null | head -1 || true)
+if [[ -z "$LATEST" ]]; then
+  printf '  status:        ready\n'
+  printf '  base_url:      %s\n' "$BASE_URL"
+  printf '  last run:      never\n'
+  exit 0
+fi
+if stat -f%m "$LATEST" >/dev/null 2>&1; then MTIME=$(stat -f%m "$LATEST"); else MTIME=$(stat -c%Y "$LATEST"); fi
+AGE_H=$(( ($(date +%s) - MTIME) / 3600 ))
+if (( AGE_H < 168 )); then STATUS="ready"; else STATUS="stale"; fi
+RES=$(node -e "try{const a=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log(Array.isArray(a)?a.length:1)}catch{console.log('?')}" "$LATEST")
+printf '  status:        %s\n' "$STATUS"
+printf '  base_url:      %s\n' "$BASE_URL"
+printf '  last run:      %sh ago (%s)\n' "$AGE_H" "$(basename "$LATEST" .json)"
+printf '  cached:        %s resources\n' "$RES"

--- a/plugins/connectors/crowdstrike-inspector/skills/crowdstrike-inspector-expert/SKILL.md
+++ b/plugins/connectors/crowdstrike-inspector/skills/crowdstrike-inspector-expert/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: crowdstrike-inspector-expert
+description: Interpret CrowdStrike Falcon findings for sensor coverage, policy visibility, and host group scoping.
+license: MIT
+---
+
+# CrowdStrike Inspector Expert
+
+Use this skill when reviewing `crowdstrike-inspector` output.
+
+Findings are written to `~/.cache/claude-grc/findings/crowdstrike-inspector/<run_id>.json`.
+
+Key SCF mappings:
+
+- `END-03`: endpoint sensor coverage
+- `CFG-02`: prevention policy visibility
+- `MON-01.2`: detection policy visibility
+- `AST-02`: host-group scoping visibility
+
+Treat `inconclusive` as an API permission or plan coverage gap, not a pass.

--- a/tests/fixtures/findings/crowdstrike-inspector/001-host-sensor-pass.json
+++ b/tests/fixtures/findings/crowdstrike-inspector/001-host-sensor-pass.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "crowdstrike-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-crowdstrike-pass",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "crowdstrike_host",
+    "id": "abc123",
+    "uri": "https://api.crowdstrike.com",
+    "region": null,
+    "account_id": "https://api.crowdstrike.com"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "END-03",
+      "status": "pass",
+      "severity": "info",
+      "message": "Falcon host 'laptop-01' has recent sensor telemetry."
+    }
+  ]
+}

--- a/tests/fixtures/findings/crowdstrike-inspector/002-host-sensor-fail.json
+++ b/tests/fixtures/findings/crowdstrike-inspector/002-host-sensor-fail.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "source": "crowdstrike-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-crowdstrike-fail",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "crowdstrike_host",
+    "id": "def456",
+    "uri": "https://api.crowdstrike.com",
+    "region": null,
+    "account_id": "https://api.crowdstrike.com"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "END-03",
+      "status": "fail",
+      "severity": "high",
+      "message": "Falcon host 'server-01' has stale/offline sensor telemetry.",
+      "remediation": {
+        "summary": "Restore Falcon sensor coverage or formally retire the endpoint from inventory.",
+        "ref": "grc-engineer://generate-implementation/crowdstrike_sensor_coverage",
+        "effort_hours": 1,
+        "automation": "manual"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/findings/crowdstrike-inspector/003-policy-inconclusive.json
+++ b/tests/fixtures/findings/crowdstrike-inspector/003-policy-inconclusive.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "crowdstrike-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-crowdstrike-inconclusive",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "crowdstrike_tenant",
+    "id": "https://api.crowdstrike.com",
+    "uri": "https://api.crowdstrike.com",
+    "region": null,
+    "account_id": "https://api.crowdstrike.com"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "CFG-02",
+      "status": "inconclusive",
+      "severity": "info",
+      "message": "CrowdStrike prevention policies could not be evaluated: insufficient permissions."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #32.\n\n## Summary\n- Adds crowdstrike-inspector as a Tier-2 connector over CrowdStrike Falcon API.\n- Evaluates host sensor telemetry, prevention/detection policy visibility, and host-group scoping visibility.\n- Registers the connector in the marketplace and adds pass, fail/high, and inconclusive contract fixtures.\n\n## Validation\n- git diff --check\n- node --check plugins/connectors/crowdstrike-inspector/scripts/collect.js\n- bash -n plugins/connectors/crowdstrike-inspector/scripts/setup.sh plugins/connectors/crowdstrike-inspector/scripts/status.sh\n- npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh\n- npm run test:contract