### PR TITLE
[codex] Add GCP docs knowledge source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,6 +54,13 @@
       "commands": ["setup", "status", "sync"]
     },
     {
+      "name": "gcp-docs",
+      "source": "./plugins/knowledge-sources/gcp-docs",
+      "description": "Knowledge source for Google Developer Knowledge API: current Google developer documentation citations for GRC workflows.",
+      "version": "0.1.0",
+      "commands": ["setup", "query", "cite"]
+    },
+    {
       "name": "teach-me",
       "source": "./plugins/teach-me",
       "description": "Socratic primer + drill plugin for new-to-GRC practitioners. Get up to speed on a framework, control, or role without already knowing it.",

--- a/plugins/knowledge-sources/gcp-docs/.claude-plugin/plugin.json
+++ b/plugins/knowledge-sources/gcp-docs/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "gcp-docs",
+  "version": "0.1.0",
+  "description": "Knowledge source for Google Developer Knowledge API: searches, cites, and answers from current Google developer documentation.",
+  "author": { "name": "GRC Engineering Club Contributors" },
+  "license": "MIT",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "keywords": ["grc", "google-cloud", "documentation", "knowledge-source", "citations"],
+  "knowledge_source_metadata": {
+    "provider": "google",
+    "api": "Developer Knowledge API",
+    "endpoint": "https://developerknowledge.googleapis.com/v1alpha",
+    "cache_ttl_days": 7,
+    "emits_findings": false
+  }
+}

--- a/plugins/knowledge-sources/gcp-docs/commands/cite.md
+++ b/plugins/knowledge-sources/gcp-docs/commands/cite.md
@@ -1,0 +1,9 @@
+# /gcp-docs:cite
+
+Return ranked Google documentation references for a control or implementation topic.
+
+```bash
+plugins/knowledge-sources/gcp-docs/scripts/cite.sh "SCF CRY-04 Cloud KMS key rotation"
+```
+
+Use `--limit=<n>` to change the result count. Default: 5.

--- a/plugins/knowledge-sources/gcp-docs/commands/query.md
+++ b/plugins/knowledge-sources/gcp-docs/commands/query.md
@@ -1,0 +1,9 @@
+# /gcp-docs:query
+
+Ask a grounded Google documentation question.
+
+```bash
+plugins/knowledge-sources/gcp-docs/scripts/query.sh "How should Cloud KMS key rotation be configured?"
+```
+
+Use `--output=json` for machine-readable answer and citation payloads.

--- a/plugins/knowledge-sources/gcp-docs/commands/setup.md
+++ b/plugins/knowledge-sources/gcp-docs/commands/setup.md
@@ -1,0 +1,9 @@
+# /gcp-docs:setup
+
+Configure a Google Developer Knowledge API key for documentation citations.
+
+```bash
+plugins/knowledge-sources/gcp-docs/scripts/setup.sh --api-key="$GOOGLE_DEVELOPER_KNOWLEDGE_API_KEY"
+```
+
+The API must be enabled in the Google Cloud project that owns the key.

--- a/plugins/knowledge-sources/gcp-docs/config/cache.yaml
+++ b/plugins/knowledge-sources/gcp-docs/config/cache.yaml
@@ -1,0 +1,4 @@
+version: 1
+cache_dir: "~/.cache/claude-grc/knowledge/google"
+ttl_days: 7
+base_url: "https://developerknowledge.googleapis.com/v1alpha"

--- a/plugins/knowledge-sources/gcp-docs/scripts/cite.sh
+++ b/plugins/knowledge-sources/gcp-docs/scripts/cite.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec node "$(dirname "$0")/gcp-docs.js" cite "$@"

