### PR TITLE
docs(scf-client): note grcengclub.github.io/scf-api is the right source

### DIFF
--- a/plugins/grc-engineer/scripts/scf-client.js
+++ b/plugins/grc-engineer/scripts/scf-client.js
@@ -5,7 +5,9 @@
  *
  * Fetches from https://grcengclub.github.io/scf-api/ on demand; caches under
  * ~/.cache/claude-grc/scf/<version>/. Respects CC BY-ND 4.0 — cached data is
- * preserved verbatim, never modified.
+ * preserved verbatim, never modified. This mirror is the right source for
+ * this toolkit: it exposes per-framework JSON crosswalks (forward + reverse,
+ * pre-indexed) for every framework our plugins target.
  *
  * Public API:
  *   initSCF({ offline, cacheDir, baseUrl }) → SCFClient


### PR DESCRIPTION
One-paragraph clarification on why `scf-client.js` reads from `grcengclub.github.io/scf-api/` — that mirror exposes per-framework JSON crosswalks (forward + reverse, pre-indexed) for every framework our plugins target.

Closes GRC-57.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation for the SCF toolkit to provide clearer descriptions of functionality.

---

**Note:** This release contains no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GRCEngClub/claude-grc-engineering/pull/157)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->