### PR TITLE
feat: add GRC draw.io diagram plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -51,20 +51,58 @@
       "source": "./plugins/bridges/vanta-bridge",
       "description": "Normalize Vanta MCP/plugin outputs into v1 Findings for GRC Engineering workflows.",
       "version": "0.1.0",
-      "commands": ["setup", "status", "sync"]
+      "commands": [
+        "setup",
+        "status",
+        "sync"
+      ]
     },
     {
       "name": "gcp-docs",
       "source": "./plugins/knowledge-sources/gcp-docs",
       "description": "Knowledge source for Google Developer Knowledge API: current Google developer documentation citations for GRC workflows.",
       "version": "0.1.0",
-      "commands": ["setup", "query", "cite"]
+      "commands": [
+        "setup",
+        "query",
+        "cite"
+      ]
     },
     {
       "name": "teach-me",
       "source": "./plugins/teach-me",
       "description": "Socratic primer + drill plugin for new-to-GRC practitioners. Get up to speed on a framework, control, or role without already knowing it.",
       "version": "0.1.0"
+    },
+    {
+      "name": "grc-diagrams",
+      "source": "./plugins/grc-diagrams",
+      "description": "Editable draw.io diagram patterns for GRC system boundaries, evidence flows, control maps, risk treatment, audits, crosswalks, TPRM, POA&M, data flows, RACI, and operating models.",
+      "version": "0.1.0",
+      "commands": [
+        "drawio",
+        "system-boundary",
+        "evidence-flow",
+        "control-map",
+        "risk-treatment",
+        "audit-workflow",
+        "framework-crosswalk",
+        "third-party-risk",
+        "poam",
+        "data-flow",
+        "shared-responsibility",
+        "raci",
+        "operating-model"
+      ],
+      "category": "workflow",
+      "tags": [
+        "drawio",
+        "diagrams",
+        "grc",
+        "audit",
+        "risk",
+        "compliance"
+      ]
     },
     {
       "name": "soc2",

--- a/.github/workflows/validate-plugin-manifests.yml
+++ b/.github/workflows/validate-plugin-manifests.yml
@@ -4,19 +4,23 @@ on:
   pull_request:
     paths:
       - 'plugins/**/plugin.json'
+      - 'plugins/grc-diagrams/**'
       - '.claude-plugin/marketplace.json'
       - 'schemas/plugin.schema.json'
       - 'schemas/marketplace.schema.json'
       - 'tests/validate-plugin-manifests.sh'
+      - 'tests/validate-grc-diagram-skills.sh'
       - '.github/workflows/validate-plugin-manifests.yml'
   push:
     branches: [main]
     paths:
       - 'plugins/**/plugin.json'
+      - 'plugins/grc-diagrams/**'
       - '.claude-plugin/marketplace.json'
       - 'schemas/plugin.schema.json'
       - 'schemas/marketplace.schema.json'
       - 'tests/validate-plugin-manifests.sh'
+      - 'tests/validate-grc-diagram-skills.sh'
       - '.github/workflows/validate-plugin-manifests.yml'
 
 concurrency:
@@ -39,3 +43,6 @@ jobs:
 
       - name: Validate every plugin and marketplace manifest
         run: bash tests/validate-plugin-manifests.sh
+
+      - name: Validate GRC diagram skills
+        run: bash tests/validate-grc-diagram-skills.sh

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The toolkit is a Claude Code plugin marketplace. Install the pieces you need:
 - Persona plugins: workflows for auditors, internal GRC teams, third-party risk, reporting, learning, and iterative GRC automation.
 - Framework plugins: reference guidance for SOC 2, NIST 800-53, ISO 27001, FedRAMP, PCI DSS, CMMC, HITRUST, CIS Controls, GDPR, DORA, HIPAA Security, regional privacy/security regimes, and more.
 - Connector plugins: thin wrappers around tools such as AWS CLI, GitHub CLI, gcloud, Azure CLI, Okta, Slack, Datadog, CrowdStrike, Drata, Splunk, Tenable, Snowflake, and POA&M automation.
+- Diagram plugins: editable draw.io system boundaries, evidence flows, control maps, risk treatment, audit workflows, framework crosswalks, TPRM, POA&M, data flows, RACI, and operating model visuals.
 - OSCAL and bridge plugins: tooling for FedRAMP/OSCAL workflows and integrations with external GRC systems.
 
 The common path is:
@@ -76,6 +77,7 @@ Using Claude Cowork instead of Claude Code? Start with [docs/CLAUDE-COWORK.md](d
 | Build audit workpapers or evidence packages | `/grc-auditor:generate-workpaper`, `/grc-engineer:collect-evidence` |
 | Generate OSCAL SSP/SAP/SAR/POA&M outputs | `/oscal:*`, `/fedramp-ssp:*` |
 | Draft leadership updates and automation coverage reports | `/report:exec-summary`, `/report:automation-coverage` |
+| Create editable GRC diagrams | `/grc-diagrams:drawio`, `/grc-diagrams:system-boundary`, `/grc-diagrams:evidence-flow`, `/grc-diagrams:control-map` |
 | Learn a framework, control, or GRC role | `/teach-me:framework`, `/teach-me:control`, `/teach-me:role`, `/teach-me:quiz` |
 
 Every command has a reference page in its plugin's `commands/` directory.
@@ -90,6 +92,7 @@ High-level categories:
 |---|---|
 | Engineering hub | `grc-engineer` |
 | Persona/workflow plugins | `grc-auditor`, `grc-internal`, `grc-tprm`, `grc-reporter`, `grc-loop`, `teach-me` |
+| Diagram plugin | `grc-diagrams` for editable draw.io GRC diagrams |
 | Framework plugins | `soc2`, `nist-800-53`, `iso27001`, `fedramp-rev5`, `fedramp-20x`, `pci-dss`, `cmmc`, `hitrust`, `cis-controls`, `gdpr`, `dora`, `us-hipaa-security`, and others |
 | Connector plugins | `aws-inspector`, `github-inspector`, `gcp-inspector`, `azure-inspector`, `okta-inspector`, `slack-inspector`, `datadog-inspector`, `crowdstrike-inspector`, `drata-inspector`, `splunk-inspector`, `tenable-inspector`, `snowflake-inspector` |
 | Bridges, dashboards, knowledge sources | `vanta-bridge`, `compliance-posture-dashboard`, `gcp-docs` |

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "scaffold-framework": "node plugins/grc-engineer/scripts/scaffold-framework.js",
     "generate-coverage": "node plugins/grc-engineer/scripts/generate-coverage.js",
     "test:contract": "bash tests/validate-contract-fixtures.sh",
+    "test:grc-diagrams": "bash tests/validate-grc-diagram-skills.sh",
     "test:contract:findings": "ajv validate --spec=draft2020 -c ajv-formats -s schemas/finding.schema.json -d 'tests/fixtures/findings/**/*.json'"
   },
   "keywords": [

--- a/plugins/grc-diagrams/.claude-plugin/plugin.json
+++ b/plugins/grc-diagrams/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "grc-diagrams",
+  "description": "Editable draw.io diagram skills for GRC system boundaries, evidence flows, control maps, risks, audits, crosswalks, TPRM, POA&M, data flows, RACI, and operating models.",
+  "version": "0.1.0",
+  "author": {
+    "name": "GRC Engineering Club Contributors"
+  },
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "keywords": [
+    "grc",
+    "drawio",
+    "diagrams",
+    "compliance",
+    "audit",
+    "risk",
+    "controls"
+  ]
+}

--- a/plugins/grc-diagrams/README.md
+++ b/plugins/grc-diagrams/README.md
@@ -1,0 +1,27 @@
+# GRC Diagrams Plugin
+
+Editable draw.io diagram patterns for GRC professionals.
+
+This plugin adds a general `/grc-diagrams:drawio` command plus focused commands for common GRC diagrams: system boundaries, evidence flows, control maps, risk treatment, audit workflows, framework crosswalks, third-party risk, POA&M, regulated data flows, shared responsibility, RACI, and compliance operating models.
+
+The skills are based on the draw.io CLI workflow from `jgraph/drawio-mcp/skill-cli`: generate native mxGraphModel XML, save `.drawio`, optionally export PNG/SVG/PDF with embedded XML, and preserve editability in draw.io.
+
+## Commands
+
+- `/grc-diagrams:drawio` - generic editable draw.io diagram generation
+- `/grc-diagrams:system-boundary` - compliance scope and authorization boundary diagrams
+- `/grc-diagrams:evidence-flow` - evidence collection and audit evidence lifecycle diagrams
+- `/grc-diagrams:control-map` - control-to-system-owner-evidence maps
+- `/grc-diagrams:risk-treatment` - risk intake, scoring, treatment, exception, and monitoring flows
+- `/grc-diagrams:audit-workflow` - audit planning through reporting and remediation workflows
+- `/grc-diagrams:framework-crosswalk` - framework/control overlap, gap, and conflict diagrams
+- `/grc-diagrams:third-party-risk` - vendor intake, tiering, review, contracting, and monitoring workflows
+- `/grc-diagrams:poam` - POA&M/finding remediation lifecycle diagrams
+- `/grc-diagrams:data-flow` - regulated data flow and classification diagrams
+- `/grc-diagrams:shared-responsibility` - cloud/SaaS responsibility split and inherited control diagrams
+- `/grc-diagrams:raci` - responsibility assignment diagrams
+- `/grc-diagrams:operating-model` - GRC program and continuous compliance operating model diagrams
+
+## Output
+
+Default output is a native `.drawio` file. If the user requests `png`, `svg`, or `pdf`, the draw.io desktop CLI should export with embedded XML so the exported artifact remains editable in draw.io.

--- a/plugins/grc-diagrams/commands/audit-workflow.md
+++ b/plugins/grc-diagrams/commands/audit-workflow.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc audit workflow diagram for GRC professionals
+---
+
+# Audit Workflow
+
+Create an editable draw.io diagram for audit planning, request lists, evidence, testing, exceptions, remediation, and reporting.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-audit-workflow-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:audit-workflow SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:audit-workflow FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:audit-workflow startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/control-map.md
+++ b/plugins/grc-diagrams/commands/control-map.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc control map diagram for GRC professionals
+---
+
+# Control Map
+
+Create an editable draw.io diagram for controls mapped across frameworks, systems, owners, risks, and evidence sources.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-control-map-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:control-map SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:control-map FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:control-map startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/data-flow.md
+++ b/plugins/grc-diagrams/commands/data-flow.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc regulated data flow diagram for GRC professionals
+---
+
+# Regulated Data Flow
+
+Create an editable draw.io diagram for regulated data flows, data classifications, storage, processing, transfer, access, retention, and logging.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-data-flow-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:data-flow SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:data-flow FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:data-flow startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/drawio.md
+++ b/plugins/grc-diagrams/commands/drawio.md
@@ -1,0 +1,28 @@
+---
+description: Create an editable native draw.io diagram, optionally exported to PNG/SVG/PDF with embedded XML
+---
+
+# Draw.io
+
+Create a native editable draw.io diagram from the user's request.
+
+## Arguments
+
+- `$ARGUMENTS` - Diagram request, context, audience, and optional output format (`png`, `svg`, `pdf`, `jpg`, or default `.drawio`).
+
+## Instructions
+
+1. Use the `drawio` skill.
+2. If the request is GRC-specific, also use the most relevant GRC diagram companion skill.
+3. Generate native mxGraphModel XML and write a `.drawio` file.
+4. Validate XML well-formedness.
+5. If an export format is requested and the draw.io CLI is available, export with embedded XML for PNG/SVG/PDF.
+6. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:drawio flowchart for access review evidence collection
+/grc-diagrams:drawio png SOC 2 system boundary for a SaaS app
+/grc-diagrams:drawio svg framework crosswalk for SOC 2, ISO 27001, and NIST CSF
+```

--- a/plugins/grc-diagrams/commands/evidence-flow.md
+++ b/plugins/grc-diagrams/commands/evidence-flow.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc evidence flow diagram for GRC professionals
+---
+
+# Evidence Flow
+
+Create an editable draw.io diagram for evidence collection, evidence lifecycle, audit evidence pipelines, and systems of record.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-evidence-flow-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:evidence-flow SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:evidence-flow FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:evidence-flow startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/framework-crosswalk.md
+++ b/plugins/grc-diagrams/commands/framework-crosswalk.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc framework crosswalk diagram for GRC professionals
+---
+
+# Framework Crosswalk
+
+Create an editable draw.io diagram for mapping controls and obligations across frameworks to show overlap, gaps, and conflicts.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-framework-crosswalk-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:framework-crosswalk SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:framework-crosswalk FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:framework-crosswalk startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/operating-model.md
+++ b/plugins/grc-diagrams/commands/operating-model.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc compliance operating model diagram for GRC professionals
+---
+
+# Compliance Operating Model
+
+Create an editable draw.io diagram for high-level GRC program architecture, continuous compliance operating models, three lines of defense, and executive program maps.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-compliance-operating-model-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:operating-model SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:operating-model FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:operating-model startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/poam.md
+++ b/plugins/grc-diagrams/commands/poam.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc poa&m lifecycle diagram for GRC professionals
+---
+
+# Poa&M Lifecycle
+
+Create an editable draw.io diagram for POA&M items, audit findings, remediation milestones, validation, closure, and escalation paths.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-poam-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:poam SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:poam FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:poam startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/raci.md
+++ b/plugins/grc-diagrams/commands/raci.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc raci diagram for GRC professionals
+---
+
+# Raci
+
+Create an editable draw.io diagram for responsibility assignments across GRC, security, engineering, legal, HR, procurement, vendors, and auditors.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-raci-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:raci SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:raci FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:raci startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/risk-treatment.md
+++ b/plugins/grc-diagrams/commands/risk-treatment.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc risk treatment diagram for GRC professionals
+---
+
+# Risk Treatment
+
+Create an editable draw.io diagram for risk intake, scoring, treatment, exception approval, residual risk, and monitoring workflows.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-risk-treatment-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:risk-treatment SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:risk-treatment FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:risk-treatment startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/shared-responsibility.md
+++ b/plugins/grc-diagrams/commands/shared-responsibility.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc shared responsibility diagram for GRC professionals
+---
+
+# Shared Responsibility
+
+Create an editable draw.io diagram for cloud/SaaS shared responsibility, inherited controls, provider controls, customer controls, and evidence ownership.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-shared-responsibility-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:shared-responsibility SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:shared-responsibility FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:shared-responsibility startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/system-boundary.md
+++ b/plugins/grc-diagrams/commands/system-boundary.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc system boundary diagram for GRC professionals
+---
+
+# System Boundary
+
+Create an editable draw.io diagram for compliance scope, authorization boundaries, trust boundaries, in-scope/out-of-scope systems, and system context diagrams.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-system-boundary-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:system-boundary SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:system-boundary FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:system-boundary startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/commands/third-party-risk.md
+++ b/plugins/grc-diagrams/commands/third-party-risk.md
@@ -1,0 +1,27 @@
+---
+description: Create an editable draw.io grc third-party risk diagram for GRC professionals
+---
+
+# Third-Party Risk
+
+Create an editable draw.io diagram for vendor intake, tiering, questionnaires, security/privacy/legal review, contracting, and ongoing monitoring.
+
+## Arguments
+
+- `$ARGUMENTS` - Scope, framework(s), system(s), audience, and optional export format such as `png`, `svg`, or `pdf`.
+
+## Instructions
+
+1. Use the `grc-third-party-risk-diagram` skill to structure the GRC-specific content.
+2. Use the `drawio` skill to generate the native `.drawio` file.
+3. Include owners, control IDs, evidence sources, systems, risks, scope boundaries, and decision points when relevant.
+4. If the user requested PNG/SVG/PDF, export with embedded diagram XML when the draw.io CLI is available.
+5. Return the absolute path to the created file.
+
+## Examples
+
+```text
+/grc-diagrams:third-party-risk SOC 2 access controls for AWS, Okta, and GitHub
+/grc-diagrams:third-party-risk FedRAMP moderate cloud platform, auditor audience, svg
+/grc-diagrams:third-party-risk startup SaaS, executive overview, png
+```

--- a/plugins/grc-diagrams/skills/drawio/SKILL.md
+++ b/plugins/grc-diagrams/skills/drawio/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: drawio
+description: Always use when the user asks to create, generate, draw, or design a diagram, flowchart, architecture diagram, ER diagram, sequence diagram, class diagram, network diagram, mockup, wireframe, UI sketch, GRC workflow, control map, audit process, risk register flow, compliance architecture, or mentions draw.io, drawio, drawoi, .drawio files, or diagram export to PNG/SVG/PDF.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# Draw.io Diagram Skill
+
+Generate draw.io diagrams as native `.drawio` files. Optionally export to PNG, SVG, or PDF with the diagram XML embedded so the exported file remains editable in draw.io.
+
+This skill is based on the draw.io CLI workflow from `jgraph/drawio-mcp/skill-cli` and adapted for GRC professionals.
+
+## How to Create a Diagram
+
+1. Generate draw.io XML in mxGraphModel format for the requested diagram.
+2. Write the XML to a `.drawio` file in the current working directory using the Write tool.
+3. Validate XML well-formedness before claiming the diagram is ready.
+4. Post-process edge routing when `npx @drawio/postprocess` is already available. Skip silently if it is unavailable. Do not install it or ask the user about it.
+5. If the user requested `png`, `svg`, or `pdf`, locate the draw.io CLI, export with embedded XML, then delete the source `.drawio` file after a successful export.
+6. If the CLI is not found, keep the `.drawio` file and tell the user they can install the draw.io desktop app to enable export or open the `.drawio` file directly.
+7. Open the result when the environment supports it. If open fails, print the absolute file path.
+
+## Choosing the Output Format
+
+Check the user's request for a format preference.
+
+- `create a flowchart` -> `flowchart.drawio`
+- `png flowchart for login` -> `login-flow.drawio.png`
+- `svg: ER diagram` -> `er-diagram.drawio.svg`
+- `pdf architecture overview` -> `architecture-overview.drawio.pdf`
+
+If no format is mentioned, write the `.drawio` file.
+
+| Format | Embed XML | Notes |
+|--------|-----------|-------|
+| `drawio` | Native | Editable source file |
+| `png` | Yes, `-e` | Viewable everywhere, editable in draw.io |
+| `svg` | Yes, `-e` | Scalable, editable in draw.io |
+| `pdf` | Yes, `-e` | Printable, editable in draw.io |
+| `jpg` | No | Lossy and not editable |
+
+Use double extensions for exported editable files: `name.drawio.png`, `name.drawio.svg`, `name.drawio.pdf`.
+
+## draw.io CLI Location
+
+Try `drawio` on PATH first. Then use platform fallbacks:
+
+- macOS: `/Applications/draw.io.app/Contents/MacOS/draw.io`
+- Linux: `drawio`
+- Windows: `C:\Program Files\draw.io\draw.io.exe`
+- WSL2: `/mnt/c/Program Files/draw.io/draw.io.exe`
+
+Detect WSL2 with:
+
+```bash
+grep -qi microsoft /proc/version 2>/dev/null && echo WSL2
+```
+
+Export command:
+
+```bash
+drawio -x -f <format> -e -b 10 -o <output> <input.drawio>
+```
+
+WSL2 example:
+
+```bash
+"/mnt/c/Program Files/draw.io/draw.io.exe" -x -f png -e -b 10 -o diagram.drawio.png diagram.drawio
+```
+
+Open commands:
+
+- macOS: `open <file>`
+- Linux: `xdg-open <file>`
+- WSL2: `cmd.exe /c start "" "$(wslpath -w <file>)"`
+- Windows: `start <file>`
+
+## XML Format
+
+A `.drawio` file is native mxGraphModel XML. Always generate XML directly. Mermaid and CSV formats require conversion and should not be saved as native `.drawio` files.
+
+Every diagram must have this structure:
+
+```xml
+<mxGraphModel adaptiveColors="auto">
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+  </root>
+</mxGraphModel>
+```
+
+Cell `id="0"` is the root layer. Cell `id="1"` is the default parent layer. All diagram elements use `parent="1"` unless the diagram intentionally uses multiple layers.
+
+## XML Reference
+
+For complete draw.io XML guidance, fetch and follow:
+
+https://raw.githubusercontent.com/jgraph/drawio-mcp/main/shared/xml-reference.md
+
+Use it for styles, edge routing, containers, layers, tags, metadata, dark mode colors, and XML well-formedness rules.
+
+## GRC Diagram Conventions
+
+- Include control IDs, frameworks, owners, evidence repositories, systems of record, and review cadence when known.
+- Use swimlanes for roles or departments: GRC, Security, Engineering, Legal, Procurement, Vendor, Auditor, Executive.
+- Use containers for system boundaries, audit scope, trust zones, cloud accounts, environments, and in-scope/out-of-scope areas.
+- Use dashed edges for evidence paths, dotted edges for optional or manual paths, and solid edges for process or system flows.
+- Use red/orange accents for risks, findings, exceptions, overdue items, and failed controls.
+- Use green/blue accents for implemented controls, automated checks, approvals, and trusted evidence.
+- Include a legend when colors or edge styles have compliance meaning.
+
+## CRITICAL: XML Well-Formedness
+
+- NEVER include ANY XML comments (`<!-- -->`) in the output.
+- Escape special characters in attribute values: `&amp;`, `&lt;`, `&gt;`, `&quot;`.
+- Always use unique `id` values for each `mxCell`.
+- Always include root cells `id="0"` and `id="1"`.
+- Every edge must have a child geometry element: `<mxGeometry relative="1" as="geometry"/>`.
+- Validate XML with a parser before finalizing.

--- a/plugins/grc-diagrams/skills/grc-audit-workflow-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-audit-workflow-diagram/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: grc-audit-workflow-diagram
+description: Use when creating a draw.io diagram for audit planning, request lists, evidence, testing, exceptions, remediation, and reporting in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC audit workflow diagram
+
+Use this skill to structure the GRC content and visual pattern for audit planning, request lists, evidence, testing, exceptions, remediation, and reporting. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- SOC 2 audit timeline
+- internal audit workflow
+- external auditor request lifecycle
+- control testing process
+
+## Recommended Elements
+
+Include these when relevant:
+
+- auditor
+- GRC
+- control owner
+- engineering
+- request list
+- evidence
+- testing
+- exception
+- remediation
+- report
+
+## Recommended Output Pattern
+
+Produce a Swimlane process map or audit timeline. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-compliance-operating-model-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-compliance-operating-model-diagram/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: grc-compliance-operating-model-diagram
+description: Use when creating a draw.io diagram for high-level GRC program architecture, continuous compliance operating models, three lines of defense, and executive program maps in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC compliance operating model diagram
+
+Use this skill to structure the GRC content and visual pattern for high-level GRC program architecture, continuous compliance operating models, three lines of defense, and executive program maps. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- continuous compliance model
+- three lines of defense
+- GRC platform ecosystem
+- policy-control-evidence-risk-audit lifecycle
+
+## Recommended Elements
+
+Include these when relevant:
+
+- program capabilities
+- systems of record
+- governance bodies
+- owners
+- feedback loops
+- maturity phases
+- automation coverage
+
+## Recommended Output Pattern
+
+Produce a Executive capability map, lifecycle, or GRC ecosystem diagram. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-control-map-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-control-map-diagram/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: grc-control-map-diagram
+description: Use when creating a draw.io diagram for controls mapped across frameworks, systems, owners, risks, and evidence sources in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC control map diagram
+
+Use this skill to structure the GRC content and visual pattern for controls mapped across frameworks, systems, owners, risks, and evidence sources. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- SOC 2 CC6.1 to AWS IAM/Okta/GitHub
+- NIST AC to ISO Annex A
+- common control implementation
+
+## Recommended Elements
+
+Include these when relevant:
+
+- controls
+- frameworks
+- systems
+- owners
+- evidence
+- risks
+- inherited controls
+- implementation status
+
+## Recommended Output Pattern
+
+Produce a Hub-and-spoke control map or control coverage diagram. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-data-flow-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-data-flow-diagram/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: grc-data-flow-diagram
+description: Use when creating a draw.io diagram for regulated data flows, data classifications, storage, processing, transfer, access, retention, and logging in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC regulated data flow diagram
+
+Use this skill to structure the GRC content and visual pattern for regulated data flows, data classifications, storage, processing, transfer, access, retention, and logging. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- customer data through SaaS
+- HIPAA ePHI flow
+- CMMC/FedRAMP CUI flow
+- PCI CHD flow
+
+## Recommended Elements
+
+Include these when relevant:
+
+- actors
+- data classes
+- systems
+- stores
+- flows
+- boundaries
+- retention
+- encryption
+- access
+- logging
+
+## Recommended Output Pattern
+
+Produce a Data flow diagram with trust-boundary and classification overlays. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-evidence-flow-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-evidence-flow-diagram/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: grc-evidence-flow-diagram
+description: Use when creating a draw.io diagram for evidence collection, evidence lifecycle, audit evidence pipelines, and systems of record in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC evidence flow diagram
+
+Use this skill to structure the GRC content and visual pattern for evidence collection, evidence lifecycle, audit evidence pipelines, and systems of record. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- AWS Config to evidence repository to auditor review
+- GitHub branch protection evidence
+- quarterly access review lifecycle
+
+## Recommended Elements
+
+Include these when relevant:
+
+- evidence sources
+- collectors
+- repositories
+- reviewers
+- approvers
+- auditors
+- retention
+- freshness
+- cadence
+
+## Recommended Output Pattern
+
+Produce a Swimlane evidence lifecycle or evidence data-flow diagram. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-framework-crosswalk-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-framework-crosswalk-diagram/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: grc-framework-crosswalk-diagram
+description: Use when creating a draw.io diagram for mapping controls and obligations across frameworks to show overlap, gaps, and conflicts in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC framework crosswalk diagram
+
+Use this skill to structure the GRC content and visual pattern for mapping controls and obligations across frameworks to show overlap, gaps, and conflicts. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- SOC 2 to ISO 27001 to NIST CSF
+- FedRAMP to NIST 800-53
+- CIS to SOC 2
+
+## Recommended Elements
+
+Include these when relevant:
+
+- source framework
+- normalized control
+- target framework
+- one-to-one/one-to-many/partial/no-match
+- gaps
+- conflicts
+
+## Recommended Output Pattern
+
+Produce a Crosswalk matrix, many-to-many map, or common-control cluster. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-poam-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-poam-diagram/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: grc-poam-diagram
+description: Use when creating a draw.io diagram for POA&M items, audit findings, remediation milestones, validation, closure, and escalation paths in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC POA&M lifecycle diagram
+
+Use this skill to structure the GRC content and visual pattern for POA&M items, audit findings, remediation milestones, validation, closure, and escalation paths. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- FedRAMP POA&M lifecycle
+- audit finding remediation
+- vulnerability exception to POA&M
+- corrective action tracking
+
+## Recommended Elements
+
+Include these when relevant:
+
+- finding
+- POA&M item
+- owner
+- severity
+- milestone
+- due date
+- validation
+- closure
+- risk acceptance
+
+## Recommended Output Pattern
+
+Produce a State machine, remediation workflow, or milestone timeline. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-raci-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-raci-diagram/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: grc-raci-diagram
+description: Use when creating a draw.io diagram for responsibility assignments across GRC, security, engineering, legal, HR, procurement, vendors, and auditors in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC RACI diagram
+
+Use this skill to structure the GRC content and visual pattern for responsibility assignments across GRC, security, engineering, legal, HR, procurement, vendors, and auditors. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- access review RACI
+- incident response compliance RACI
+- vendor review RACI
+- policy lifecycle RACI
+
+## Recommended Elements
+
+Include these when relevant:
+
+- responsible
+- accountable
+- consulted
+- informed roles
+- controls
+- cadence
+- artifacts
+- approvals
+
+## Recommended Output Pattern
+
+Produce a RACI matrix, swimlane responsibility flow, or ownership map. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-risk-treatment-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-risk-treatment-diagram/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: grc-risk-treatment-diagram
+description: Use when creating a draw.io diagram for risk intake, scoring, treatment, exception approval, residual risk, and monitoring workflows in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC risk treatment diagram
+
+Use this skill to structure the GRC content and visual pattern for risk intake, scoring, treatment, exception approval, residual risk, and monitoring workflows. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- risk register lifecycle
+- vulnerability-to-risk workflow
+- vendor risk acceptance
+- policy exception approval
+
+## Recommended Elements
+
+Include these when relevant:
+
+- risk source
+- assessment
+- inherent/residual score
+- treatment choice
+- owner
+- approver
+- due date
+- monitoring
+
+## Recommended Output Pattern
+
+Produce a Decision tree or risk treatment lifecycle. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-shared-responsibility-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-shared-responsibility-diagram/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: grc-shared-responsibility-diagram
+description: Use when creating a draw.io diagram for cloud/SaaS shared responsibility, inherited controls, provider controls, customer controls, and evidence ownership in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC shared responsibility diagram
+
+Use this skill to structure the GRC content and visual pattern for cloud/SaaS shared responsibility, inherited controls, provider controls, customer controls, and evidence ownership. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- AWS/FedRAMP split
+- SaaS provider/customer control split
+- inherited cloud controls
+
+## Recommended Elements
+
+Include these when relevant:
+
+- provider
+- customer
+- shared
+- inherited
+- excluded zones
+- control ownership
+- evidence ownership
+
+## Recommended Output Pattern
+
+Produce a Split responsibility, layered stack, or inherited evidence map. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-system-boundary-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-system-boundary-diagram/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: grc-system-boundary-diagram
+description: Use when creating a draw.io diagram for compliance scope, authorization boundaries, trust boundaries, in-scope/out-of-scope systems, and system context diagrams in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC system boundary diagram
+
+Use this skill to structure the GRC content and visual pattern for compliance scope, authorization boundaries, trust boundaries, in-scope/out-of-scope systems, and system context diagrams. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- FedRAMP authorization boundary
+- SOC 2 system boundary
+- PCI CDE boundary
+- HIPAA ePHI boundary
+
+## Recommended Elements
+
+Include these when relevant:
+
+- systems
+- actors
+- identity providers
+- data stores
+- monitoring
+- boundaries
+- inherited services
+- exclusions
+- control overlays
+
+## Recommended Output Pattern
+
+Produce a Architecture boundary diagram, trust-zone diagram, or system context diagram. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/plugins/grc-diagrams/skills/grc-third-party-risk-diagram/SKILL.md
+++ b/plugins/grc-diagrams/skills/grc-third-party-risk-diagram/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: grc-third-party-risk-diagram
+description: Use when creating a draw.io diagram for vendor intake, tiering, questionnaires, security/privacy/legal review, contracting, and ongoing monitoring in a GRC, security, audit, compliance, privacy, cloud, or risk context.
+allowed-tools: Write, Bash, Read, WebFetch
+---
+
+# GRC third-party risk diagram
+
+Use this skill to structure the GRC content and visual pattern for vendor intake, tiering, questionnaires, security/privacy/legal review, contracting, and ongoing monitoring. Then use the `drawio` skill to generate the native editable `.drawio` file and optional PNG/SVG/PDF export.
+
+## Common Requests
+
+- new vendor intake
+- security questionnaire workflow
+- vendor tiering
+- DPIA handoff
+- continuous vendor monitoring
+
+## Recommended Elements
+
+Include these when relevant:
+
+- business owner
+- procurement
+- legal
+- privacy
+- security
+- vendor
+- approver
+- artifacts
+- tiering decisions
+
+## Recommended Output Pattern
+
+Produce a Vendor lifecycle, swimlane workflow, or tiering decision tree. Choose a layout that matches the audience:
+
+- Executive: compact lifecycle/capability view with business impact labels.
+- Auditor/assessor: explicit evidence, owner, control, cadence, and scope labels.
+- Practitioner/engineering: operational systems, data paths, automation, failure/exception paths, and implementation detail.
+
+## draw.io Instructions
+
+1. Load and follow the `drawio` skill.
+2. Generate native mxGraphModel XML directly. Do not generate Mermaid as the final artifact.
+3. Use descriptive lowercase hyphenated filenames.
+4. Include a legend when colors, edge styles, or containers have compliance meaning.
+5. Validate XML well-formedness before finalizing.
+6. If PNG/SVG/PDF is requested, export with embedded diagram XML when the draw.io CLI is available.
+
+## Visual Conventions
+
+- Blue: systems, platforms, services, and automated collectors.
+- Green: implemented controls, approvals, validated evidence, and compliant outcomes.
+- Orange/red: risks, findings, exceptions, overdue items, gaps, and failed controls.
+- Gray: manual tasks, external parties, optional steps, and out-of-scope areas.
+- Dashed containers: audit scope, trust boundaries, authorization boundary, or responsibility boundary.
+- Solid edges: primary process or system flow.
+- Dashed edges: evidence or attestation flow.
+- Dotted edges: optional, manual, exception, or escalation flow.
+
+## Quality Bar
+
+- Make ownership explicit.
+- Label regulated data, control IDs, frameworks, and evidence repositories when known.
+- Show decision criteria where the process branches.
+- Avoid generic boxes like "Compliance" without a role, system, artifact, or action.
+- Prefer editable source of truth over screenshots.

--- a/tests/validate-grc-diagram-skills.sh
+++ b/tests/validate-grc-diagram-skills.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Validate the GRC draw.io diagram plugin has the expected command/skill surface.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+plugin_root="plugins/grc-diagrams"
+manifest="$plugin_root/.claude-plugin/plugin.json"
+marketplace=".claude-plugin/marketplace.json"
+
+required_skills=(
+  drawio
+  grc-system-boundary-diagram
+  grc-evidence-flow-diagram
+  grc-control-map-diagram
+  grc-risk-treatment-diagram
+  grc-audit-workflow-diagram
+  grc-framework-crosswalk-diagram
+  grc-third-party-risk-diagram
+  grc-poam-diagram
+  grc-data-flow-diagram
+  grc-shared-responsibility-diagram
+  grc-raci-diagram
+  grc-compliance-operating-model-diagram
+)
+
+required_commands=(
+  drawio
+  system-boundary
+  evidence-flow
+  control-map
+  risk-treatment
+  audit-workflow
+  framework-crosswalk
+  third-party-risk
+  poam
+  data-flow
+  shared-responsibility
+  raci
+  operating-model
+)
+
+[[ -f "$manifest" ]] || { echo "missing $manifest" >&2; exit 1; }
+
+node <<'NODE'
+const fs = require('fs');
+const marketplace = JSON.parse(fs.readFileSync('.claude-plugin/marketplace.json', 'utf8'));
+const entry = marketplace.plugins.find((plugin) => plugin.name === 'grc-diagrams');
+if (!entry) throw new Error('grc-diagrams is not registered in marketplace.json');
+if (entry.source !== './plugins/grc-diagrams') throw new Error(`unexpected grc-diagrams source: ${entry.source}`);
+const manifest = JSON.parse(fs.readFileSync('plugins/grc-diagrams/.claude-plugin/plugin.json', 'utf8'));
+if (manifest.name !== 'grc-diagrams') throw new Error(`unexpected plugin name: ${manifest.name}`);
+NODE
+
+for skill in "${required_skills[@]}"; do
+  file="$plugin_root/skills/$skill/SKILL.md"
+  [[ -f "$file" ]] || { echo "missing skill $file" >&2; exit 1; }
+  grep -q '^---$' "$file" || { echo "skill missing frontmatter fence: $file" >&2; exit 1; }
+  grep -q '^name:' "$file" || { echo "skill missing name: $file" >&2; exit 1; }
+  grep -q '^description:' "$file" || { echo "skill missing description: $file" >&2; exit 1; }
+  if [[ "$skill" != "drawio" ]]; then
+    grep -q 'drawio' "$file" || { echo "GRC companion skill must reference drawio: $file" >&2; exit 1; }
+    grep -q 'GRC' "$file" || { echo "GRC companion skill must include GRC context: $file" >&2; exit 1; }
+  fi
+done
+
+grep -q 'https://raw.githubusercontent.com/jgraph/drawio-mcp/main/shared/xml-reference.md' "$plugin_root/skills/drawio/SKILL.md" || {
+  echo "drawio skill must reference upstream drawio XML reference" >&2
+  exit 1
+}
+grep -q 'NEVER include ANY XML comments' "$plugin_root/skills/drawio/SKILL.md" || {
+  echo "drawio skill must preserve XML well-formedness guidance" >&2
+  exit 1
+}
+
+for command in "${required_commands[@]}"; do
+  file="$plugin_root/commands/$command.md"
+  [[ -f "$file" ]] || { echo "missing command $file" >&2; exit 1; }
+  grep -q '^---$' "$file" || { echo "command missing frontmatter fence: $file" >&2; exit 1; }
+  grep -q '^description:' "$file" || { echo "command missing description: $file" >&2; exit 1; }
+  grep -q 'draw.io' "$file" || { echo "command must mention draw.io: $file" >&2; exit 1; }
+done
+
+echo "GRC diagram plugin skill/command surface is valid."


### PR DESCRIPTION
## Summary
- Add new `grc-diagrams` plugin with a base draw.io skill adapted from `jgraph/drawio-mcp/skill-cli`
- Add 12 GRC-specific draw.io companion skills and commands: system boundary, evidence flow, control map, risk treatment, audit workflow, framework crosswalk, third-party risk, POA&M, data flow, shared responsibility, RACI, and operating model
- Register the plugin in the marketplace, document it in the README, and add validation coverage in CI

## Test Plan
- [x] `npm run test:grc-diagrams`
- [x] `bash tests/validate-plugin-manifests.sh`
- [x] `git diff --check`

Closes #129
Closes #130
Closes #131
Closes #132
Closes #133
Closes #134
Closes #135
Closes #136
Closes #137
Closes #138
Closes #139
Closes #140


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `grc-diagrams` plugin for generating editable draw.io diagrams for GRC and compliance workflows. Includes 13 diagram types: system boundaries, evidence flows, control maps, risk treatments, audit workflows, framework crosswalks, third-party risk assessments, POA&Ms, data flows, shared responsibility matrices, RACI charts, and compliance operating models.

* **Chores**
  * Updated plugin manifest and registry. Added validation tests and documentation for the new plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->