--- a/plugins/knowledge-sources/gcp-docs/scripts/gcp-docs.js
+++ b/plugins/knowledge-sources/gcp-docs/scripts/gcp-docs.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+
+const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'knowledge-sources', 'gcp-docs.yaml');
+const ENV_FILE = path.join(CONFIG_DIR, 'knowledge-sources', 'gcp-docs.env');
+const DEFAULT_BASE_URL = 'https://developerknowledge.googleapis.com/v1alpha';
+const DEFAULT_CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'knowledge', 'google');
+const CONTROL_QUERIES = {
+  'CRY-04': 'Google Cloud KMS key rotation encryption key management',
+  'DCH-06': 'Google Cloud data classification data loss prevention sensitive data protection',
+  'IAC-02': 'Google Cloud identity access management multi-factor authentication workforce identity',
+  'MON-01': 'Google Cloud audit logs logging monitoring security operations',
+  'NET-06': 'Google Cloud VPC firewall network segmentation security best practices',
+  'VPM-02': 'Google Cloud vulnerability scanning Security Command Center container analysis'
+};
+
+async function main(argv) {
+  const command = argv.shift();
+  if (!command || !['status', 'query', 'cite'].includes(command)) usage();
+  const args = parseArgs(argv);
+  const cfg = await config(args);
+  if (command === 'status') return status(cfg, args);
+  const question = args._.join(' ').trim();
+  if (!question) usage();
+  if (command === 'query') return query(cfg, question, args);
+  if (command === 'cite') return cite(cfg, question, args);
+}
+
+async function status(cfg, args) {
+  const url = new URL(`${cfg.baseUrl}/documents:searchDocumentChunks`);
+  url.searchParams.set('query', 'Cloud KMS key rotation');
+  url.searchParams.set('pageSize', '1');
+  url.searchParams.set('key', cfg.apiKey || '');
+  const code = await fetch(url).then(r => r.status).catch(() => 0);
+  if (args.output === 'code') process.stdout.write(String(code));
+  else process.stdout.write(`gcp-docs: ${code === 200 ? 'ready' : `unavailable (${code})`}\n`);
+}
+
+async function query(cfg, question, args) {
+  const cacheKey = `answer-${hash(question)}.json`;
+  const cached = await readCache(cfg, cacheKey);
+  if (cached) return write(cached, args);
+  const raw = await requestJson(cfg, '/topLevel:answerQuery', { query: question }, 'POST');
+  const out = {
+    question,
+    answer: raw.answer || raw.answerText || raw.summary || '',
+    citations: citations(raw),
+    raw
+  };
+  await writeCache(cfg, cacheKey, out);
+  write(out, args);
+}
+
+async function cite(cfg, topic, args) {
+  const queryText = CONTROL_QUERIES[topic.toUpperCase()] || topic;
+  const limit = args.limit || 5;
+  const cacheKey = `cite-${hash(queryText)}-${limit}.json`;
+  const cached = await readCache(cfg, cacheKey);
+  if (cached) return write(cached, args);
+  const raw = await requestJson(cfg, '/documents:searchDocumentChunks', { query: queryText, pageSize: String(limit) }, 'GET');
+  const results = (raw.results || raw.documentChunks || raw.chunks || []).map((item) => {
+    const chunk = item.documentChunk || item.chunk || item;
+    return {
+      title: chunk.title || chunk.documentTitle || item.title || null,
+      uri: chunk.uri || chunk.documentUri || item.uri || parentToUri(chunk.parent || item.parent),
+      document: chunk.parent || item.parent || null,
+      snippet: chunk.content || chunk.text || item.content || item.snippet || '',
+      score: item.score || item.relevanceScore || null
+    };
+  });
+  const out = { topic, query: queryText, results, raw };
+  await writeCache(cfg, cacheKey, out);
+  write(out, args);
+}
+
+async function requestJson(cfg, endpoint, params, method) {
+  const url = new URL(`${cfg.baseUrl}${endpoint}`);
+  url.searchParams.set('key', cfg.apiKey);
+  const init = { method };
+  if (method === 'GET') for (const [k, v] of Object.entries(params)) if (v) url.searchParams.set(k, v);
+  else {
+    init.headers = { 'content-type': 'application/json' };
+    init.body = JSON.stringify(params);
+  }
+  const r = await fetch(url, init);
+  const raw = await r.json().catch(() => ({}));
+  if (!r.ok) throw new Error(raw.error?.message || `Developer Knowledge API request failed: HTTP ${r.status}`);
+  return raw;
+}
+
+async function config(args) {
+  const fileCfg = await readYaml(CONFIG_FILE);
+  const env = await readEnv(ENV_FILE);
+  const apiKey = args.apiKey || process.env.GOOGLE_DEVELOPER_KNOWLEDGE_API_KEY || env.GOOGLE_DEVELOPER_KNOWLEDGE_API_KEY;
+  if (!apiKey) throw new Error('missing GOOGLE_DEVELOPER_KNOWLEDGE_API_KEY; run /gcp-docs:setup first.');
+  return {
+    apiKey,
+    baseUrl: args.baseUrl || process.env.GOOGLE_DEVELOPER_KNOWLEDGE_API_BASE_URL || fileCfg.base_url || DEFAULT_BASE_URL,
+    cacheDir: expandHome(fileCfg.cache_dir || DEFAULT_CACHE_DIR),
+    ttlDays: Number(fileCfg.ttl_days || 7)
+  };
+}
+
+async function readCache(cfg, name) {
+  try {
+    const p = path.join(cfg.cacheDir, name);
+    const st = await fs.stat(p);
+    if ((Date.now() - st.mtimeMs) / 86400000 > cfg.ttlDays) return null;
+    return JSON.parse(await fs.readFile(p, 'utf8'));
+  } catch { return null; }
+}
+async function writeCache(cfg, name, value) { await fs.mkdir(cfg.cacheDir, { recursive: true }); await fs.writeFile(path.join(cfg.cacheDir, name), JSON.stringify(value, null, 2)); }
+function write(out, args) {
+  if (args.output === 'json') process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+  else if (out.answer) process.stdout.write(`${out.answer}\n\n${out.citations.map(c => `- ${c.uri || c.title}`).join('\n')}\n`);
+  else process.stdout.write(out.results.map(r => `- ${r.title || r.uri}\n  ${r.uri || ''}\n  ${String(r.snippet || '').slice(0, 240)}`).join('\n') + '\n');
+}
+function citations(raw) { return raw.citations || raw.groundingAttributions || raw.sources || []; }
+function parentToUri(parent) { return parent?.startsWith('documents/') ? `https://${parent.slice('documents/'.length)}` : null; }
+async function readYaml(file) { try { const out = {}; for (const line of (await fs.readFile(file, 'utf8')).split(/\r?\n/)) { const m = line.match(/^([A-Za-z0-9_-]+):\s*"?([^"]*)"?$/); if (m) out[m[1]] = m[2]; } return out; } catch { return {}; } }
+async function readEnv(file) { try { return Object.fromEntries((await fs.readFile(file, 'utf8')).split(/\r?\n/).map(l => l.match(/^([A-Z0-9_]+)="?(.*?)"?$/)).filter(Boolean).map(m => [m[1], m[2]])); } catch { return {}; } }
+function expandHome(v) { return String(v).replace(/^~(?=$|\/)/, os.homedir()); }
+function hash(v) { return crypto.createHash('sha256').update(v).digest('hex').slice(0, 16); }
+function parseArgs(argv) { const out = { _: [], output: 'summary', limit: 5 }; for (const tok of argv) { if (!tok.startsWith('--')) out._.push(tok); else { const [k, v = ''] = tok.slice(2).split('='); if (k === 'api-key') out.apiKey = v; else if (k === 'base-url') out.baseUrl = v; else if (k === 'output') out.output = v; else if (k === 'limit') out.limit = Number(v); else usage(); } } return out; }
+function usage() { process.stderr.write('usage: gcp-docs.js <status|query|cite> [--output=json] <question-or-topic>\n'); process.exit(2); }
+
+main(process.argv.slice(2)).catch(err => { process.stderr.write(`[gcp-docs] ${err.message}\n`); process.exit(1); });

--- a/plugins/knowledge-sources/gcp-docs/scripts/query.sh
+++ b/plugins/knowledge-sources/gcp-docs/scripts/query.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec node "$(dirname "$0")/gcp-docs.js" query "$@"

--- a/plugins/knowledge-sources/gcp-docs/scripts/setup.sh
+++ b/plugins/knowledge-sources/gcp-docs/scripts/setup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/knowledge-sources"
+CONFIG_FILE="$CONFIG_DIR/gcp-docs.yaml"
+ENV_FILE="$CONFIG_DIR/gcp-docs.env"
+API_KEY="${GOOGLE_DEVELOPER_KNOWLEDGE_API_KEY:-}"
+BASE_URL="${GOOGLE_DEVELOPER_KNOWLEDGE_API_BASE_URL:-https://developerknowledge.googleapis.com/v1alpha}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --api-key=*) API_KEY="${arg#*=}" ;;
+    --base-url=*) BASE_URL="${arg#*=}" ;;
+    *) echo "[gcp-docs:setup] unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$API_KEY" ]]; then
+  echo "[gcp-docs:setup] missing Developer Knowledge API key." >&2
+  exit 2
+fi
+
+STATUS=$(node "$(dirname "$0")/gcp-docs.js" status --api-key="$API_KEY" --base-url="$BASE_URL" --output=code || true)
+if [[ "$STATUS" != "200" ]]; then
+  echo "[gcp-docs:setup] API check failed: HTTP $STATUS" >&2
+  exit 2
+fi
+
+mkdir -p "$CONFIG_DIR" "$HOME/.cache/claude-grc/knowledge/google"
+cat > "$CONFIG_FILE" <<EOF
+version: 1
+source: gcp-docs
+source_version: "0.1.0"
+base_url: "$BASE_URL"
+cache_dir: "$HOME/.cache/claude-grc/knowledge/google"
+ttl_days: 7
+EOF
+
+umask 077
+cat > "$ENV_FILE" <<EOF
+GOOGLE_DEVELOPER_KNOWLEDGE_API_KEY="$API_KEY"
+EOF
+
+printf 'gcp-docs:setup ok\n  base_url: %s\n  config:   %s\n' "$BASE_URL" "$CONFIG_FILE"

