### PR TITLE
feat: add testssl-inspector connector plugin (GRC-55)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -292,6 +292,12 @@
       "version": "0.1.0"
     },
     {
+      "name": "testssl-inspector",
+      "source": "./plugins/connectors/testssl-inspector",
+      "description": "GRC connector wrapping testssl.sh: TLS/SSL protocol, cipher, certificate, and known-CVE checks on HTTPS endpoints → v1 finding contract",
+      "version": "0.1.0"
+    },
+    {
       "name": "okta-inspector",
       "source": "./plugins/connectors/okta-inspector",
       "description": "GRC connector for Okta: password/MFA/session policies, inactive users, admin factor enrollment \u2192 v1 finding contract",

--- a/plugins/connectors/testssl-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/testssl-inspector/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "testssl-inspector",
+  "version": "0.1.0",
+  "description": "GRC connector wrapping testssl.sh. Scans HTTPS endpoints for protocol/cipher posture, certificate issues, and known TLS CVEs (Heartbleed, ROBOT, POODLE, FREAK, LOGJAM, SWEET32, ...). Emits findings conforming to schemas/finding.schema.json v1, mapped to SOC 2 CC6.1/CC6.6/CC6.7, NIST 800-53 SC-8/SC-13/SC-17/RA-5/SI-2, PCI DSS 4.0.1 §4, ISO 27001 A.8.20/A.8.24, and SCF CRY/VPM controls.",
+  "author": { "name": "GRC Engineering Club Contributors" },
+  "license": "MIT",
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "keywords": ["grc", "compliance", "tls", "ssl", "testssl", "vulnerability", "scf", "pci-dss", "soc2", "connector"]
+}

