### PR TITLE
feat: add access-review-triage skill to grc-engineer plugin

### DIFF
--- a/plugins/grc-engineer/skills/access-review-triage/SKILL.md
+++ b/plugins/grc-engineer/skills/access-review-triage/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: access-review-triage
+description: Helps you triage a quarterly user access review from an Okta, Azure AD, AWS IAM, GitHub, or generic CSV/JSON export. For each row, recommends certify, revoke, manager confirm, or investigate using rules that catch the usual audit-fail patterns: terminated users still active, dormant admin accounts, separation-of-duty conflicts, service accounts in a human review. Drafts manager confirmation emails and writes an audit evidence packet mapped to SOC 2 CC6.1/CC6.2, PCI 7-8, ISO A.9, NIST AC-2. Built for small and mid-size orgs running UARs in spreadsheets without an IGA tool. Never auto-revokes. Output is a draft for human review before action.
+allowed-tools: Read, Glob, Grep, Bash, Write
+---
+
+# Access Review Triage
+
+You are the skill invoked when a GRC engineer or compliance owner is running a quarterly user access review (UAR) and has access export files to triage. Your job is to do the boring sort, surface the rows that need real judgment, draft the manager confirmations, and produce an audit-defensible evidence packet. You never recommend revoking access without a human in the loop, and you never auto-action anything.
+
+## Operating principles
+
+1. **Human owns every decision.** Your output is always a draft. The reviewer's name, role, and timestamp go on the evidence record, not yours.
+2. **Audit defensibility beats coverage.** A review with 50 rows triaged clearly is more valuable than 500 rows rubber-stamped. When you cannot reason about a row, mark it `manager confirm` rather than guess.
+3. **Cite your reasoning per row.** Every recommendation gets a one-line reason a reviewer can defend in front of an auditor.
+4. **Built for the spreadsheet shop.** Assume the user has no IGA tool. Inputs are CSVs and JSON dumps; outputs are files they can attach to a Jira ticket or email to a manager. Don't require external services.
+5. **Map to controls explicitly.** Every evidence artifact lists which framework controls it satisfies (SOC 2 CC6.1/CC6.2, PCI 7-8, ISO A.9, NIST AC-2). This is the artifact that lives in the audit binder.
+
+## Inputs
+
+The user provides one or more of:
+
+| Input | Required | Shape | Notes |
+|---|---|---|---|
+| Access dump | Yes | CSV or JSON | At minimum: `user`, `system`, `role` or `permissions`. Strongly preferred: `last_login`, `status`. |
+| Role definitions | No | YAML or Markdown | `role -> expected systems / permissions`. Without this, you cannot run rule 6 (role-vs-title mismatch). |
+| Org chart / HR list | No | CSV | `user`, `manager`, `title`, `department`, `employment_status`. Without this, you cannot run rule 1 (terminated user check). |
+| Prior cycle decisions | No | The `decisions.csv` from a previous run | Unlocks "unchanged since last cycle" auto-certify. |
+| SoD conflicts config | No | YAML | List of conflicting entitlement pairs. Default file shipped at `examples/sod-conflicts.yaml`. |
+
+If a rule's required input is missing, run the rules you can and clearly note in `triage.md` which checks were skipped and why.
+
+## Steps
+
+1. **Identify the system.** Look at the columns or JSON shape of the access dump. If headers match Okta's user export schema, treat as Okta. Same for Azure AD, AWS IAM, GitHub. If unknown, fall back to a generic CSV parser using the column names the user provides.
+2. **Load auxiliary inputs.** Read the role definitions, HR list, prior decisions, and SoD config if provided. Build lookup tables.
+3. **Walk the decision rules in order** (see Decision rules below). First match wins. Tag each row with `recommendation`, `reason`, and `priority` (P0 / P1 / P2).
+4. **Compute summary stats.** Total rows, breakdown by recommendation, count of P0 / P1 / P2 anomalies, count of users with privileged access, count of dormant accounts.
+5. **Draft manager emails.** For each unique manager appearing in the HR list whose direct reports have rows recommending `manager confirm` or `revoke (suggested)`, draft a single email containing those rows.
+6. **Write the four artifacts** to `~/.cache/claude-grc/access-reviews/<system>-<YYYY-QN>/` (see Output format).
+7. **Print a one-line summary** to the user: `<system> <YYYY-QN>: <N> rows triaged. <a> auto-certify, <b> manager-confirm, <c> revoke (suggested), <d> investigate (<x> P0).`
+
+## Decision rules
+
+For every row of the access dump, walk these checks in order. **First match wins.**
+
+| Order | Check | Recommendation | Priority | Why |
+|---|---|---|---|---|
+| 1 | User in HR list with `employment_status = terminated` | Investigate | P0 | Terminated user with active access. Audit-fail material. |
+| 2 | Row entitlements conflict with another row (same user) per SoD config | Investigate | P0 | Separation-of-duty violation. |
+| 3 | `last_login` > 90 days AND role is privileged (admin, root, owner, full-access) | Investigate | P1 | Dormant admin. Top breach vector. |
+| 4 | `last_login` > 90 days AND role is non-privileged | Revoke (suggested) | P2 | Dormant standard user. Low-cost cleanup. |
+| 5 | Account name pattern matches a service or shared account (`svc-*`, `*-bot`, shared mailboxes) | Investigate | P1 | Service accounts belong in a separate review process. Surface here so they are not silently certified. |
+| 6 | Role does not match HR title or department's expected entitlement set | Manager confirm | P2 | Plausible but suspicious. Manager owns it. |
+| 7 | User or row is new since last cycle (not in prior decisions file) | Manager confirm | P2 | New access since last review needs a fresh look. |
+| 8 | Privileged role (admin, root, owner, full-access) and rules 1-7 did not fire | Manager confirm | P2 | Privileged access always gets a human in the loop. |
+| 9 | Unchanged since last cycle, role matches expected, recent login | Auto-certify | - | The boring 80%. |
+| 10 | Anything else | Manager confirm | P2 | Default to safe. Human looks at it. |
+
+**Order matters.** Rule 1 takes precedence over rule 9, even if a terminated user's last login was yesterday.
+
+## Output format
+
+Write to `~/.cache/claude-grc/access-reviews/<system>-<YYYY-QN>/` (e.g. `okta-2026-Q2/`).
+
+### 1. `triage.md`
+
+Human-readable report. Sections in this order:
+
+- **Executive summary**: totals, breakdown by recommendation, P0/P1 count, scope (system, cycle, input file).
+- **Inputs and assumptions**: which auxiliary inputs were provided, which decision rules were therefore skipped.
+- **P0 anomalies**: terminated users with active access, SoD conflicts. One subsection per row, with the reasoning.
+- **P1 anomalies**: dormant admins, service accounts in human review. Same shape.
+- **Manager confirm queue**: grouped by manager.
+- **Auto-certified rows**: table only, no per-row reasoning needed.
+
+### 2. `decisions.csv`
+
+Machine-readable. Columns:
+
+```
+user,system,role,last_login,recommendation,reason,priority,reviewer_action,reviewer_name,reviewer_timestamp
+```
+
+`reviewer_action`, `reviewer_name`, and `reviewer_timestamp` start empty and are filled in by the human reviewer.
+
+### 3. `manager-emails/<manager>.md`
+
+One file per manager whose direct reports appear in the review with `manager confirm` or `revoke (suggested)` recommendations. Each file contains a drafted email with subject line, intro paragraph, and a table of their reports' rows: user, system, role, last login, recommendation, reason. Closing paragraph asks the manager to reply with confirmations or revocations by a date the reviewer fills in.
+
+### 4. `evidence.json`
+
+Audit packet. JSON shape:
+
+```json
+{
+  "review_id": "okta-2026-Q2-<sha256-prefix>",
+  "system": "okta",
+  "cycle": "2026-Q2",
+  "input_file": "okta-export-2026-04-30.csv",
+  "input_sha256": "...",
+  "run_timestamp": "2026-05-10T...",
+  "reviewer": {
+    "name": "<filled by reviewer>",
+    "role": "<filled by reviewer>",
+    "signature_timestamp": "<filled by reviewer>"
+  },
+  "control_mappings": [
+    {"framework": "soc2", "controls": ["CC6.1", "CC6.2"]},
+    {"framework": "pci-dss", "controls": ["7.1", "7.2", "8.1"]},
+    {"framework": "iso27001", "controls": ["A.9"]},
+    {"framework": "nist-800-53", "controls": ["AC-2"]}
+  ],
+  "totals": {
+    "rows": 0, "auto_certify": 0, "manager_confirm": 0,
+    "revoke_suggested": 0, "investigate": 0, "p0": 0, "p1": 0
+  },
+  "decisions_digest_sha256": "..."
+}
+```
+
+`decisions_digest_sha256` is a SHA-256 of the canonical `decisions.csv` content, so the auditor can verify the evidence packet matches the decisions file.
+
+## What you will not do
+
+- Do not auto-revoke or auto-action any access. Recommendations only.
+- Do not invent a `last_login` if missing. Mark the field unknown and treat it as "cannot apply dormancy rules."
+- Do not silently skip rows. If a row is malformed, list it in a `parse_errors.md` file with the original line and the parse error.
+- Do not claim a finding maps to a framework control beyond the four listed. If a user asks about another framework, point them to the relevant framework plugin.
+- Do not include personally identifiable information (PII) beyond the username, role, and login fields. If the input contains other PII (SSN, address, etc.), warn the user and ignore those columns.
+- Do not run for orgs that have an IGA tool (Sailpoint, Saviynt, Okta Access Certifications). Surface a one-line message: "Your IGA tool's certification workflow is already designed for this. This skill is for spreadsheet-based reviews. If you still want to run, pass `--force`."

