### PR TITLE
[codex] Stabilize lychee for PCAOB link

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -25,6 +25,7 @@ exclude = [
   "^https://github\\.com/orgs/.*/projects/",
   # Some regulator sites return 5xx to scrapers but render fine in browsers
   "^https://www\\.ecfr\\.gov",
+  "^https://pcaobus\\.org/oversight/standards/auditing-standards$",
   # canada.ca returns HTTP/2 protocol errors to lychee's client; renders fine in browsers
   "^https://www\\.canada\\.ca",
   # Upstream external repo was transferred to hackIDLE; both URLs should be updated in a docs pass


### PR DESCRIPTION
## Summary

Lychee is failing on the existing PCAOB auditing standards URL with HTTP 522 even though this is an external regulator-site availability/scraper issue, not a docs regression.

Adds that exact URL to the existing regulator-site exclusion list so unrelated PRs are not blocked.

## Validation

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link-checker configuration to exclude a specific standards reference URL from validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->