--- a/plugins/connectors/testssl-inspector/README.md
+++ b/plugins/connectors/testssl-inspector/README.md
@@ -1,0 +1,48 @@
+# testssl-inspector
+
+A Claude Code plugin that wraps [`testssl.sh`](https://github.com/testssl/testssl.sh) and emits the toolkit's v1 Finding shape, mapped to SOC 2, NIST 800-53 r5, PCI DSS 4.0.1, ISO 27001:2022, and SCF controls.
+
+## What it does
+
+Runs `testssl.sh` against one or more HTTPS endpoints, parses the JSON output, and produces structured findings the rest of the toolkit can consume — gap assessments, evidence packs, continuous-monitoring runs.
+
+| What testssl checks | Where it lands in compliance frameworks |
+|---|---|
+| Protocols (SSLv2/3, TLS 1.0–1.3) | SOC 2 CC6.7 · NIST SC-8/SC-13 · PCI 4.2.1 · ISO A.8.24 · SCF CRY-03 |
+| Cipher suites (incl. NULL, EXPORT, 3DES, RC4) | SOC 2 CC6.7 · NIST SC-13 · PCI 4.2.1.1 · ISO A.8.24 · SCF CRY-04 |
+| Certificate (expiry, chain, signature, key, CAA, OCSP, CT) | SOC 2 CC6.1 · NIST SC-17 · PCI 4.2.1 · ISO A.8.24 · SCF CRY-08 |
+| Known CVEs (Heartbleed, ROBOT, POODLE, SWEET32, FREAK, LOGJAM, DROWN, BEAST, …) | SOC 2 CC6.6 · NIST RA-5/SI-2 · PCI 6.3.3 · ISO A.8.8 · SCF VPM-03 |
+| HTTP transport headers (HSTS, HPKP, cookie flags) | SOC 2 CC6.7 · NIST SC-8 · ISO A.8.20 · SCF CRY-03 |
+
+## Install
+
+```bash
+/plugin install testssl-inspector@grc-engineering-suite
+```
+
+You'll also need `testssl.sh` itself — the plugin auto-detects it. Install one of:
+
+- macOS: `brew install testssl`
+- Debian/Ubuntu: `sudo apt-get install -y testssl.sh`
+- From source: `git clone https://github.com/testssl/testssl.sh ~/.local/share/testssl.sh && export PATH="$HOME/.local/share/testssl.sh:$PATH"`
+- Or use Docker without installing — pass `--docker` to setup.
+
+## Quick start
+
+```bash
+/testssl-inspector:setup --target=example.com
+/testssl-inspector:scan --target=example.com --fast
+/testssl-inspector:status
+```
+
+See `commands/scan.md` for the full option set, and `skills/testssl-inspector-expert/SKILL.md` for remediation guidance per finding family.
+
+## Outputs
+
+- `~/.config/claude-grc/connectors/testssl-inspector.yaml` — config (runner, version, target list)
+- `~/.cache/claude-grc/findings/testssl-inspector/<run_id>.json` — one v1 Finding document per scanned endpoint
+- `~/.cache/claude-grc/runs.log` — append-only run summary line
+
+## Scope
+
+Only HTTPS endpoints in the current wrapper. `testssl.sh` itself supports `--starttls` for SMTP/IMAP/POP/FTP/etc.; if you need any of those, open an issue.

--- a/plugins/connectors/testssl-inspector/commands/scan.md
+++ b/plugins/connectors/testssl-inspector/commands/scan.md
@@ -1,0 +1,75 @@
+---
+name: testssl-inspector scan
+description: Run testssl.sh against one or more HTTPS endpoints and emit v1 Findings mapped to SOC 2, NIST 800-53, PCI DSS 4.0.1, ISO 27001, and SCF controls.
+---
+
+# /testssl-inspector:scan
+
+Wraps `testssl.sh`, normalizes its JSON output into the toolkit's v1 finding contract, and writes one document per target.
+
+## How to run
+
+```bash
+node plugins/connectors/testssl-inspector/scripts/scan.js [options]
+```
+
+## Options
+
+- `--target=host[:port]` — repeatable; or pass targets positionally. Port defaults to 443.
+- `--fast` — `testssl.sh --fast` (~3× faster, drops vulnerability checks).
+- `--full` — full check set (default). Slower; includes CVE checks (Heartbleed, ROBOT, POODLE, BEAST, BREACH, SWEET32, FREAK, LOGJAM, DROWN, …).
+- `--docker` / `--no-docker` — override the runner choice from the config.
+- `--output=summary|silent|json` — default `summary` prints counts to stdout; `json` emits machine-readable run info; `silent` writes the cache file and nothing else.
+- `--quiet` — suppress stderr progress lines.
+
+## What it evaluates
+
+Each testssl.sh finding maps to evaluations across multiple frameworks:
+
+| testssl group | SOC 2 | NIST 800-53 | PCI DSS 4.0.1 | ISO 27001 | SCF |
+|---|---|---|---|---|---|
+| Weak protocols (SSLv2/3, TLS 1.0/1.1) | CC6.7 | SC-8, SC-13 | 4.2.1 | A.8.24 | CRY-03 |
+| Weak ciphers (NULL, EXPORT, 3DES, RC4, anon) | CC6.7 | SC-13 | 4.2.1.1 | A.8.24 | CRY-04 |
+| Certificate posture (expiry, signature, chain, key size, OCSP, CT) | CC6.1 | SC-17 | 4.2.1 | A.8.24 | CRY-08 |
+| Known CVEs (Heartbleed, ROBOT, POODLE, SWEET32, FREAK, LOGJAM, DROWN, BEAST, LUCKY13, …) | CC6.6 | RA-5, SI-2 | 6.3.3 | A.8.8 | VPM-03 |
+| HTTP transport headers (HSTS, HPKP, cookie flags) | CC6.7 | SC-8 | — | A.8.20 | CRY-03 |
+
+Severity translation: testssl `FATAL`/`CRITICAL` → `critical`; `HIGH` → `high`; `WARN`/`MEDIUM` → `medium`; `LOW` → `low`; `OK`/`INFO` → `info` (and `pass` for status). Anything else → `inconclusive`.
+
+## Output
+
+- `~/.cache/claude-grc/findings/testssl-inspector/<run_id>.json`
+- One Finding doc per target with `resource.type = "tls_endpoint"`, `resource.id = "<host>:<port>"`, and `resource.uri = "https://<host>:<port>/"`.
+- Critical findings and any with a CVE are also lifted into a `findings[]` narrative array for quick triage.
+- Summary printed to stdout unless `--output=silent`:
+
+  ```
+  testssl-inspector: 2 targets, 2 resources, 47 evaluations, 9 failing (1 critical, 3 high, 4 medium, 1 low). → /home/.../<run_id>.json
+  ```
+
+## Exit codes
+
+- `0` — clean run, no scan errors
+- `2` — usage error (missing target)
+- `3` — testssl.sh / docker unavailable (or every target failed)
+- `4` — partial run (some targets failed but at least one succeeded)
+- `5` — not configured (no config file and no `--target` provided)
+
+## Examples
+
+```bash
+# Fast scan of one endpoint
+/testssl-inspector:scan --target=example.com --fast
+
+# Full vulnerability scan against two endpoints, Docker runner
+/testssl-inspector:scan --target=example.com --target=api.example.com:8443 --docker
+
+# Pipe summary into another step
+/testssl-inspector:scan --target=example.com --output=json | jq '.counters'
+```
+
+## Targets and scope
+
+- Only HTTPS endpoints. testssl supports `--starttls` for SMTP/IMAP/etc.; not currently wired into this wrapper — open an issue if you need it.
+- Scanning runs on the local machine and requires outbound network reach to the target. Not suitable for endpoints behind a private network unless the runner has access.
+- Be courteous: testssl makes a couple hundred connections per target. Don't point it at infrastructure you don't own without authorization.

--- a/plugins/connectors/testssl-inspector/commands/setup.md
+++ b/plugins/connectors/testssl-inspector/commands/setup.md
@@ -1,0 +1,62 @@
+---
+name: testssl-inspector setup
+description: Locate testssl.sh (native install or Docker), record version, and write default targets to the connector config.
+---
+
+# /testssl-inspector:setup
+
+One-time configuration step. Verifies `testssl.sh` is reachable, captures its version, and seeds a config file with any targets you pass.
+
+## How to run
+
+```bash
+bash plugins/connectors/testssl-inspector/scripts/setup.sh [options]
+```
+
+## Options
+
+- `--docker` — use the `drwetter/testssl.sh` Docker image instead of a native binary. Pulls the image if not already present.
+- `--target=host[:port]` — repeatable; pre-populate the targets list. Port defaults to 443.
+
+## What it does
+
+1. Locates `testssl.sh` — checks `$PATH`, then `~/.local/share/testssl.sh/testssl.sh`, `/opt/testssl.sh/testssl.sh`, `/usr/local/bin/testssl.sh`.
+2. If not found and `--docker` not passed, prints install instructions and exits with code 3.
+3. Captures the testssl version.
+4. Writes `~/.config/claude-grc/connectors/testssl-inspector.yaml` with:
+   - `use_docker` and `testssl_path`
+   - `testssl_version`
+   - `targets:` list (empty if not provided)
+5. Creates the cache dir `~/.cache/claude-grc/findings/testssl-inspector/`.
+
+## Install paths
+
+| OS / approach | Command |
+|---|---|
+| macOS (Homebrew) | `brew install testssl` |
+| Debian / Ubuntu | `sudo apt-get install -y testssl.sh` |
+| From source | `git clone https://github.com/testssl/testssl.sh ~/.local/share/testssl.sh && export PATH="$HOME/.local/share/testssl.sh:$PATH"` |
+| Docker (no install) | run `/testssl-inspector:setup --docker` and the plugin will use the image |
+
+## Exit codes
+
+- `0` success
+- `2` unknown flag
+- `3` testssl.sh and Docker both unavailable
+
+## Examples
+
+```bash
+# Native testssl on PATH, no targets yet
+/testssl-inspector:setup
+
+# Docker-based, pre-load two targets
+/testssl-inspector:setup --docker --target=example.com --target=api.example.com:8443
+```
+
+## Next
+
+```bash
+/testssl-inspector:scan --target=example.com
+/testssl-inspector:status
+```

--- a/plugins/connectors/testssl-inspector/commands/status.md
+++ b/plugins/connectors/testssl-inspector/commands/status.md
@@ -1,0 +1,28 @@
+---
+name: testssl-inspector status
+description: Show configured testssl runner, version, target count, and recent scans on disk.
+---
+
+# /testssl-inspector:status
+
+Quick health check.
+
+## How to run
+
+```bash
+bash plugins/connectors/testssl-inspector/scripts/status.sh
+```
+
+## What it shows
+
+- Runner (`native` vs `docker`) and the binary path if native
+- testssl.sh version captured at setup
+- Config file path
+- Configured target count
+- Cache directory + number of scans on disk
+- Filename of the latest scan, if any
+
+## Exit codes
+
+- `0` configured and reachable
+- `5` not configured — run `/testssl-inspector:setup` first

--- a/plugins/connectors/testssl-inspector/scripts/scan.js
+++ b/plugins/connectors/testssl-inspector/scripts/scan.js
@@ -1,0 +1,522 @@
+#!/usr/bin/env node
+
+/**
+ * testssl-inspector:scan
+ *
+ * Wraps testssl.sh and emits findings conforming to schemas/finding.schema.json v1.
+ *
+ * Resource type is `tls_endpoint`. Each finding from testssl is mapped to one
+ * or more control evaluations across SOC 2, NIST 800-53, PCI DSS 4.0.1,
+ * ISO 27001:2022, and SCF.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'connectors', 'testssl-inspector.yaml');
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'testssl-inspector');
+const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
+const SOURCE = 'testssl-inspector';
+const SOURCE_VERSION = '0.1.0';
+
+const EXIT = { OK: 0, USAGE: 2, TOOL_UNAVAILABLE: 3, PARTIAL: 4, NOT_CONFIGURED: 5 };
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  const log = args.quiet ? () => {} : (m) => process.stderr.write(`[${SOURCE}] ${m}\n`);
+
+  let config = {};
+  try { config = parseYaml(await fs.readFile(CONFIG_FILE, 'utf8')); }
+  catch { /* config is optional; targets can come from CLI */ }
+
+  const targets = args.targets.length ? args.targets : (config.targets || []);
+  if (!targets.length) {
+    fail(EXIT.USAGE, 'no targets. Pass --target=host[:port] (repeatable) or list them in config (run /testssl-inspector:setup).');
+  }
+
+  const mode = args.fast ? 'fast' : 'full';
+  const useDocker = args.docker ?? (config.use_docker === true);
+  const runner = await resolveRunner({ useDocker, configBinary: config.testssl_path });
+  log(`runner=${runner.label} mode=${mode} targets=${targets.length}`);
+
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  const runId = makeRunId();
+  const startedAt = Date.now();
+  const findings = [];
+  const errors = [];
+
+  for (const target of targets) {
+    try {
+      const raw = await runTestssl(runner, target, mode, log);
+      const doc = normalizeTargetFindings(raw, target, runId, runner.version);
+      findings.push(doc);
+    } catch (err) {
+      errors.push({ target, error: err.message });
+      log(`${target} scan failed: ${err.message}`);
+    }
+  }
+
+  const cachePath = path.join(CACHE_DIR, `${runId}.json`);
+  await fs.writeFile(cachePath, JSON.stringify(findings, null, 2));
+
+  const counters = { pass: 0, fail: 0, inconclusive: 0, not_applicable: 0, skipped: 0 };
+  const sev = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  for (const d of findings) for (const e of d.evaluations) {
+    counters[e.status] = (counters[e.status] || 0) + 1;
+    if (e.severity) sev[e.severity] = (sev[e.severity] || 0) + 1;
+  }
+
+  await appendRunLog({
+    source: SOURCE, run_id: runId, started_at: new Date(startedAt).toISOString(),
+    duration_ms: Date.now() - startedAt,
+    targets: targets.length, errors: errors.length,
+    counters, severities: sev, cache_path: cachePath,
+  });
+
+  if (args.output === 'json') {
+    process.stdout.write(JSON.stringify({ run_id: runId, cache_path: cachePath, counters, severities: sev, errors }, null, 2) + '\n');
+  } else if (args.output !== 'silent') {
+    const failingSev = `${sev.critical} critical, ${sev.high} high, ${sev.medium} medium, ${sev.low} low`;
+    process.stdout.write(
+      `${SOURCE}: ${targets.length} target${targets.length === 1 ? '' : 's'}, ` +
+      `${findings.length} resource${findings.length === 1 ? '' : 's'}, ` +
+      `${counters.fail + counters.pass + counters.inconclusive} evaluations, ` +
+      `${counters.fail} failing (${failingSev}). ` +
+      `${errors.length ? `${errors.length} scan errors. ` : ''}` +
+      `→ ${cachePath}\n`
+    );
+  }
+
+  if (errors.length && findings.length === 0) process.exit(EXIT.TOOL_UNAVAILABLE);
+  if (errors.length) process.exit(EXIT.PARTIAL);
+  process.exit(EXIT.OK);
+}
+
+function parseArgs(argv) {
+  const args = { targets: [], fast: false, docker: undefined, quiet: false, output: 'summary' };
+  for (const a of argv) {
+    if (a === '--fast') args.fast = true;
+    else if (a === '--full') args.fast = false;
+    else if (a === '--docker') args.docker = true;
+    else if (a === '--no-docker') args.docker = false;
+    else if (a === '--quiet') args.quiet = true;
+    else if (a.startsWith('--target=')) args.targets.push(a.slice(9));
+    else if (a.startsWith('--output=')) args.output = a.slice(9);
+    else if (a === '-h' || a === '--help') {
+      process.stdout.write(
+        `Usage: scan.js --target=host[:port] [--target=...] [--fast|--full] [--docker] [--output=summary|silent|json] [--quiet]\n`
+      );
+      process.exit(0);
+    } else if (!a.startsWith('-')) args.targets.push(a);
+    else fail(EXIT.USAGE, `unknown flag: ${a}`);
+  }
+  return args;
+}
+
+/** Resolve which testssl invocation we'll use. */
+async function resolveRunner({ useDocker, configBinary }) {
+  if (useDocker) {
+    if (!await commandExists('docker')) fail(EXIT.TOOL_UNAVAILABLE, 'docker not on PATH — drop --docker or install Docker.');
+    return {
+      label: 'docker drwetter/testssl.sh',
+      version: await dockerImageVersion(),
+      argv: (target, mode) => [
+        'run', '--rm', '--network', 'host',
+        '-v', `${CACHE_DIR}:/tmp/scan-out`,
+        'drwetter/testssl.sh:latest',
+        ...testsslArgs(target, mode, '/tmp/scan-out'),
+      ],
+      cmd: 'docker',
+    };
+  }
+  const binary = configBinary || await whichTestssl();
+  if (!binary) {
+    fail(EXIT.TOOL_UNAVAILABLE,
+      'testssl.sh not on PATH. Install via: brew install testssl (macOS), apt install testssl.sh (Debian/Ubuntu), or ' +
+      'git clone https://github.com/testssl/testssl.sh ~/.local/share/testssl.sh && ' +
+      `export PATH="$HOME/.local/share/testssl.sh:$PATH". Or rerun with --docker.`);
+  }
+  const version = await runCapture(binary, ['--version']).then(parseTestsslVersion).catch(() => 'unknown');
+  return {
+    label: binary,
+    version,
+    cmd: binary,
+    argv: (target, mode) => testsslArgs(target, mode),
+  };
+}
+
+async function whichTestssl() {
+  for (const candidate of ['testssl.sh', 'testssl']) {
+    if (await commandExists(candidate)) return candidate;
+  }
+  for (const candidate of [
+    path.join(os.homedir(), '.local/share/testssl.sh/testssl.sh'),
+    '/opt/testssl.sh/testssl.sh',
+    '/usr/local/bin/testssl.sh',
+  ]) {
+    try { await fs.access(candidate); return candidate; } catch {}
+  }
+  return null;
+}
+
+async function dockerImageVersion() {
+  try {
+    const out = await runCapture('docker', ['run', '--rm', 'drwetter/testssl.sh:latest', '--version']);
+    return parseTestsslVersion(out);
+  } catch { return 'unknown'; }
+}
+
+function parseTestsslVersion(text) {
+  const m = String(text).match(/testssl\.sh\s+([0-9][^\s,]+)/i);
+  return m ? m[1] : 'unknown';
+}
+
+function testsslArgs(target, mode, outDir = null) {
+  const out = outDir || CACHE_DIR;
+  const jsonPath = path.join(out, `testssl-raw-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`);
+  const base = [
+    '--quiet', '--warnings', 'off', '--color', '0',
+    '--jsonfile-pretty', jsonPath,
+  ];
+  if (mode === 'fast') base.push('--fast');
+  base.push(target);
+  base.__jsonPath = jsonPath;
+  return base;
+}
+
+async function runTestssl(runner, target, mode, log) {
+  const argv = runner.argv(target, mode);
+  const jsonPath = argv.__jsonPath;
+  log(`scanning ${target}`);
+  await runCapture(runner.cmd, argv, { allowNonZero: true }); // testssl exits non-zero when it finds issues
+  let raw;
+  try { raw = JSON.parse(await fs.readFile(jsonPath, 'utf8')); }
+  catch (err) { throw new Error(`testssl produced no parseable JSON at ${jsonPath}: ${err.message}`); }
+  fs.rm(jsonPath, { force: true }).catch(() => {}); // best-effort cleanup
+  return raw;
+}
+
+function runCapture(cmd, argv, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, argv, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '', stderr = '';
+    child.stdout.on('data', d => { stdout += d; });
+    child.stderr.on('data', d => { stderr += d; });
+    child.on('error', reject);
+    child.on('close', code => {
+      if (code === 0 || opts.allowNonZero) resolve(stdout);
+      else reject(new Error(`${cmd} exited ${code}: ${stderr.trim().slice(0, 500)}`));
+    });
+  });
+}
+
+function commandExists(cmd) {
+  return runCapture(process.platform === 'win32' ? 'where' : 'which', [cmd])
+    .then(() => true).catch(() => false);
+}
+
+/** ---- Normalization: testssl JSON → v1 Finding doc ---- */
+
+function normalizeTargetFindings(raw, target, runId, sourceVersion) {
+  const entries = extractEntries(raw);
+  const { host, port } = parseTarget(target);
+  const collectedAt = new Date().toISOString();
+
+  const evaluations = [];
+  const narrative = [];
+  // Track which (framework, control_id, mapping_key) tuples we've already emitted to avoid duplicates.
+  const seen = new Set();
+
+  for (const entry of entries) {
+    const id = String(entry.id || '');
+    const status = entrySeverityToStatus(entry);
+    const severity = entrySeverityToOurSeverity(entry);
+    const mappings = mapTestsslId(id, entry);
+    if (!mappings.length) continue;
+
+    for (const m of mappings) {
+      const key = `${m.framework}::${m.control_id}::${id}::${status}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const ev = {
+        control_framework: m.framework,
+        control_id: m.control_id,
+        status,
+        severity,
+      };
+      if (status === 'fail' || status === 'inconclusive') {
+        ev.message = formatMessage(entry, id);
+      }
+      evaluations.push(ev);
+    }
+
+    if (entry.cve || (status === 'fail' && severity === 'critical')) {
+      narrative.push({
+        id: `${SOURCE}-${id}`,
+        title: `${id} — ${truncate(entry.finding || '', 100)}`,
+        severity,
+        description: formatMessage(entry, id),
+        related_control_ids: mappings.map(m => `${m.framework}:${m.control_id}`),
+      });
+    }
+  }
+
+  if (evaluations.length === 0) {
+    evaluations.push({
+      control_framework: 'SCF',
+      control_id: 'CRY-03',
+      status: 'inconclusive',
+      severity: 'info',
+      message: 'testssl.sh produced no recognized TLS findings for this endpoint. Either the target is not exposing TLS, the scan was blocked, or all checked tests fell outside the mapping table.',
+    });
+  }
+
+  return {
+    schema_version: '1.0.0',
+    source: SOURCE,
+    source_version: `${SOURCE_VERSION}+testssl-${sourceVersion}`,
+    run_id: runId,
+    collected_at: collectedAt,
+    resource: {
+      type: 'tls_endpoint',
+      id: `${host}:${port}`,
+      uri: `https://${host}:${port}/`,
+      region: null,
+      account_id: null,
+    },
+    evaluations,
+    findings: narrative.slice(0, 50), // narrative cap to keep documents bounded
+    metadata: {
+      target,
+      host,
+      port,
+      mode_was: raw?.scanTime ? 'full' : 'unknown',
+    },
+  };
+}
+
+function extractEntries(raw) {
+  if (Array.isArray(raw)) return raw;
+  if (Array.isArray(raw?.scanResult)) {
+    // Older testssl multi-target shape: scanResult[0].pretests + .protocols + .ciphers + ...
+    const out = [];
+    for (const target of raw.scanResult) {
+      for (const k of Object.keys(target)) {
+        const v = target[k];
+        if (Array.isArray(v)) out.push(...v);
+      }
+    }
+    return out;
+  }
+  return [];
+}
+
+function parseTarget(target) {
+  const [host, portRaw] = target.split(':');
+  const port = portRaw && /^\d+$/.test(portRaw) ? Number(portRaw) : 443;
+  return { host, port };
+}
+
+function entrySeverityToStatus(entry) {
+  const s = String(entry.severity || '').toUpperCase();
+  if (s === 'OK' || s === 'INFO') return 'pass';
+  if (s === 'LOW' || s === 'MEDIUM' || s === 'HIGH' || s === 'CRITICAL' || s === 'WARN' || s === 'FATAL') return 'fail';
+  if (s === 'DEBUG') return 'pass';
+  return 'inconclusive';
+}
+
+function entrySeverityToOurSeverity(entry) {
+  const s = String(entry.severity || '').toUpperCase();
+  if (s === 'CRITICAL' || s === 'FATAL') return 'critical';
+  if (s === 'HIGH') return 'high';
+  if (s === 'MEDIUM' || s === 'WARN') return 'medium';
+  if (s === 'LOW') return 'low';
+  return 'info';
+}
+
+function formatMessage(entry, id) {
+  const parts = [];
+  if (entry.finding) parts.push(entry.finding);
+  if (entry.cve) parts.push(`CVE: ${entry.cve}`);
+  if (entry.cwe) parts.push(`CWE: ${entry.cwe}`);
+  return parts.join(' — ') || `testssl.sh ${id}: ${entry.severity || 'no detail'}`;
+}
+
+function truncate(s, n) {
+  return s.length <= n ? s : s.slice(0, n - 1) + '…';
+}
+
+/** ---- Control mapping ----
+ * Each function returns an array of {framework, control_id} pairs for a given testssl id.
+ * The mapping is intentionally conservative — only well-established crosswalks.
+ */
+
+const MAPPINGS = (() => {
+  // Group: protocol support (TLS 1.0/1.1 weak, TLS 1.2/1.3 strong, SSLv2/SSLv3 broken)
+  const protocolWeak = [
+    { framework: 'SOC2-TSC-2017',    control_id: 'CC6.7' },
+    { framework: 'NIST-800-53-r5',   control_id: 'SC-8' },
+    { framework: 'NIST-800-53-r5',   control_id: 'SC-13' },
+    { framework: 'PCI-DSS-4.0',      control_id: '4.2.1' },
+    { framework: 'ISO-27001-2022',   control_id: 'A.8.24' },
+    { framework: 'SCF',              control_id: 'CRY-03' },
+  ];
+  // Group: cipher suite checks
+  const cipherWeak = [
+    { framework: 'SOC2-TSC-2017',    control_id: 'CC6.7' },
+    { framework: 'NIST-800-53-r5',   control_id: 'SC-13' },
+    { framework: 'PCI-DSS-4.0',      control_id: '4.2.1.1' },
+    { framework: 'ISO-27001-2022',   control_id: 'A.8.24' },
+    { framework: 'SCF',              control_id: 'CRY-04' },
+  ];
+  // Group: certificate posture
+  const certificate = [
+    { framework: 'SOC2-TSC-2017',    control_id: 'CC6.1' },
+    { framework: 'NIST-800-53-r5',   control_id: 'SC-17' },
+    { framework: 'PCI-DSS-4.0',      control_id: '4.2.1' },
+    { framework: 'ISO-27001-2022',   control_id: 'A.8.24' },
+    { framework: 'SCF',              control_id: 'CRY-08' },
+  ];
+  // Group: known TLS CVEs / vulnerability management
+  const cve = [
+    { framework: 'SOC2-TSC-2017',    control_id: 'CC6.6' },
+    { framework: 'NIST-800-53-r5',   control_id: 'RA-5' },
+    { framework: 'NIST-800-53-r5',   control_id: 'SI-2' },
+    { framework: 'PCI-DSS-4.0',      control_id: '6.3.3' },
+    { framework: 'ISO-27001-2022',   control_id: 'A.8.8' },
+    { framework: 'SCF',              control_id: 'VPM-03' },
+  ];
+  // Group: HTTP transport security headers
+  const headers = [
+    { framework: 'SOC2-TSC-2017',    control_id: 'CC6.7' },
+    { framework: 'NIST-800-53-r5',   control_id: 'SC-8' },
+    { framework: 'ISO-27001-2022',   control_id: 'A.8.20' },
+    { framework: 'SCF',              control_id: 'CRY-03' },
+  ];
+
+  // Map specific testssl id (or prefix) → group
+  // Keys checked with both exact match and prefix match (longest prefix wins).
+  return {
+    // ---- protocols ----
+    'SSLv2': protocolWeak,
+    'SSLv3': protocolWeak,
+    'TLS1':  protocolWeak,
+    'TLS1_1': protocolWeak,
+    'TLS1_2': protocolWeak,   // mapped — but if "offered" then passes; "not offered" is a fail
+    'TLS1_3': protocolWeak,
+    // ---- ciphers ----
+    'cipher_negotiated': cipherWeak,
+    'cipher_order':      cipherWeak,
+    'cipherlist_':       cipherWeak, // prefix: cipherlist_NULL, cipherlist_LOW, etc.
+    'std_NULL':          cipherWeak,
+    'std_aNULL':         cipherWeak,
+    'std_EXPORT':        cipherWeak,
+    'std_LOW':           cipherWeak,
+    'std_3DES_IDEA':     cipherWeak,
+    'std_OBSOLETED':     cipherWeak,
+    'std_STRONG_NOFS':   cipherWeak,
+    'std_STRONG_FS':     cipherWeak,
+    // ---- certificate ----
+    'cert_': certificate, // prefix
+    'OCSP_': certificate, // prefix
+    'CT':    certificate,
+    'DNS_CAArecord': certificate,
+    // ---- known CVEs ----
+    'heartbleed':           cve,
+    'CCS':                  cve,
+    'ticketbleed':          cve,
+    'ROBOT':                cve,
+    'secure_renego':        cve,
+    'secure_client_renego': cve,
+    'CRIME_TLS':            cve,
+    'BREACH':               cve,
+    'POODLE_SSL':           cve,
+    'fallback_SCSV':        cve,
+    'SWEET32':              cve,
+    'FREAK':                cve,
+    'DROWN':                cve,
+    'LOGJAM':               cve,
+    'LOGJAM-common_primes': cve,
+    'BEAST_CBC_TLS1':       cve,
+    'BEAST':                cve,
+    'LUCKY13':              cve,
+    'winshock':             cve,
+    'RC4':                  cve,
+    // ---- security headers ----
+    'HSTS':                 headers,
+    'HSTS_preload':         headers,
+    'HSTS_time':            headers,
+    'HPKP':                 headers,
+    'cookie_secure':        headers,
+    'cookie_httponly':      headers,
+    'banner_server':        headers,
+    'banner_application':   headers,
+    'security_headers':     headers,
+  };
+})();
+
+function mapTestsslId(id, _entry) {
+  if (!id) return [];
+  // Exact match first
+  if (MAPPINGS[id]) return MAPPINGS[id];
+  // Longest-prefix match
+  let bestKey = null;
+  for (const key of Object.keys(MAPPINGS)) {
+    if (key.endsWith('_') || (!MAPPINGS[id] && id.startsWith(key + '_'))) {
+      if (id.startsWith(key) && (bestKey === null || key.length > bestKey.length)) {
+        bestKey = key;
+      }
+    }
+  }
+  return bestKey ? MAPPINGS[bestKey] : [];
+}
+
+/** ---- Utils ---- */
+
+function makeRunId() {
+  return `tssl-${new Date().toISOString().replace(/[:.]/g, '').slice(0, 15)}-${crypto.randomBytes(3).toString('hex')}`;
+}
+
+async function appendRunLog(record) {
+  const line = JSON.stringify(record) + '\n';
+  try { await fs.appendFile(RUNS_LOG, line); } catch {}
+}
+
+function fail(code, msg) {
+  process.stderr.write(`[${SOURCE}] ${msg}\n`);
+  process.exit(code);
+}
+
+function parseYaml(text) {
+  // Minimal YAML for the small config shape we support: key: value, lists with "- " items.
+  const out = {};
+  let listKey = null;
+  for (const line of text.split('\n')) {
+    const trimmed = line.replace(/#.*$/, '').replace(/\s+$/, '');
+    if (!trimmed) continue;
+    if (/^\s+- /.test(trimmed) && listKey) {
+      out[listKey].push(trimmed.replace(/^\s+- /, '').replace(/^["']|["']$/g, ''));
+      continue;
+    }
+    const m = /^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/.exec(trimmed);
+    if (!m) continue;
+    const [, k, v] = m;
+    if (v === '') { out[k] = []; listKey = k; continue; }
+    listKey = null;
+    if (v === 'true') out[k] = true;
+    else if (v === 'false') out[k] = false;
+    else if (/^[0-9]+$/.test(v)) out[k] = Number(v);
+    else out[k] = v.replace(/^["']|["']$/g, '');
+  }
+  return out;
+}
+
+const invokedFromCLI = import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedFromCLI) {
+  main(process.argv.slice(2)).catch(err => { fail(1, err.stack || err.message); });
+}

--- a/plugins/connectors/testssl-inspector/scripts/setup.sh
+++ b/plugins/connectors/testssl-inspector/scripts/setup.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# testssl-inspector:setup — verify testssl.sh is reachable and write default config.
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors"
+CONFIG_FILE="$CONFIG_DIR/testssl-inspector.yaml"
+SOURCE="testssl-inspector"
+SOURCE_VERSION="0.1.0"
+
+USE_DOCKER="false"
+TARGETS=()
+for arg in "$@"; do
+  case "$arg" in
+    --docker)        USE_DOCKER="true" ;;
+    --target=*)      TARGETS+=("${arg#*=}") ;;
+    -h|--help)
+      cat <<'EOF'
+testssl-inspector:setup — locate testssl.sh and write default targets.
+
+Usage:
+  /testssl-inspector:setup [--docker] [--target=host[:port]] [--target=...]
+
+Examples:
+  /testssl-inspector:setup --target=example.com
+  /testssl-inspector:setup --docker --target=example.com:8443 --target=api.example.com
+EOF
+      exit 0 ;;
+    *) echo "[$SOURCE:setup] unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+resolve_binary() {
+  for candidate in testssl.sh testssl; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"; return 0
+    fi
+  done
+  for candidate in \
+    "$HOME/.local/share/testssl.sh/testssl.sh" \
+    "/opt/testssl.sh/testssl.sh" \
+    "/usr/local/bin/testssl.sh"; do
+    [[ -x "$candidate" ]] && { echo "$candidate"; return 0; }
+  done
+  return 1
+}
+
+TESTSSL_BIN=""
+VERSION="unknown"
+RUNNER="native"
+
+if [[ "$USE_DOCKER" == "true" ]]; then
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "[$SOURCE:setup] --docker passed but docker is not on PATH." >&2
+    exit 3
+  fi
+  RUNNER="docker"
+  if docker image inspect drwetter/testssl.sh:latest >/dev/null 2>&1; then
+    VERSION=$(docker run --rm drwetter/testssl.sh:latest --version 2>/dev/null \
+      | grep -Eo 'testssl\.sh +[0-9][^ ,]*' | awk '{print $2}' | head -1)
+    VERSION="${VERSION:-unknown}"
+  else
+    echo "[$SOURCE:setup] drwetter/testssl.sh image not pulled yet. Pulling..."
+    docker pull drwetter/testssl.sh:latest >/dev/null
+    VERSION=$(docker run --rm drwetter/testssl.sh:latest --version 2>/dev/null \
+      | grep -Eo 'testssl\.sh +[0-9][^ ,]*' | awk '{print $2}' | head -1)
+    VERSION="${VERSION:-unknown}"
+  fi
+else
+  if TESTSSL_BIN=$(resolve_binary); then
+    VERSION=$("$TESTSSL_BIN" --version 2>/dev/null \
+      | grep -Eo 'testssl\.sh +[0-9][^ ,]*' | awk '{print $2}' | head -1)
+    VERSION="${VERSION:-unknown}"
+  else
+    cat >&2 <<EOF
+[$SOURCE:setup] testssl.sh not found on PATH or in common install paths.
+
+Install one of these and re-run:
+  macOS:           brew install testssl
+  Debian/Ubuntu:   sudo apt-get install -y testssl.sh
+  From source:     git clone https://github.com/testssl/testssl.sh ~/.local/share/testssl.sh
+                   export PATH="\$HOME/.local/share/testssl.sh:\$PATH"
+
+Or use Docker without installing anything:
+  /testssl-inspector:setup --docker
+EOF
+    exit 3
+  fi
+fi
+
+mkdir -p "$CONFIG_DIR"
+{
+  echo "version: 1"
+  echo "source: $SOURCE"
+  echo "source_version: \"$SOURCE_VERSION\""
+  if [[ "$RUNNER" == "docker" ]]; then
+    echo "use_docker: true"
+  else
+    echo "use_docker: false"
+    echo "testssl_path: \"$TESTSSL_BIN\""
+  fi
+  echo "testssl_version: \"$VERSION\""
+  echo "targets:"
+  if (( ${#TARGETS[@]} == 0 )); then
+    echo "  # add targets as: - host[:port]"
+  else
+    for t in "${TARGETS[@]}"; do echo "  - \"$t\""; done
+  fi
+} > "$CONFIG_FILE"
+
+CACHE_DIR="$HOME/.cache/claude-grc/findings/testssl-inspector"
+mkdir -p "$CACHE_DIR"
+touch "$HOME/.cache/claude-grc/runs.log"
+
+cat <<EOF
+testssl-inspector:setup ✓
+  runner:           $RUNNER${TESTSSL_BIN:+ ($TESTSSL_BIN)}
+  testssl version: $VERSION
+  config:          $CONFIG_FILE
+  targets:         ${#TARGETS[@]} configured
+
+Next:
+  /testssl-inspector:scan --target=example.com
+  /testssl-inspector:scan --target=example.com --fast
+  /grc-engineer:gap-assessment SOC2,PCI-DSS --sources=testssl-inspector
+EOF

--- a/plugins/connectors/testssl-inspector/scripts/status.sh
+++ b/plugins/connectors/testssl-inspector/scripts/status.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# testssl-inspector:status — quick health view.
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_GRC_CONFIG_DIR:-$HOME/.config/claude-grc}/connectors"
+CONFIG_FILE="$CONFIG_DIR/testssl-inspector.yaml"
+CACHE_DIR="$HOME/.cache/claude-grc/findings/testssl-inspector"
+SOURCE="testssl-inspector"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "$SOURCE:status — not configured. Run /testssl-inspector:setup."
+  exit 5
+fi
+
+VERSION=$(grep -E '^testssl_version:' "$CONFIG_FILE" 2>/dev/null | awk -F'"' '{print $2}')
+RUNNER="native"
+if grep -qE '^use_docker:\s*true' "$CONFIG_FILE" 2>/dev/null; then RUNNER="docker"; fi
+TESTSSL_PATH=$(grep -E '^testssl_path:' "$CONFIG_FILE" 2>/dev/null | awk -F'"' '{print $2}')
+
+TARGET_COUNT=0
+if grep -qE '^targets:' "$CONFIG_FILE" 2>/dev/null; then
+  TARGET_COUNT=$(awk '/^targets:/{ flag=1; next } flag && /^[A-Za-z_]/{ flag=0 } flag && /^[[:space:]]*-/{ c++ } END{ print c+0 }' "$CONFIG_FILE")
+fi
+
+RECENT_RUNS=0
+LATEST_RUN=""
+if [[ -d "$CACHE_DIR" ]]; then
+  RECENT_RUNS=$(find "$CACHE_DIR" -maxdepth 1 -name '*.json' -type f 2>/dev/null | wc -l | tr -d ' ')
+  LATEST_RUN=$(ls -1t "$CACHE_DIR"/*.json 2>/dev/null | head -1 | xargs -I{} basename {} 2>/dev/null || true)
+fi
+
+cat <<EOF
+testssl-inspector:status
+  runner:          $RUNNER${TESTSSL_PATH:+ ($TESTSSL_PATH)}
+  testssl version: ${VERSION:-unknown}
+  config:          $CONFIG_FILE
+  targets:         $TARGET_COUNT configured
+  cache:           $CACHE_DIR
+  scans on disk:   $RECENT_RUNS
+  latest:          ${LATEST_RUN:-<none>}
+EOF

--- a/plugins/connectors/testssl-inspector/skills/testssl-inspector-expert/SKILL.md
+++ b/plugins/connectors/testssl-inspector/skills/testssl-inspector-expert/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: testssl-inspector-expert
+description: Interpret testssl-inspector normalized findings, recommend remediations, and tie evidence back to SOC 2 / NIST 800-53 / PCI DSS 4.0.1 / ISO 27001 / SCF controls.
+license: MIT
+---
+
+# testssl Inspector Expert
+
+Use this skill when reviewing findings produced by `/testssl-inspector:scan`. The connector wraps `testssl.sh` and emits v1 Findings against `tls_endpoint` resources; this skill translates those into remediation advice an engineer can act on and audit evidence a reviewer can sign off.
+
+## Reading the output
+
+Findings live at `~/.cache/claude-grc/findings/testssl-inspector/<run_id>.json`. Each document covers one TLS endpoint:
+
+- `resource.type = "tls_endpoint"`, `resource.id = "<host>:<port>"`, `resource.uri = "https://<host>:<port>/"`
+- `evaluations[]` — one entry per (control_framework, control_id, testssl finding) tuple
+- `findings[]` — narrative roll-up for CVEs and critical results (cap 50 per doc)
+- `metadata.target`, `metadata.host`, `metadata.port` — the original input
+
+## What testssl IDs mean
+
+Most fails fall into one of five families. The remediation pattern is the same within each family.
+
+### Family 1 — Weak protocol offered
+
+IDs: `SSLv2`, `SSLv3`, `TLS1`, `TLS1_1`. Maps to SOC 2 CC6.7, NIST SC-8/SC-13, PCI 4.2.1, ISO A.8.24, SCF CRY-03.
+
+Remediation:
+
+- Terminate TLS at a load balancer or web server that supports a TLS 1.2+ minimum. AWS ALB: set the security policy to `ELBSecurityPolicy-TLS-1-2-2017-01` or newer. NGINX: `ssl_protocols TLSv1.2 TLSv1.3;`. Apache: `SSLProtocol -all +TLSv1.2 +TLSv1.3`.
+- PCI DSS 4.0.1 specifically prohibits SSL and "early TLS" (1.0/1.1) — these are audit-fail conditions, not advisories.
+
+### Family 2 — Weak ciphers in the offered list
+
+IDs: `cipher_negotiated`, `cipherlist_*` (`NULL`, `aNULL`, `EXPORT`, `LOW`, `3DES_IDEA`, `OBSOLETED`), `RC4`, `std_*` variants. Maps to CC6.7, SC-13, PCI 4.2.1.1, A.8.24, SCF CRY-04.
+
+Remediation:
+
+- Pin an explicit cipher list. Modern baseline: `TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384`.
+- Prefer forward-secrecy ciphers (ECDHE/DHE families). Anything without `(EC)DHE` should be disabled in 2026.
+
+### Family 3 — Certificate posture
+
+IDs: `cert_expirationStatus`, `cert_notAfter`, `cert_signatureAlgorithm`, `cert_keySize`, `cert_chain_of_trust`, `OCSP_*`, `CT`, `DNS_CAArecord`. Maps to CC6.1, SC-17, PCI 4.2.1, A.8.24, SCF CRY-08.
+
+Remediation depends on the specific failure:
+
+- **Expired / near-expiry**: rotate via ACM (AWS), Let's Encrypt, or your CA portal. Set up rotation alerts at T-30, T-14, T-7 days.
+- **Weak signature** (SHA-1, MD5): reissue with SHA-256+ signature.
+- **Weak key size** (RSA <2048): reissue with RSA 2048+ or ECDSA P-256+.
+- **Broken chain**: server is missing an intermediate. Re-deploy the cert bundle with the full chain (your CA's portal shows the bundle order).
+- **No CAA record**: add a `CAA` DNS record naming your authorized issuer(s) — defense against unauthorized certificate issuance.
+
+### Family 4 — Known TLS CVEs
+
+IDs: `heartbleed`, `CCS`, `ticketbleed`, `ROBOT`, `secure_renego`, `secure_client_renego`, `CRIME_TLS`, `BREACH`, `POODLE_SSL`, `fallback_SCSV`, `SWEET32`, `FREAK`, `DROWN`, `LOGJAM`, `BEAST`, `LUCKY13`, `RC4`, `winshock`. Maps to CC6.6, RA-5, SI-2, PCI 6.3.3, A.8.8, SCF VPM-03.
+
+These are not configuration tuning — they're vulnerability remediation. Treat any non-`OK` finding here as an audit-tracked vuln with a remediation deadline. Most are addressed by:
+
+- Patching OpenSSL / the TLS implementation on the server.
+- Disabling vulnerable protocols/ciphers (e.g., POODLE → drop SSLv3; SWEET32 → drop 3DES/Blowfish; BEAST → use TLS 1.2+).
+- For BREACH (HTTP-layer): disable HTTP compression for responses containing sensitive data, or add a per-request masking token.
+
+### Family 5 — HTTP transport headers
+
+IDs: `HSTS`, `HSTS_preload`, `HSTS_time`, `HPKP`, `cookie_secure`, `cookie_httponly`, `banner_*`, `security_headers`. Maps to CC6.7, SC-8, A.8.20, SCF CRY-03.
+
+Remediation:
+
+- **HSTS missing or short max-age**: `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` and submit to the HSTS preload list (hstspreload.org) for the strongest posture.
+- **Cookies without `Secure` or `HttpOnly`**: fix the application — set both flags on every session cookie.
+- **HPKP**: deprecated; if testssl flags HPKP usage, plan to remove it (browsers no longer enforce).
+
+## Evidence packaging
+
+For an audit, the auditor wants three things per finding:
+
+1. The raw testssl JSON or its normalized v1 doc (already in `~/.cache/claude-grc/findings/testssl-inspector/<run_id>.json`).
+2. The scan timestamp (`collected_at` field).
+3. A remediation narrative tying each failed evaluation to a specific control and a future check.
+
+Workflow:
+
+```bash
+/testssl-inspector:scan --target=auth.example.com --target=api.example.com
+# Inspect the resulting findings file. Attach it to the audit evidence packet
+# alongside the remediation tickets opened for each fail.
+
+/grc-engineer:gap-assessment SOC2,PCI-DSS --sources=testssl-inspector
+# Aggregates testssl evaluations with your other connector outputs into a
+# control-by-control posture view.
+```
+
+## What you will not do
+
+- Don't run testssl against endpoints you don't own or are not authorized to test. testssl makes hundreds of connections per target and looks like a scanner to defenders.
+- Don't recommend ignoring a fail because "the application is internal." TLS 1.0/1.1 and weak ciphers are no less broken on intranets.
+- Don't recommend disabling individual checks just because they're noisy. If a check produces too many false positives, raise an issue against this connector with the testssl `id` and reasoning so we can refine the mapping table.
+- Don't claim a finding maps to a framework beyond the five listed in `scan.md`. If a user asks about SP 800-52 Rev. 2 specifically, point them at the relevant framework plugin instead.

--- a/tests/fixtures/findings/testssl-inspector/001-clean-modern.json
+++ b/tests/fixtures/findings/testssl-inspector/001-clean-modern.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.0.0",
+  "source": "testssl-inspector",
+  "source_version": "0.1.0+testssl-3.2",
+  "run_id": "fixture-tssl-001",
+  "collected_at": "2026-05-14T18:00:00Z",
+  "resource": {
+    "type": "tls_endpoint",
+    "id": "clean.example.com:443",
+    "uri": "https://clean.example.com:443/",
+    "region": null,
+    "account_id": null
+  },
+  "evaluations": [
+    {
+      "control_framework": "SOC2-TSC-2017",
+      "control_id": "CC6.7",
+      "status": "pass",
+      "severity": "info"
+    },
+    {
+      "control_framework": "NIST-800-53-r5",
+      "control_id": "SC-8",
+      "status": "pass",
+      "severity": "info"
+    },
+    {
+      "control_framework": "PCI-DSS-4.0",
+      "control_id": "4.2.1",
+      "status": "pass",
+      "severity": "info"
+    },
+    {
+      "control_framework": "ISO-27001-2022",
+      "control_id": "A.8.24",
+      "status": "pass",
+      "severity": "info"
+    },
+    {
+      "control_framework": "SCF",
+      "control_id": "CRY-03",
+      "status": "pass",
+      "severity": "info"
+    }
+  ],
+  "metadata": {
+    "target": "clean.example.com",
+    "host": "clean.example.com",
+    "port": 443
+  }
+}

--- a/tests/fixtures/findings/testssl-inspector/002-weak-protocol.json
+++ b/tests/fixtures/findings/testssl-inspector/002-weak-protocol.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "1.0.0",
+  "source": "testssl-inspector",
+  "source_version": "0.1.0+testssl-3.2",
+  "run_id": "fixture-tssl-002",
+  "collected_at": "2026-05-14T18:01:00Z",
+  "resource": {
+    "type": "tls_endpoint",
+    "id": "legacy.example.com:443",
+    "uri": "https://legacy.example.com:443/",
+    "region": null,
+    "account_id": null
+  },
+  "evaluations": [
+    {
+      "control_framework": "SOC2-TSC-2017",
+      "control_id": "CC6.7",
+      "status": "fail",
+      "severity": "high",
+      "message": "TLS 1.0 offered — testssl id TLS1, severity HIGH. PCI DSS 4.0.1 prohibits TLS 1.0/1.1; SOC 2 CC6.7 requires modern transmission encryption."
+    },
+    {
+      "control_framework": "NIST-800-53-r5",
+      "control_id": "SC-8",
+      "status": "fail",
+      "severity": "high",
+      "message": "TLS 1.0 offered — testssl id TLS1. SC-8 requires confidentiality of transmitted information using approved cryptography (FIPS-validated TLS 1.2+)."
+    },
+    {
+      "control_framework": "NIST-800-53-r5",
+      "control_id": "SC-13",
+      "status": "fail",
+      "severity": "high",
+      "message": "TLS 1.0 offered — testssl id TLS1. SC-13 requires approved cryptographic mechanisms; TLS 1.0 is deprecated."
+    },
+    {
+      "control_framework": "PCI-DSS-4.0",
+      "control_id": "4.2.1",
+      "status": "fail",
+      "severity": "critical",
+      "message": "TLS 1.0 offered — testssl id TLS1. PCI DSS 4.0.1 4.2.1 explicitly forbids SSL and early TLS (1.0/1.1)."
+    },
+    {
+      "control_framework": "ISO-27001-2022",
+      "control_id": "A.8.24",
+      "status": "fail",
+      "severity": "high",
+      "message": "TLS 1.0 offered — testssl id TLS1. A.8.24 requires cryptography to be used in accordance with the organization's policy and applicable agreements."
+    },
+    {
+      "control_framework": "SCF",
+      "control_id": "CRY-03",
+      "status": "fail",
+      "severity": "high",
+      "message": "TLS 1.0 offered — testssl id TLS1. CRY-03 requires transmission of sensitive data to use cryptographic mechanisms aligned with current standards."
+    }
+  ],
+  "findings": [
+    {
+      "id": "testssl-inspector-TLS1",
+      "title": "TLS1 — offered (deprecated)",
+      "severity": "high",
+      "description": "TLS 1.0 offered — testssl id TLS1, severity HIGH.",
+      "related_control_ids": [
+        "SOC2-TSC-2017:CC6.7",
+        "NIST-800-53-r5:SC-8",
+        "NIST-800-53-r5:SC-13",
+        "PCI-DSS-4.0:4.2.1",
+        "ISO-27001-2022:A.8.24",
+        "SCF:CRY-03"
+      ]
+    }
+  ],
+  "metadata": {
+    "target": "legacy.example.com",
+    "host": "legacy.example.com",
+    "port": 443
+  }
+}

--- a/tests/fixtures/findings/testssl-inspector/003-heartbleed.json
+++ b/tests/fixtures/findings/testssl-inspector/003-heartbleed.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "1.0.0",
+  "source": "testssl-inspector",
+  "source_version": "0.1.0+testssl-3.2",
+  "run_id": "fixture-tssl-003",
+  "collected_at": "2026-05-14T18:02:00Z",
+  "resource": {
+    "type": "tls_endpoint",
+    "id": "vuln.example.com:443",
+    "uri": "https://vuln.example.com:443/",
+    "region": null,
+    "account_id": null
+  },
+  "evaluations": [
+    {
+      "control_framework": "SOC2-TSC-2017",
+      "control_id": "CC6.6",
+      "status": "fail",
+      "severity": "critical",
+      "message": "Heartbleed (CVE-2014-0160) — vulnerable, info leak. CC6.6 vulnerability management requires identification and remediation of known vulnerabilities."
+    },
+    {
+      "control_framework": "NIST-800-53-r5",
+      "control_id": "RA-5",
+      "status": "fail",
+      "severity": "critical",
+      "message": "Heartbleed (CVE-2014-0160) — vulnerable, info leak. RA-5 requires regular vulnerability scanning and remediation."
+    },
+    {
+      "control_framework": "NIST-800-53-r5",
+      "control_id": "SI-2",
+      "status": "fail",
+      "severity": "critical",
+      "message": "Heartbleed (CVE-2014-0160) — vulnerable, info leak. SI-2 requires timely flaw remediation; this CVE has had a patched OpenSSL release since 2014."
+    },
+    {
+      "control_framework": "PCI-DSS-4.0",
+      "control_id": "6.3.3",
+      "status": "fail",
+      "severity": "critical",
+      "message": "Heartbleed (CVE-2014-0160) — vulnerable, info leak. PCI 6.3.3 requires high-risk vulnerabilities be addressed within 1 month."
+    },
+    {
+      "control_framework": "ISO-27001-2022",
+      "control_id": "A.8.8",
+      "status": "fail",
+      "severity": "critical",
+      "message": "Heartbleed (CVE-2014-0160) — vulnerable, info leak. A.8.8 requires management of technical vulnerabilities."
+    },
+    {
+      "control_framework": "SCF",
+      "control_id": "VPM-03",
+      "status": "fail",
+      "severity": "critical",
+      "message": "Heartbleed (CVE-2014-0160) — vulnerable, info leak. VPM-03 requires remediation of identified vulnerabilities within risk-based timeframes."
+    }
+  ],
+  "findings": [
+    {
+      "id": "testssl-inspector-heartbleed",
+      "title": "heartbleed — vulnerable, info leak",
+      "severity": "critical",
+      "description": "Heartbleed (CVE-2014-0160) — vulnerable, info leak — CVE: CVE-2014-0160",
+      "related_control_ids": [
+        "SOC2-TSC-2017:CC6.6",
+        "NIST-800-53-r5:RA-5",
+        "NIST-800-53-r5:SI-2",
+        "PCI-DSS-4.0:6.3.3",
+        "ISO-27001-2022:A.8.8",
+        "SCF:VPM-03"
+      ]
+    }
+  ],
+  "metadata": {
+    "target": "vuln.example.com",
+    "host": "vuln.example.com",
+    "port": 443
+  }
+}


### PR DESCRIPTION
Closes #152 / GRC-55.

## What ships

A new connector plugin at \`plugins/connectors/testssl-inspector/\` that wraps [testssl.sh](https://github.com/testssl/testssl.sh) and emits v1 Findings against \`tls_endpoint\` resources.

**Three commands** (existing inspector convention):
- \`/testssl-inspector:setup\` — locate testssl.sh (native install or \`--docker\` fallback), record version, seed config
- \`/testssl-inspector:scan\` — run testssl in \`--fast\` or \`--full\` mode against one or more targets, normalize JSON to v1 Findings, write to cache
- \`/testssl-inspector:status\` — runner, version, target count, recent scans

**One skill** — \`testssl-inspector-expert\` — interprets findings, groups them into five remediation families (weak protocols / weak ciphers / certificate posture / known CVEs / transport headers), and gives concrete fix patterns per family.

## Control mapping

Each testssl finding maps to evaluations across:

| testssl group           | SOC 2 | NIST 800-53        | PCI DSS 4.0.1 | ISO 27001:2022 | SCF       |
|-------------------------|-------|--------------------|---------------|----------------|-----------|
| Weak protocols (SSLv2/3, TLS 1.0/1.1) | CC6.7 | SC-8, SC-13 | 4.2.1 | A.8.24 | CRY-03 |
| Weak ciphers (NULL, EXPORT, 3DES, RC4) | CC6.7 | SC-13 | 4.2.1.1 | A.8.24 | CRY-04 |
| Certificate posture | CC6.1 | SC-17 | 4.2.1 | A.8.24 | CRY-08 |
| Known CVEs (Heartbleed, ROBOT, POODLE, SWEET32, FREAK, LOGJAM, DROWN, BEAST, ...) | CC6.6 | RA-5, SI-2 | 6.3.3 | A.8.8 | VPM-03 |
| HTTP transport headers (HSTS, HPKP, cookie flags) | CC6.7 | SC-8 | - | A.8.20 | CRY-03 |

Severity translation: \`FATAL\`/\`CRITICAL\` → \`critical\`, \`HIGH\` → \`high\`, \`WARN\`/\`MEDIUM\` → \`medium\`, \`LOW\` → \`low\`, \`OK\`/\`INFO\` → \`info\` (status=pass). Anything else → \`inconclusive\`.

## Test plan

- [x] Plugin manifest validates against \`schemas/plugin.schema.json\` (CI \`Validate plugin and marketplace manifests\` — 63 manifests, all valid)
- [x] Three v1 fixture documents (clean modern endpoint, TLS 1.0 offered, Heartbleed detected) validate against \`schemas/finding.schema.json\` (\`tests/validate-contract-fixtures.sh\` — 49 fixtures, all valid)
- [x] \`node --check\` and \`bash -n\` pass on all scripts
- [x] CLI smoke-tested: \`--help\` works; missing-target produces a helpful error pointing at setup; setup correctly errors with install instructions when testssl is unavailable
- [ ] Manual end-to-end on a host with testssl.sh installed (not exercised locally; reviewers welcome to run \`/testssl-inspector:setup --target=example.com && /testssl-inspector:scan --target=example.com --fast\`)