--- a/plugins/grc-engineer/skills/access-review-triage/examples/expected-triage.md
+++ b/plugins/grc-engineer/skills/access-review-triage/examples/expected-triage.md
@@ -1,0 +1,107 @@
+# Access Review Triage — okta 2026-Q2
+
+> Expected output for running `access-review-triage` against the example fixtures in this folder.
+> Re-generate this file if the decision rules in `SKILL.md` change.
+
+## Executive summary
+
+| Metric | Count |
+|---|---|
+| Rows triaged | 9 |
+| Auto-certify | 1 |
+| Manager confirm | 2 |
+| Revoke (suggested) | 1 |
+| Investigate | 5 |
+| P0 anomalies | 3 |
+| P1 anomalies | 2 |
+
+**Scope:** system `okta`, cycle `2026-Q2`, input `okta-access-export.csv` (SHA-256 prefix `<hash>`).
+
+## Inputs and assumptions
+
+| Auxiliary input | Provided? | Effect |
+|---|---|---|
+| HR list (`hr-list.csv`) | Yes | Rule 1 (terminated user) and rule 6 (role-vs-title) are active. |
+| SoD config (`sod-conflicts.yaml`) | Yes | Rule 2 (SoD conflict) is active. |
+| Prior decisions (`prior-decisions.csv`) | Yes | Rules 7 (new since last cycle) and 9 (auto-certify) are active. |
+| Role definitions | No | Rule 6 (role-vs-title) ran on HR titles only; no expected-entitlement map. |
+
+## P0 anomalies
+
+### 1. `mike.left@acme.com` — terminated user with active access
+
+- **System / role:** okta / analyst
+- **Last login:** 2026-04-20
+- **HR status:** `terminated`
+- **Why P0:** Rule 1. HR list flags this user as terminated. Active access to okta is an audit-fail condition (SOC 2 CC6.2, PCI 8.1.3, ISO A.9.2.6).
+- **Recommendation:** Investigate. Confirm separation date with HR, revoke access if confirmed, and document the gap between separation and revocation in a `parse_errors.md`-style retrospective.
+
+### 2. `ap.both@acme.com` — separation-of-duty conflict (AP creator + AP approver)
+
+- **System / roles:** okta / `ap-creator` AND `ap-approver`
+- **Last login:** 2026-05-07
+- **Why P0:** Rule 2. `sod-conflicts.yaml` defines `[ap-creator, ap-approver]` as a SoD conflict. The user holds both roles. Whoever creates an invoice should not be able to approve it (SOC 2 CC6.1, PCI 7.1, ISO A.9, US-SOX ITGC).
+- **Recommendation:** Investigate. Manager and Finance lead should choose which role to retain and revoke the other. Record the decision in the audit packet.
+
+## P1 anomalies
+
+### 3. `dormant.dave@acme.com` — dormant admin
+
+- **System / role:** okta / admin
+- **Last login:** 2025-11-20 (171 days ago)
+- **Why P1:** Rule 3. Privileged role + last login > 90 days. Dormant admin is a top breach vector. Could indicate a forgotten account or a credential held for off-hours misuse.
+- **Recommendation:** Investigate. Confirm whether the user still requires admin access; if yes, why no recent login; if no, revoke.
+
+### 4. `svc-deployer@acme.com` — service account in human review
+
+- **System / role:** okta / deploy-bot
+- **Last login:** 2026-05-09
+- **Why P1:** Rule 5. Account name matches the `svc-*` service-account pattern. Service accounts belong in a separate review process (ownership, rotation, scope). Including them in a human UAR risks silent certification.
+- **Recommendation:** Investigate. Move to the service-account review track. Confirm owner of record and most recent secret rotation.
+
+## Manager confirm queue
+
+Grouped by manager.
+
+### `jdoe@acme.com` (manager: cto@acme.com)
+
+| User | Role | Last login | Reason |
+|---|---|---|---|
+| jdoe@acme.com | admin | 2026-05-05 | Rule 8: privileged role. Always gets a human in the loop. |
+
+### `marcom.head@acme.com`
+
+| User | Role | Last login | Reason |
+|---|---|---|---|
+| jane.new@acme.com | marketing | 2026-05-09 | Rule 7: new since last cycle. Not in `prior-decisions.csv`. |
+
+## Revoke (suggested)
+
+| User | Role | Last login | Reason |
+|---|---|---|---|
+| sleepy.sue@acme.com | viewer | 2025-12-01 (161 days ago) | Rule 4: dormant non-privileged user. Low-cost cleanup. |
+
+## Auto-certified rows
+
+| User | Role | Last login | Why |
+|---|---|---|---|
+| sarah.kim@acme.com | engineer | 2026-05-08 | Rule 9: unchanged since last cycle, role matches prior cycle, recent login. |
+
+## Control mappings
+
+This review produces evidence for:
+
+| Framework | Controls |
+|---|---|
+| SOC 2 | CC6.1, CC6.2 |
+| PCI DSS v4.0 | 7.1, 7.2, 8.1 |
+| ISO 27001 | A.9 |
+| NIST 800-53 | AC-2 |
+
+Mappings recorded verbatim in `evidence.json`.
+
+## One-line summary printed at end of run
+
+```
+okta 2026-Q2: 9 rows triaged. 1 auto-certify, 2 manager-confirm, 1 revoke (suggested), 5 investigate (3 P0, 2 P1).
+```

