### PR TITLE
fix(grc-portfolio): bump vite 5 → 6.4.2 (GHSA-4w7w-66w2-5vf9)

### DIFF
--- a/demo/claude-grc-portfolio/package.json
+++ b/demo/claude-grc-portfolio/package.json
@@ -17,11 +17,11 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "^5.0.0",
     "eslint": "^8.55.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^5.0.8"
+    "vite": "^6.4.2"
   }
 }

--- a/plugins/grc-portfolio/examples/package.json
+++ b/plugins/grc-portfolio/examples/package.json
@@ -18,11 +18,11 @@
   "devDependencies": {
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "^5.0.0",
     "eslint": "^8.55.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^5.0.8"
+    "vite": "^6.4.2"
   }
 }


### PR DESCRIPTION
## Summary

Closes the two open Dependabot alerts on \`main\` — both flag the same advisory ([GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9), medium): Vite path traversal in optimized deps \`.map\` handling, affecting all Vite versions ≤ 6.4.1, fixed in 6.4.2.

Bumps the two affected manifests:
- \`demo/claude-grc-portfolio/package.json\`
- \`plugins/grc-portfolio/examples/package.json\`

\`vite\`: \`^5.0.8\` → \`^6.4.2\`
\`@vitejs/plugin-react\`: \`^4.2.1\` → \`^5.0.0\` (4.x line is Vite-5-only)

## Test plan

- [x] Demo builds cleanly on Vite 6.4.2 (\`vite v6.4.2 building for production... ✓ built in 2.42s\`, 37 modules, no errors)
- [x] Output shape unchanged (same chunks: react-vendor, router-vendor, index)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool dependencies: upgraded @vitejs/plugin-react to version 5.0.0 and Vite to version 6.4.2 across demo and example project configurations for improved build performance and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GRCEngClub/claude-grc-engineering/pull/155)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->