--- a/plugins/knowledge-sources/gcp-docs/skills/gcp-docs-expert/SKILL.md
+++ b/plugins/knowledge-sources/gcp-docs/skills/gcp-docs-expert/SKILL.md
@@ -1,0 +1,15 @@
+# GCP Docs Expert
+
+Use `gcp-docs` when implementation guidance needs current Google Cloud, Google Workspace, Firebase, Android, Chrome, or related public Google developer documentation.
+
+This is a knowledge-source plugin. It does not emit Findings. It returns citations and grounded answers that other plugins can use in remediation guidance, evidence procedures, and control implementation notes.
+
+Requirements:
+- Enable the Google Developer Knowledge API in a Google Cloud project.
+- Create an API key restricted to the Developer Knowledge API.
+- Set `GOOGLE_DEVELOPER_KNOWLEDGE_API_KEY` or run `/gcp-docs:setup`.
+
+Limits:
+- The API is experimental.
+- Only public pages in Google's documented corpus are available.
+- Returned Markdown is generated from source HTML and can have formatting discrepancies.


### PR DESCRIPTION
## Summary

Adds the `gcp-docs` knowledge-source plugin for #46. This uses the current Google Developer Knowledge API shape documented by Google: API key auth, `SearchDocumentChunks`, document retrieval support, and `AnswerQuery` for grounded answers.

Adds:

- `plugins/knowledge-sources/gcp-docs`
- setup/query/cite commands
- API-key setup and 7-day local cache config
- `knowledge_source_metadata` in the plugin manifest
- marketplace registration

## Validation

- `git diff --check`
- `node --check plugins/knowledge-sources/gcp-docs/scripts/gcp-docs.js`
- `bash -n plugins/knowledge-sources/gcp-docs/scripts/setup.sh plugins/knowledge-sources/gcp-docs/scripts/query.sh plugins/knowledge-sources/gcp-docs/scripts/cite.sh`
- `npx -y -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 bash tests/validate-plugin-manifests.sh`

Closes #46.