--- a/plugins/grc-engineer/skills/access-review-triage/examples/hr-list.csv
+++ b/plugins/grc-engineer/skills/access-review-triage/examples/hr-list.csv
@@ -1,0 +1,8 @@
+user,manager,title,department,employment_status
+jdoe@acme.com,cto@acme.com,Engineering Manager,Engineering,active
+sarah.kim@acme.com,jdoe@acme.com,Software Engineer,Engineering,active
+mike.left@acme.com,lisa.head@acme.com,Data Analyst,Analytics,terminated
+dormant.dave@acme.com,lisa.head@acme.com,IT Administrator,IT,active
+sleepy.sue@acme.com,bob.sales@acme.com,Sales Operations,Sales,active
+ap.both@acme.com,finance.boss@acme.com,AP Clerk,Finance,active
+jane.new@acme.com,marcom.head@acme.com,Marketing Coordinator,Marketing,active

--- a/plugins/grc-engineer/skills/access-review-triage/examples/okta-access-export.csv
+++ b/plugins/grc-engineer/skills/access-review-triage/examples/okta-access-export.csv
@@ -1,0 +1,10 @@
+user,system,role,last_login,status
+jdoe@acme.com,okta,admin,2026-05-05,active
+sarah.kim@acme.com,okta,engineer,2026-05-08,active
+mike.left@acme.com,okta,analyst,2026-04-20,active
+dormant.dave@acme.com,okta,admin,2025-11-20,active
+sleepy.sue@acme.com,okta,viewer,2025-12-01,active
+svc-deployer@acme.com,okta,deploy-bot,2026-05-09,active
+ap.both@acme.com,okta,ap-creator,2026-05-07,active
+ap.both@acme.com,okta,ap-approver,2026-05-07,active
+jane.new@acme.com,okta,marketing,2026-05-09,active

