### PR TITLE
polish(grc-portfolio): tier-2 cleanup from greptile + coderabbit review

### DIFF
--- a/demo/claude-grc-portfolio/src/components/Projects.jsx
+++ b/demo/claude-grc-portfolio/src/components/Projects.jsx
@@ -100,7 +100,13 @@ export default function Projects() {
                     <span className="tag">+{project.technologies.length - 3}</span>
                   )}
                 </div>
-                <a href={project.url} target="_blank" rel="noopener noreferrer" className="project-link">
+                <a
+                  href={project.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="project-link"
+                  aria-label={`View ${project.name} (opens in new tab)`}
+                >
                   View ↗
                 </a>
               </div>

--- a/demo/claude-grc-portfolio/src/index.css
+++ b/demo/claude-grc-portfolio/src/index.css
@@ -23,7 +23,7 @@
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-html { scroll-behavior: smooth; font-size: 16px; }
+html { scroll-behavior: smooth; font-size: 16px; scroll-padding-top: 80px; }
 
 body {
   font-family: var(--font-sans);

--- a/plugins/grc-portfolio/cloudformation/website-infrastructure-no-domain.yaml
+++ b/plugins/grc-portfolio/cloudformation/website-infrastructure-no-domain.yaml
@@ -69,6 +69,11 @@ Resources:
         HttpVersion: http2and3
         PriceClass: PriceClass_100  # Use only North America and Europe (cheapest)
         ViewerCertificate:
+          # Using CloudFront's default *.cloudfront.net certificate.
+          # AWS does not let you set MinimumProtocolVersion when using the
+          # default cert (older TLS versions are accepted on the default
+          # CloudFront domain). If you need to enforce TLS 1.2+, use
+          # website-infrastructure.yaml with a custom domain + ACM cert.
           CloudFrontDefaultCertificate: true
         Origins:
           - Id: S3Origin

--- a/plugins/grc-portfolio/cloudformation/website-infrastructure.yaml
+++ b/plugins/grc-portfolio/cloudformation/website-infrastructure.yaml
@@ -32,6 +32,13 @@ Conditions:
   ShouldCreateHostedZone: !Equals [!Ref CreateHostedZone, 'Yes']
   UseExistingHostedZone: !Equals [!Ref CreateHostedZone, 'No']
 
+Rules:
+  ExistingHostedZoneRequired:
+    RuleCondition: !Equals [!Ref CreateHostedZone, 'No']
+    Assertions:
+      - Assert: !Not [!Equals [!Ref ExistingHostedZoneId, '']]
+        AssertDescription: ExistingHostedZoneId is required when CreateHostedZone is "No".
+
 Resources:
   # S3 Bucket for website content
   WebsiteBucket:

--- a/plugins/grc-portfolio/commands/build.md
+++ b/plugins/grc-portfolio/commands/build.md
@@ -27,8 +27,9 @@ src/
   main.jsx
   App.jsx
   index.css
+index.html              ← (Vite's entry HTML lives at the project root)
 public/
-  index.html
+  favicon.svg
 package.json
 vite.config.js
 ```

--- a/plugins/grc-portfolio/scripts/bootstrap.sh
+++ b/plugins/grc-portfolio/scripts/bootstrap.sh
@@ -165,20 +165,19 @@ else
     print_error "validate-stack.sh not found! This should not happen."
 fi
 
-print_info "Use these scripts from your project directory:"
-echo "  ../aws-deployment-kit/scripts/deploy.sh <bucket> <distribution-id> [profile]"
-echo "  ../aws-deployment-kit/scripts/validate-stack.sh [template-file] [profile]"
+print_info "Run these from your project directory (point at the plugin's scripts/):"
+echo "  <plugin-root>/scripts/deploy.sh <bucket> <distribution-id> [profile]"
+echo "  <plugin-root>/scripts/validate-stack.sh [template-file] [profile]"
 
 # Summary
 print_header "Setup Complete!"
 
 echo "✓ All required tools are installed"
-echo "✓ Helper scripts created"
 echo ""
 echo "Next steps:"
-echo "  1. Read the GUIDE.md file for detailed instructions"
-echo "  2. Customize the CloudFormation template if needed"
-echo "  3. Deploy your infrastructure using the AWS Console or CLI"
-echo "  4. Use ./deploy.sh to deploy your website"
+echo "  1. From Claude Code, run /grc-portfolio:plan to scaffold your site config."
+echo "  2. Run /grc-portfolio:preflight to validate AWS readiness."
+echo "  3. Run /grc-portfolio:infra to deploy the CloudFormation stack."
+echo "  4. Run /grc-portfolio:deploy to build and publish the site."
 echo ""
 print_success "You're ready to deploy your website to AWS!"

--- a/plugins/grc-portfolio/scripts/create-env-file.sh
+++ b/plugins/grc-portfolio/scripts/create-env-file.sh
@@ -1,17 +1,24 @@
 #!/bin/bash
 
-# Helper script to create .env.local file with AWS credentials
+# Helper script to create .env.local with AWS credentials.
+#
+# Secrets are read from environment variables to keep them out of shell
+# history and ps(1) output. Pipe them in or export them inline:
+#
+#   AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... ./create-env-file.sh
+#
+# Optional:
+#   AWS_REGION (default: us-east-1)
+#   ENV_FILE   (default: .env.local in the current directory)
 
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <ACCESS_KEY_ID> <SECRET_ACCESS_KEY>"
-    exit 1
-fi
+set -euo pipefail
 
-ACCESS_KEY_ID=$1
-SECRET_ACCESS_KEY=$2
-ENV_FILE=".env.local"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set in the environment}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set in the environment}"
 
-# Check if .env.local already exists
+AWS_REGION="${AWS_REGION:-us-east-1}"
+ENV_FILE="${ENV_FILE:-.env.local}"
+
 if [ -f "$ENV_FILE" ]; then
     echo "⚠️  $ENV_FILE already exists!"
     read -p "Do you want to overwrite it? (y/N): " -n 1 -r
@@ -22,18 +29,22 @@ if [ -f "$ENV_FILE" ]; then
     fi
 fi
 
-# Create .env.local file
-cat > "$ENV_FILE" << EOF
+# Create the file with restrictive permissions before writing secrets.
+umask 077
+: > "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+cat > "$ENV_FILE" <<EOF
 # AWS SES Configuration
 # Generated on $(date)
-AWS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY
+AWS_REGION=$AWS_REGION
+AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 EOF
 
-echo "✅ Created $ENV_FILE successfully!"
+echo "✅ Created $ENV_FILE (mode 600)"
 echo ""
 echo "🔒 Security reminder:"
 echo "   - Never commit this file to version control"
-echo "   - It's already in .gitignore"
+echo "   - It should already be in .gitignore"
 echo ""

--- a/plugins/grc-portfolio/scripts/setup-ses-iam-user.sh
+++ b/plugins/grc-portfolio/scripts/setup-ses-iam-user.sh
@@ -70,6 +70,22 @@ aws iam attach-user-policy \
   --profile "$PROFILE" \
   2>/dev/null || echo "Policy already attached"
 
+# Pre-check existing access keys (AWS allows at most 2 per user).
+echo "🔍 Checking existing access keys..."
+EXISTING_KEYS=$(aws iam list-access-keys \
+  --user-name "$USER_NAME" \
+  --profile "$PROFILE" \
+  --query 'length(AccessKeyMetadata)' \
+  --output text 2>/dev/null || echo 0)
+
+if [ "${EXISTING_KEYS:-0}" -ge 2 ]; then
+    echo "❌ User $USER_NAME already has $EXISTING_KEYS access keys (AWS maximum is 2)."
+    echo "   Delete an unused key before re-running:"
+    echo "     aws iam list-access-keys --user-name $USER_NAME --profile $PROFILE"
+    echo "     aws iam delete-access-key --user-name $USER_NAME --access-key-id <id> --profile $PROFILE"
+    exit 1
+fi
+
 # Create access key
 echo "🔑 Creating access key..."
 ACCESS_KEY_OUTPUT=$(aws iam create-access-key \
@@ -96,6 +112,6 @@ echo ""
 echo "⚠️  IMPORTANT: Save these credentials now!"
 echo "    The secret access key cannot be retrieved again."
 echo ""
-echo "📝 To save these to .env.local, run from your project root:"
-echo "   ./scripts/create-env-file.sh \"$ACCESS_KEY_ID\" \"$SECRET_ACCESS_KEY\""
+echo "📝 To save these to .env.local without exposing them in shell history, run:"
+echo "   AWS_ACCESS_KEY_ID=<paste> AWS_SECRET_ACCESS_KEY=<paste> ./scripts/create-env-file.sh"
 echo ""

--- a/plugins/grc-portfolio/scripts/validate-stack.sh
+++ b/plugins/grc-portfolio/scripts/validate-stack.sh
@@ -37,8 +37,12 @@ info() {
     echo -e "${BLUE}ℹ $1${NC}"
 }
 
-# Default template file
-TEMPLATE_FILE="${1:-cloudformation/website-infrastructure.yaml}"
+# Resolve the default template relative to this script, not the caller's CWD,
+# so the script works regardless of where it's invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TEMPLATE_FILE="${1:-$PLUGIN_ROOT/cloudformation/website-infrastructure.yaml}"
 AWS_PROFILE="${2:-default}"
 
 # Check if template file exists

--- a/plugins/grc-portfolio/skills/website-build/SKILL.md
+++ b/plugins/grc-portfolio/skills/website-build/SKILL.md
@@ -36,8 +36,9 @@ src/
     ContactForm.jsx  (if features.contactForm)
     ... (type-specific components)
   assets/
+index.html           (Vite's entry HTML, references /src/main.jsx)
 public/
-  index.html
+  favicon.svg
 package.json
 vite.config.js
 .env.example
@@ -175,6 +176,8 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 Import and compose all generated components in order. Use a single-page layout with sections. Include smooth scrolling.
 
 ## Step 8: Generate index.html
+
+Write this file at the **project root** (`<projectDir>/index.html`), not under `public/`. Vite resolves the entry HTML from the project root, and `/src/main.jsx` is referenced as an absolute project-root path:
 
 ```html
 <!DOCTYPE html>

--- a/plugins/grc-portfolio/skills/website-cicd/SKILL.md
+++ b/plugins/grc-portfolio/skills/website-cicd/SKILL.md
@@ -39,7 +39,10 @@ aws iam create-open-id-connect-provider \
 
 ### 2b: Create IAM Role with Trust Policy
 
-Create a trust policy that allows only this specific GitHub repo to assume the role:
+Create a trust policy that allows only this specific GitHub repo's `main`
+branch (and `workflow_dispatch` runs against `main`) to assume the role.
+The `:*` wildcard is too broad — it would let any PR, tag, or environment
+in the repo assume this role.
 
 ```json
 {
@@ -53,16 +56,18 @@ Create a trust policy that allows only this specific GitHub repo to assume the r
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-        },
-        "StringLike": {
-          "token.actions.githubusercontent.com:sub": "repo:<github.owner>/<github.repoName>:*"
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:<github.owner>/<github.repoName>:ref:refs/heads/main"
         }
       }
     }
   ]
 }
 ```
+
+If the project deploys from a different branch, replace `main` accordingly.
+For preview deploys from PRs, add a second statement scoped to
+`repo:<owner>/<repo>:pull_request` and a separate, narrower IAM policy.
 
 Create the role:
 ```bash
@@ -151,7 +156,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/plugins/grc-portfolio/skills/website-deploy/SKILL.md
+++ b/plugins/grc-portfolio/skills/website-deploy/SKILL.md
@@ -29,12 +29,20 @@ Extract needed values:
 
 ## Step 2: Set Environment Variables (if contact form)
 
-If `features.contactForm` is true and `aws.contactApiEndpoint` is set:
+If `features.contactForm` is true and `aws.contactApiEndpoint` is set, ensure
+`.env` in the project directory contains:
 
-Create or update `.env` in the project directory:
 ```
 VITE_CONTACT_API_ENDPOINT=<aws.contactApiEndpoint>
 ```
+
+**Update the file non-destructively** — do not overwrite an existing `.env`:
+
+1. If `.env` does not exist, create it with just this line.
+2. If `.env` exists and already has a `VITE_CONTACT_API_ENDPOINT=` line, replace only that line.
+3. If `.env` exists but does not contain `VITE_CONTACT_API_ENDPOINT=`, append the line.
+
+Preserve any other variables the user has set (e.g. `VITE_GA_ID`, analytics keys, feature flags).
 
 ## Step 3: Build the Site
 

--- a/plugins/grc-portfolio/skills/website-infra/SKILL.md
+++ b/plugins/grc-portfolio/skills/website-infra/SKILL.md
@@ -34,53 +34,49 @@ If validation fails, report the error and stop.
 
 ## Step 4: Deploy Main Stack
 
-Deploy the CloudFormation stack:
+Use `aws cloudformation deploy` — it is idempotent (creates the stack on
+first run, applies a change-set on subsequent runs) and waits for completion
+inline, so the user doesn't need a separate `wait` step.
 
 **With custom domain:**
 ```bash
-aws cloudformation create-stack \
+aws cloudformation deploy \
   --stack-name <aws.stackName> \
-  --template-body file://<template-path> \
-  --parameters \
-    ParameterKey=ProjectName,ParameterValue=<projectName> \
-    ParameterKey=DomainName,ParameterValue=<aws.domain> \
-    ParameterKey=HostedZoneId,ParameterValue=<aws.hostedZoneId> \
-    ParameterKey=CertificateArn,ParameterValue=<aws.certArn> \
+  --template-file <template-path> \
+  --parameter-overrides \
+    ProjectName=<projectName> \
+    DomainName=<aws.domain> \
+    HostedZoneId=<aws.hostedZoneId> \
+    CertificateArn=<aws.certArn> \
   --profile <aws.profile> \
-  --region us-east-1
+  --region us-east-1 \
+  --no-fail-on-empty-changeset
 ```
 
 **Without custom domain:**
 ```bash
-aws cloudformation create-stack \
+aws cloudformation deploy \
   --stack-name <aws.stackName> \
-  --template-body file://<template-path> \
-  --parameters \
-    ParameterKey=ProjectName,ParameterValue=<projectName> \
+  --template-file <template-path> \
+  --parameter-overrides ProjectName=<projectName> \
   --profile <aws.profile> \
-  --region us-east-1
+  --region us-east-1 \
+  --no-fail-on-empty-changeset
 ```
 
 Note: Check the actual template parameters first by reading the template file, as parameter names may differ from the examples above. Use the actual parameter names from the template.
 
-## Step 5: Wait for Completion
+The deploy command can take 5-15 minutes (especially with CloudFront
+distribution creation). Tell the user it's in progress and approximately
+how long it might take.
 
-```bash
-aws cloudformation wait stack-create-complete \
-  --stack-name <aws.stackName> \
-  --profile <aws.profile> \
-  --region us-east-1
-```
-
-This can take 5-15 minutes (especially with CloudFront distribution creation). Tell the user it's in progress and approximately how long it might take.
-
-If the stack fails, retrieve the failure reason:
+If the deploy fails, retrieve the failure reason:
 ```bash
 aws cloudformation describe-stack-events \
   --stack-name <aws.stackName> \
   --profile <aws.profile> \
   --region us-east-1 \
-  --query "StackEvents[?ResourceStatus=='CREATE_FAILED'].[LogicalResourceId,ResourceStatusReason]" \
+  --query "StackEvents[?ResourceStatus=='CREATE_FAILED' || ResourceStatus=='UPDATE_FAILED'].[LogicalResourceId,ResourceStatusReason]" \
   --output table
 ```
 

--- a/plugins/grc-portfolio/skills/website-preflight/SKILL.md
+++ b/plugins/grc-portfolio/skills/website-preflight/SKILL.md
@@ -127,4 +127,4 @@ Tell the user:
 ## Variables
 
 - `$TOOLKIT_DIR` = read from `site-config.json` `toolkitDir` field
-- `$ARGUMENTS` = arguments passed after `/preflight` (expected: project directory path)
+- `$ARGUMENTS` = arguments passed after `/grc-portfolio:preflight` (expected: project directory path)

--- a/plugins/grc-portfolio/skills/website-repo/SKILL.md
+++ b/plugins/grc-portfolio/skills/website-repo/SKILL.md
@@ -68,14 +68,30 @@ npm-debug.log*
 lambda/*.zip
 ```
 
-If it exists, verify it includes at least `node_modules`, `dist`, `.env`, and `.DS_Store`.
+If it exists, verify it includes at least `node_modules`, `dist`, `.env`, `.env.local`, and `.DS_Store`. **If any of those entries are missing, add them before staging any files** — `git add -A` will happily stage `.env.local` with secrets in it otherwise.
 
 ## Step 5: Initialize Git and Commit
 
 ```bash
 cd <projectDir>
 git init
+```
+
+Before staging, confirm `.env*` files are ignored:
+
+```bash
+git check-ignore -q .env .env.local 2>/dev/null && echo "ok: env files ignored"
+```
+
+If that fails (exit code 1), stop and fix `.gitignore` — do not run `git add -A` until env files are ignored.
+
+```bash
 git add -A
+# Sanity check: nothing under .env* should be staged.
+if git diff --cached --name-only | grep -E '^\.env(\.|$)'; then
+  echo "ERROR: env file staged — unstage it and fix .gitignore" >&2
+  exit 1
+fi
 git commit -m "Initial commit: scaffolded GRC portfolio website"
 ```
 

--- a/plugins/grc-portfolio/templates/SITE-PLAN-TEMPLATE.md
+++ b/plugins/grc-portfolio/templates/SITE-PLAN-TEMPLATE.md
@@ -50,9 +50,9 @@
 
 ## Next Steps
 
-1. Run `/preflight` to validate AWS readiness
-2. Run `/build` to scaffold the React/Vite project
-3. Run `/repo` to create a GitHub repository
-4. Run `/infra` to deploy AWS infrastructure
-5. Run `/deploy` to publish the site
-6. Run `/cicd` to set up continuous deployment
+1. Run `/grc-portfolio:build` to scaffold the React/Vite project
+2. Run `/grc-portfolio:preflight` to validate AWS readiness
+3. Run `/grc-portfolio:infra` to deploy AWS infrastructure
+4. Run `/grc-portfolio:deploy` to publish the site
+5. Run `/grc-portfolio:repo` to create a GitHub repository
+6. Run `/grc-portfolio:cicd` to set up continuous deployment


### PR DESCRIPTION
## Summary

Follow-up to #149 — addresses the remaining substantive greptile and CodeRabbit findings on the grc-portfolio plugin that weren't part of the Tier-1 contact-form hardening.

## What's in

**CloudFormation**
- `website-infrastructure.yaml`: add a \`Rule\` asserting \`ExistingHostedZoneId\` is non-empty when \`CreateHostedZone=No\` (would silently misbehave otherwise).
- `website-infrastructure-no-domain.yaml`: document the AWS constraint that the default CloudFront cert can't set \`MinimumProtocolVersion\`; point users at the with-domain template for TLS 1.2+.

**Scripts**
- `create-env-file.sh`: read AWS creds from env vars instead of CLI args (keeps them out of \`ps\` / shell history); umask 077 + chmod 600 on the written file.
- `setup-ses-iam-user.sh`: pre-check the user doesn't already have 2 access keys before calling \`create-access-key\` (AWS hard limit); switch the printed next-step to the env-var interface.
- `validate-stack.sh`: resolve the default template path relative to the script dir.
- `bootstrap.sh`: replace stale \`../aws-deployment-kit/\` next-steps with the actual \`/grc-portfolio:*\` flow.

**Skills**
- `website-cicd`: tighten OIDC trust policy from \`:*\` to a specific branch ref; bump runtime to Node 20 (Node 18 is EOL).
- `website-infra`: switch \`create-stack\` calls to \`aws cloudformation deploy\` (idempotent, inline wait); drop the redundant wait step; cover \`UPDATE_FAILED\` in diagnostics.
- `website-deploy`: non-destructive \`.env\` update semantics so the step doesn't clobber other env vars.
- `website-repo`: gate \`git add -A\` on \`git check-ignore\` for \`.env*\`; add a post-stage sanity check that fails if any env file got staged.
- `website-build`, `commands/build.md`: fix the documented project structure — Vite's \`index.html\` lives at the project root, not under \`public/\`.
- `website-preflight`: align \`\$ARGUMENTS\` description with the namespaced command.
- `SITE-PLAN-TEMPLATE.md`: namespace the Next Steps and reorder to the actual flow.

**Demo**
- \`Projects.jsx\`: per-link aria-labels (a11y).
- \`index.css\`: add \`scroll-padding-top\` so in-page anchors don't hide under the sticky navbar.

## What's not in (intentional)

Pure-cosmetic CSS nits CodeRabbit flagged in \`plugins/grc-portfolio/examples/App.css\` (font-family quoting, keyframe naming). That file is a reference snippet, not the scaffold the build skill produces.

## Test plan

- [x] All bash scripts pass \`bash -n\`
- [x] All CloudFormation templates parse with CFN-tag-aware YAML loader
- [ ] (manual) Re-run the plugin end-to-end against a real AWS account