--- a/plugins/grc-engineer/skills/access-review-triage/examples/prior-decisions.csv
+++ b/plugins/grc-engineer/skills/access-review-triage/examples/prior-decisions.csv
@@ -1,0 +1,8 @@
+user,system,role,last_login,recommendation,reason,priority,reviewer_action,reviewer_name,reviewer_timestamp
+jdoe@acme.com,okta,admin,2026-02-04,manager confirm,Privileged role,P2,certified,lisa.head@acme.com,2026-02-12T14:02:00Z
+sarah.kim@acme.com,okta,engineer,2026-02-07,auto-certify,Unchanged role, recent login,,certified,jdoe@acme.com,2026-02-12T14:04:00Z
+dormant.dave@acme.com,okta,admin,2026-02-01,manager confirm,Privileged role,P2,certified,lisa.head@acme.com,2026-02-12T14:08:00Z
+sleepy.sue@acme.com,okta,viewer,2025-11-15,auto-certify,Unchanged role,,certified,bob.sales@acme.com,2026-02-12T14:10:00Z
+ap.both@acme.com,okta,ap-creator,2026-02-06,auto-certify,Unchanged role,,certified,finance.boss@acme.com,2026-02-12T14:11:00Z
+svc-deployer@acme.com,okta,deploy-bot,2026-02-09,investigate,Service account in human review,P1,deferred to service-account review,grc@acme.com,2026-02-12T14:15:00Z
+mike.left@acme.com,okta,analyst,2026-02-03,auto-certify,Unchanged role,,certified,lisa.head@acme.com,2026-02-12T14:18:00Z

--- a/plugins/grc-engineer/skills/access-review-triage/examples/sod-conflicts.yaml
+++ b/plugins/grc-engineer/skills/access-review-triage/examples/sod-conflicts.yaml
@@ -1,0 +1,17 @@
+# Separation-of-duty conflict pairs.
+# If a single user has BOTH roles in a pair on the same system, rule 2 fires
+# (Investigate, P0). Extend this file per your org's policy. Pairs are
+# unordered: ["a", "b"] and ["b", "a"] both match.
+
+conflicts:
+  - roles: ["ap-creator", "ap-approver"]
+    reason: "Accounts payable separation of duties. Whoever creates an invoice cannot approve it."
+    frameworks: ["soc2:CC6.1", "pci-dss:7.1", "iso27001:A.9", "us-sox:ITGC"]
+
+  - roles: ["iam-admin", "audit-log-reader"]
+    reason: "An IAM admin who can also read the audit log can mask their own actions."
+    frameworks: ["soc2:CC6.1", "nist-800-53:AC-5"]
+
+  - roles: ["dev-deploy", "prod-deploy"]
+    reason: "Developers should not push directly to production without a separate approver."
+    frameworks: ["soc2:CC8.1", "pci-dss:6.4"]


### PR DESCRIPTION
## Summary

Adds a new skill that helps GRC engineers triage quarterly user access reviews (UARs) when no IGA tool (Sailpoint, Saviynt, Okta Access Certifications) is in place. This is the common case for small and mid-size orgs running UARs in spreadsheets.

The skill takes a CSV or JSON access export (Okta, Azure AD, AWS IAM, GitHub, or generic shapes) plus optional HR list, SoD config, and prior-cycle decisions. It produces four artifacts: a human-readable triage report, a row-by-row decisions CSV, drafted per-manager confirmation emails, and a signed audit evidence packet mapped to SOC 2 CC6.1/CC6.2, PCI 7-8, ISO A.9, NIST AC-2.

It is opinionated about staying in its lane: 10 ordered decision rules cover the usual audit-fail patterns (terminated users with active access, SoD conflicts, dormant admins, service accounts in human review, role-vs-title mismatch, new access since last cycle, privileged-role human review, and an auto-certify path for the boring 80%). It never auto-revokes. It refuses to run for orgs that have an IGA tool unless `--force` is passed.

## Type of change

- [ ] Connector
- [ ] Framework plugin
- [x] Persona plugin
- [ ] Documentation
- [ ] Community / governance
- [ ] CI / automation
- [ ] Other

New skill inside the existing `grc-engineer` persona plugin. Not a new plugin.

## Schema impact

- [x] No schema changes
- [ ] `schemas/finding.schema.json` changed
- [ ] Another schema or contract surface changed

The skill emits a JSON evidence packet whose shape is documented in `SKILL.md` rather than a versioned schema. Happy to graduate it to `schemas/` if a reviewer would prefer.

## Test plan

Manual validation. The skill is markdown only (instructions for Claude), so the test is whether each decision rule fires correctly against the worked example.

Walked every row of `examples/okta-access-export.csv` through the 10 decision rules and confirmed the expected recommendation:

```text
1. jdoe@acme.com           admin                       → Rule 8 (privileged):   Manager confirm
2. sarah.kim@acme.com      engineer                    → Rule 9 (unchanged):    Auto-certify
3. mike.left@acme.com      analyst (terminated in HR)  → Rule 1:                Investigate P0
4. dormant.dave@acme.com   admin (171 days idle)       → Rule 3:                Investigate P1
5. sleepy.sue@acme.com     viewer (161 days idle)      → Rule 4:                Revoke (suggested)
6. svc-deployer@acme.com   deploy-bot (svc-* pattern)  → Rule 5:                Investigate P1
7. ap.both@acme.com        ap-creator + ap-approver    → Rule 2:                Investigate P0
8. jane.new@acme.com       marketing (new this cycle)  → Rule 7:                Manager confirm
```

Confirmed `examples/expected-triage.md` matches what the rules should produce.

`npx markdownlint-cli2` produces MD060 table-style warnings consistent with existing skills (`plugins/grc-tprm/skills/tprm-scorer/SKILL.md`, `plugins/oscal/skills/oscal-expert/SKILL.md`). Happy to fix if a reviewer wants a uniform table style across the new files.

## CHANGELOG

- [ ] No CHANGELOG entry needed
- [ ] I added a CHANGELOG entry
- [x] A maintainer should add the CHANGELOG entry during merge

## Notes for reviewers

- **Audience scope is intentional.** The skill explicitly excludes orgs with an IGA tool. The first line of its description, the `SKILL.md` body, and the `What you will not do` section all say so. If the audience framing should be softer, happy to adjust.
- **SoD conflicts are a config, not hardcoded.** `examples/sod-conflicts.yaml` ships three obvious pairs (AP creator + approver, IAM admin + audit reader, dev + prod deploy). Users point to their own file with `--sod-config`. This keeps the skill out of the business of defining anyone's SoD policy.
- **Evidence packet is the audit-binder artifact.** `evidence.json` carries an input file hash and a SHA-256 digest of the decisions CSV so an auditor can verify the packet matches what was actually reviewed. Open to feedback on whether this format should align with `schemas/finding.schema.json` or stay separate.
- **First contribution to this repo.** Per `docs/CONTRIBUTING.md`, looking for a maintainer vouch and feedback on convention fit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive skill documentation detailing operational framework, supported inputs, output specifications, and audit validation.
  * Provided example outputs demonstrating triage metrics, anomaly categorization, and priority levels.
  * Included separation-of-duty conflict configuration template for policy customization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GRCEngClub/claude-grc-engineering/pull/151)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->