### PR TITLE
feat(testssl-inspector): drive framework mappings via SCF crosswalks

### DIFF
--- a/plugins/connectors/testssl-inspector/.claude-plugin/plugin.json
+++ b/plugins/connectors/testssl-inspector/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "testssl-inspector",
   "version": "0.1.0",
-  "description": "GRC connector wrapping testssl.sh. Scans HTTPS endpoints for protocol/cipher posture, certificate issues, and known TLS CVEs (Heartbleed, ROBOT, POODLE, FREAK, LOGJAM, SWEET32, ...). Emits findings conforming to schemas/finding.schema.json v1, mapped to SOC 2 CC6.1/CC6.6/CC6.7, NIST 800-53 SC-8/SC-13/SC-17/RA-5/SI-2, PCI DSS 4.0.1 §4, ISO 27001 A.8.20/A.8.24, and SCF CRY/VPM controls.",
+  "description": "GRC connector wrapping testssl.sh. Scans HTTPS endpoints for protocol/cipher posture, certificate issues, and known TLS CVEs (Heartbleed, ROBOT, POODLE, FREAK, LOGJAM, SWEET32, ...). Emits findings conforming to schemas/finding.schema.json v1, anchored on SCF CRY-01/CRY-03/CRY-05/CRY-08/NET-09/VPM-01/VPM-06/WEB-03 and fanned out at scan time via SCF crosswalks to SOC 2 TSC 2017, NIST 800-53 r5, PCI DSS 4.0.1, and ISO 27002:2022.",
   "author": { "name": "GRC Engineering Club Contributors" },
   "license": "MIT",
   "repository": "https://github.com/GRCEngClub/claude-grc-engineering",

--- a/plugins/connectors/testssl-inspector/README.md
+++ b/plugins/connectors/testssl-inspector/README.md
@@ -1,18 +1,20 @@
 # testssl-inspector
 
-A Claude Code plugin that wraps [`testssl.sh`](https://github.com/testssl/testssl.sh) and emits the toolkit's v1 Finding shape, mapped to SOC 2, NIST 800-53 r5, PCI DSS 4.0.1, ISO 27001:2022, and SCF controls.
+A Claude Code plugin that wraps [`testssl.sh`](https://github.com/testssl/testssl.sh) and emits the toolkit's v1 Finding shape. Mappings are anchored on SCF (Secure Controls Framework) controls and fanned out at scan time to SOC 2 TSC 2017, NIST 800-53 r5, PCI DSS 4.0.1, and ISO 27002:2022 via the SCF crosswalk.
 
 ## What it does
 
 Runs `testssl.sh` against one or more HTTPS endpoints, parses the JSON output, and produces structured findings the rest of the toolkit can consume — gap assessments, evidence packs, continuous-monitoring runs.
 
-| What testssl checks | Where it lands in compliance frameworks |
+| What testssl checks | SCF anchors |
 |---|---|
-| Protocols (SSLv2/3, TLS 1.0–1.3) | SOC 2 CC6.7 · NIST SC-8/SC-13 · PCI 4.2.1 · ISO A.8.24 · SCF CRY-03 |
-| Cipher suites (incl. NULL, EXPORT, 3DES, RC4) | SOC 2 CC6.7 · NIST SC-13 · PCI 4.2.1.1 · ISO A.8.24 · SCF CRY-04 |
-| Certificate (expiry, chain, signature, key, CAA, OCSP, CT) | SOC 2 CC6.1 · NIST SC-17 · PCI 4.2.1 · ISO A.8.24 · SCF CRY-08 |
-| Known CVEs (Heartbleed, ROBOT, POODLE, SWEET32, FREAK, LOGJAM, DROWN, BEAST, …) | SOC 2 CC6.6 · NIST RA-5/SI-2 · PCI 6.3.3 · ISO A.8.8 · SCF VPM-03 |
-| HTTP transport headers (HSTS, HPKP, cookie flags) | SOC 2 CC6.7 · NIST SC-8 · ISO A.8.20 · SCF CRY-03 |
+| Protocols (SSLv2/3, TLS 1.0–1.3) | `CRY-01`, `CRY-03`, `NET-09` |
+| Cipher suites (incl. NULL, EXPORT, 3DES, RC4) | `CRY-01.2`, `CRY-05` |
+| Certificate (expiry, chain, signature, key, CAA, OCSP, CT) | `CRY-08` |
+| Known CVEs (Heartbleed, ROBOT, POODLE, SWEET32, FREAK, LOGJAM, DROWN, BEAST, …) | `VPM-01`, `VPM-06` |
+| HTTP transport headers (HSTS, HPKP, cookie flags) | `CRY-03`, `WEB-03`, `NET-09` |
+
+At scan startup the connector fetches per-framework crosswalk JSON from `grcengclub.github.io/scf-api/` (cached under `~/.cache/claude-grc/scf/<version>/`, refreshed every 7 days) and uses it to fan each SCF anchor out to the equivalent control IDs in SOC 2, NIST 800-53 r5, PCI DSS 4.0.1, and ISO 27002:2022. Pass `--scf-only` to skip the fan-out, or `--offline` to stay on cached data. If the mirror is unreachable and no cache is present, the connector falls back to a curated hardcoded mapping covering all five frameworks at one canonical control per family.
 
 ## Install
 

--- a/plugins/connectors/testssl-inspector/commands/scan.md
+++ b/plugins/connectors/testssl-inspector/commands/scan.md
@@ -19,20 +19,31 @@ node plugins/connectors/testssl-inspector/scripts/scan.js [options]
 - `--fast` — `testssl.sh --fast` (~3× faster, drops vulnerability checks).
 - `--full` — full check set (default). Slower; includes CVE checks (Heartbleed, ROBOT, POODLE, BEAST, BREACH, SWEET32, FREAK, LOGJAM, DROWN, …).
 - `--docker` / `--no-docker` — override the runner choice from the config.
+- `--scf-only` — emit only SCF evaluations; skip fan-out to NIST/SOC2/PCI/ISO. Smaller output, no network. Useful for CI or air-gapped environments.
+- `--offline` — never make network calls. Uses cached SCF crosswalks if present (under `~/.cache/claude-grc/scf/<version>/`); otherwise falls back to the hardcoded framework table. testssl itself still has to reach the target.
 - `--output=summary|silent|json` — default `summary` prints counts to stdout; `json` emits machine-readable run info; `silent` writes the cache file and nothing else.
 - `--quiet` — suppress stderr progress lines.
 
 ## What it evaluates
 
-Each testssl.sh finding maps to evaluations across multiple frameworks:
+Each testssl.sh finding is mapped first to one or more **SCF (Secure Controls Framework) control IDs**, then fanned out to downstream frameworks via the SCF crosswalk at `https://grcengclub.github.io/scf-api/`. Crosswalks are cached at `~/.cache/claude-grc/scf/<version>/` (shared with the `grc-engineer` plugin's SCF client) and refreshed every 7 days.
 
-| testssl group | SOC 2 | NIST 800-53 | PCI DSS 4.0.1 | ISO 27001 | SCF |
-|---|---|---|---|---|---|
-| Weak protocols (SSLv2/3, TLS 1.0/1.1) | CC6.7 | SC-8, SC-13 | 4.2.1 | A.8.24 | CRY-03 |
-| Weak ciphers (NULL, EXPORT, 3DES, RC4, anon) | CC6.7 | SC-13 | 4.2.1.1 | A.8.24 | CRY-04 |
-| Certificate posture (expiry, signature, chain, key size, OCSP, CT) | CC6.1 | SC-17 | 4.2.1 | A.8.24 | CRY-08 |
-| Known CVEs (Heartbleed, ROBOT, POODLE, SWEET32, FREAK, LOGJAM, DROWN, BEAST, LUCKY13, …) | CC6.6 | RA-5, SI-2 | 6.3.3 | A.8.8 | VPM-03 |
-| HTTP transport headers (HSTS, HPKP, cookie flags) | CC6.7 | SC-8 | — | A.8.20 | CRY-03 |
+| testssl finding family | SCF anchors |
+|---|---|
+| Weak protocols (SSLv2/3, TLS 1.0/1.1) | `CRY-01`, `CRY-03`, `NET-09` |
+| Weak ciphers (NULL, EXPORT, 3DES, RC4, anon) | `CRY-01.2`, `CRY-05` |
+| Certificate posture (expiry, signature, chain, key size, OCSP, CT) | `CRY-08` |
+| Known CVEs (Heartbleed, ROBOT, POODLE, SWEET32, FREAK, LOGJAM, DROWN, BEAST, LUCKY13, …) | `VPM-01`, `VPM-06` |
+| HTTP transport headers (HSTS, HPKP, cookie flags) | `CRY-03`, `WEB-03`, `NET-09` |
+
+The SCF crosswalk fan-out resolves each anchor to its equivalent controls in:
+
+- **NIST 800-53 r5** (e.g. `CRY-01` → `SC-08(01)`, `SC-08(02)`, `SC-13`, `SI-07(06)`)
+- **SOC 2 TSC 2017** (CC-family controls and POFs)
+- **PCI DSS 4.0.1** (§4 cryptography, §6 vulnerability management, §11 testing)
+- **ISO 27002:2022** (technical Annex A catalog — same numbering as ISO 27001:2022 Annex A, but the 27002 crosswalk has the technical depth; SCF's 27001:2022 crosswalk is sparse)
+
+If the SCF mirror is unreachable (network error, `--offline` with no cache), the script falls back to a curated hardcoded table that covers the same five frameworks at one canonical control per family. This is the v0 behavior; you'll see a `(scf expansion unavailable; framework fallback used)` note in the summary line when it kicks in.
 
 Severity translation: testssl `FATAL`/`CRITICAL` → `critical`; `HIGH` → `high`; `WARN`/`MEDIUM` → `medium`; `LOW` → `low`; `OK`/`INFO` → `info` (and `pass` for status). Anything else → `inconclusive`.
 

--- a/plugins/connectors/testssl-inspector/scripts/scan.js
+++ b/plugins/connectors/testssl-inspector/scripts/scan.js
@@ -5,9 +5,12 @@
  *
  * Wraps testssl.sh and emits findings conforming to schemas/finding.schema.json v1.
  *
- * Resource type is `tls_endpoint`. Each finding from testssl is mapped to one
- * or more control evaluations across SOC 2, NIST 800-53, PCI DSS 4.0.1,
- * ISO 27001:2022, and SCF.
+ * Resource type is `tls_endpoint`. Each testssl finding is mapped first to one
+ * or more SCF (Secure Controls Framework) control IDs, then fanned out to
+ * SOC 2 / NIST 800-53 r5 / PCI DSS 4.0.1 / ISO 27002:2022 via the SCF
+ * crosswalk at https://grcengclub.github.io/scf-api/. If the crosswalk is
+ * unreachable, the script falls back to a curated hardcoded mapping table
+ * (the same controls the v0 of this connector emitted directly).
  */
 
 import fs from 'node:fs/promises';
@@ -20,9 +23,12 @@ import { pathToFileURL } from 'node:url';
 const CONFIG_DIR = process.env.CLAUDE_GRC_CONFIG_DIR || path.join(os.homedir(), '.config', 'claude-grc');
 const CONFIG_FILE = path.join(CONFIG_DIR, 'connectors', 'testssl-inspector.yaml');
 const CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'findings', 'testssl-inspector');
+const SCF_CACHE_DIR = path.join(os.homedir(), '.cache', 'claude-grc', 'scf');
 const RUNS_LOG = path.join(os.homedir(), '.cache', 'claude-grc', 'runs.log');
 const SOURCE = 'testssl-inspector';
 const SOURCE_VERSION = '0.1.0';
+const SCF_BASE_URL = process.env.CLAUDE_GRC_SCF_BASE_URL || 'https://grcengclub.github.io/scf-api';
+const SCF_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 const EXIT = { OK: 0, USAGE: 2, TOOL_UNAVAILABLE: 3, PARTIAL: 4, NOT_CONFIGURED: 5 };
 
@@ -44,6 +50,21 @@ async function main(argv) {
   const runner = await resolveRunner({ useDocker, configBinary: config.testssl_path });
   log(`runner=${runner.label} mode=${mode} targets=${targets.length}`);
 
+  // Pre-fetch SCF crosswalks for the frameworks we expand to. Done once per run.
+  // If --scf-only is passed, or fetching fails, we skip expansion.
+  let expansion = null;
+  if (!args.scfOnly) {
+    try {
+      expansion = await loadCrosswalkExpansion(uniqueScfIds(FAMILY_TO_SCF), { offline: args.offline, log });
+      log(`scf expansion: ${expansion.scfVersion || 'unknown'} (${expansion.frameworkCount} frameworks)`);
+    } catch (err) {
+      log(`scf expansion unavailable (${err.message}); using hardcoded framework fallback`);
+      expansion = null;
+    }
+  } else {
+    log('scf expansion skipped (--scf-only)');
+  }
+
   await fs.mkdir(CACHE_DIR, { recursive: true });
   const runId = makeRunId();
   const startedAt = Date.now();
@@ -53,7 +74,7 @@ async function main(argv) {
   for (const target of targets) {
     try {
       const raw = await runTestssl(runner, target, mode, log);
-      const doc = normalizeTargetFindings(raw, target, runId, runner.version);
+      const doc = normalizeTargetFindings(raw, target, runId, runner.version, expansion);
       findings.push(doc);
     } catch (err) {
       errors.push({ target, error: err.message });
@@ -75,6 +96,7 @@ async function main(argv) {
     source: SOURCE, run_id: runId, started_at: new Date(startedAt).toISOString(),
     duration_ms: Date.now() - startedAt,
     targets: targets.length, errors: errors.length,
+    scf_expansion: expansion ? { scf_version: expansion.scfVersion, frameworks: expansion.frameworkCount } : null,
     counters, severities: sev, cache_path: cachePath,
   });
 
@@ -88,6 +110,7 @@ async function main(argv) {
       `${counters.fail + counters.pass + counters.inconclusive} evaluations, ` +
       `${counters.fail} failing (${failingSev}). ` +
       `${errors.length ? `${errors.length} scan errors. ` : ''}` +
+      `${expansion ? '' : '(scf expansion unavailable; framework fallback used) '}` +
       `→ ${cachePath}\n`
     );
   }
@@ -98,18 +121,20 @@ async function main(argv) {
 }
 
 function parseArgs(argv) {
-  const args = { targets: [], fast: false, docker: undefined, quiet: false, output: 'summary' };
+  const args = { targets: [], fast: false, docker: undefined, quiet: false, output: 'summary', scfOnly: false, offline: false };
   for (const a of argv) {
     if (a === '--fast') args.fast = true;
     else if (a === '--full') args.fast = false;
     else if (a === '--docker') args.docker = true;
     else if (a === '--no-docker') args.docker = false;
     else if (a === '--quiet') args.quiet = true;
+    else if (a === '--scf-only') args.scfOnly = true;
+    else if (a === '--offline') args.offline = true;
     else if (a.startsWith('--target=')) args.targets.push(a.slice(9));
     else if (a.startsWith('--output=')) args.output = a.slice(9);
     else if (a === '-h' || a === '--help') {
       process.stdout.write(
-        `Usage: scan.js --target=host[:port] [--target=...] [--fast|--full] [--docker] [--output=summary|silent|json] [--quiet]\n`
+        `Usage: scan.js --target=host[:port] [--target=...] [--fast|--full] [--docker] [--scf-only] [--offline] [--output=summary|silent|json] [--quiet]\n`
       );
       process.exit(0);
     } else if (!a.startsWith('-')) args.targets.push(a);
@@ -220,39 +245,253 @@ function commandExists(cmd) {
     .then(() => true).catch(() => false);
 }
 
+/** ---- SCF crosswalk expansion ----
+ *
+ * Maps testssl finding families to SCF control IDs (FAMILY_TO_SCF), then at
+ * scan-startup time fetches per-framework crosswalk JSON from the SCF mirror
+ * and builds a lookup: scf_id -> { framework_label: [framework_control_ids] }.
+ *
+ * Cache: ~/.cache/claude-grc/scf/<version>/api/crosswalks/<framework-id>.json
+ * Shared with grc-engineer's scf-client.js cache layout.
+ */
+
+// ISO 27002:2022 is used rather than 27001:2022 because the latter (the ISMS
+// management standard) is mapped sparsely in SCF's public crosswalk and
+// covers almost none of the technical anchors we care about. 27002:2022 holds
+// the Annex A control catalog — same control numbering in 27001:2022 Annex A,
+// just published as its own framework in SCF's catalog.
+const EXPAND_FRAMEWORKS = [
+  { id: 'general-nist-800-53-r5-2', label: 'NIST-800-53-r5' },
+  { id: 'general-aicpa-tsc-2017',   label: 'SOC2-TSC-2017' },
+  { id: 'general-pci-dss-4-0-1',    label: 'PCI-DSS-4.0' },
+  { id: 'general-iso-27002-2022',   label: 'ISO-27002-2022' },
+];
+
+async function loadCrosswalkExpansion(scfIds, { offline, log }) {
+  // First: load the SCF summary to discover the current version (for the cache dir).
+  const summary = await fetchScfFile('api/summary.json', { offline });
+  const scfVersion = (summary && (summary.scf_version || summary.version)) || 'unknown';
+
+  // Fetch crosswalks in parallel.
+  const crosswalks = await Promise.all(
+    EXPAND_FRAMEWORKS.map(async fw => {
+      try {
+        const cw = await fetchScfFile(`api/crosswalks/${encodeURIComponent(fw.id)}.json`, { offline, scfVersion });
+        return { fw, cw };
+      } catch (err) {
+        log(`crosswalk for ${fw.label} unavailable: ${err.message}`);
+        return { fw, cw: null };
+      }
+    })
+  );
+
+  // Build: scf_id -> { framework_label: [framework_control_ids] }
+  const scfIdSet = new Set(scfIds);
+  const lookup = new Map();
+  let frameworkCount = 0;
+  for (const { fw, cw } of crosswalks) {
+    if (!cw) continue;
+    frameworkCount += 1;
+    const mappings = cw?.scf_to_framework?.mappings || {};
+    for (const scfId of scfIdSet) {
+      const targets = mappings[scfId];
+      if (!Array.isArray(targets) || targets.length === 0) continue;
+      if (!lookup.has(scfId)) lookup.set(scfId, {});
+      lookup.get(scfId)[fw.label] = targets.slice();
+    }
+  }
+
+  return { scfVersion, frameworkCount, lookup };
+}
+
+async function fetchScfFile(relativePath, { offline = false, scfVersion = null } = {}) {
+  const versionDir = scfVersion || 'unknown';
+  const cachePath = path.join(SCF_CACHE_DIR, versionDir, relativePath);
+
+  try {
+    const stat = await fs.stat(cachePath);
+    const fresh = Date.now() - stat.mtimeMs < SCF_CACHE_TTL_MS;
+    if (fresh || offline) return JSON.parse(await fs.readFile(cachePath, 'utf8'));
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    if (offline) throw new Error(`SCF cache miss and --offline set: ${relativePath}`);
+  }
+
+  const url = `${SCF_BASE_URL.replace(/\/$/, '')}/${relativePath}`;
+  let res;
+  try {
+    res = await fetch(url, { headers: { 'accept': 'application/json', 'user-agent': 'claude-grc-engineering/0.1' } });
+  } catch (networkErr) {
+    // Fall back to stale cache if it exists.
+    try { return JSON.parse(await fs.readFile(cachePath, 'utf8')); }
+    catch { throw new Error(`SCF fetch failed for ${relativePath}: ${networkErr.message}`); }
+  }
+  if (!res.ok) throw new Error(`SCF fetch returned HTTP ${res.status} for ${relativePath}`);
+  const body = await res.text();
+  await fs.mkdir(path.dirname(cachePath), { recursive: true });
+  await fs.writeFile(cachePath, body);
+  return JSON.parse(body);
+}
+
+/** ---- Mapping tables ---- */
+
+/**
+ * testssl finding family → SCF control IDs.
+ * Each family represents a class of TLS posture issues; the SCF controls are
+ * chosen as the canonical anchors that fan out to the relevant downstream
+ * framework controls via SCF crosswalks. Spot-verified against
+ * grcengclub.github.io/scf-api crosswalks for NIST 800-53 r5 v2026.1.
+ */
+const FAMILY_TO_SCF = {
+  protocolWeak: ['CRY-01', 'CRY-03', 'NET-09'],
+  cipherWeak:   ['CRY-01.2', 'CRY-05'],
+  certificate:  ['CRY-08'],
+  cve:          ['VPM-01', 'VPM-06'],
+  headers:      ['CRY-03', 'WEB-03', 'NET-09'],
+};
+
+/**
+ * testssl finding id (exact or prefix) → family name.
+ * Longest prefix wins for ambiguous ids.
+ */
+const TESTSSL_ID_TO_FAMILY = {
+  // protocols
+  'SSLv2': 'protocolWeak', 'SSLv3': 'protocolWeak',
+  'TLS1': 'protocolWeak', 'TLS1_1': 'protocolWeak',
+  'TLS1_2': 'protocolWeak', 'TLS1_3': 'protocolWeak',
+  // ciphers
+  'cipher_negotiated': 'cipherWeak', 'cipher_order': 'cipherWeak',
+  'cipherlist_': 'cipherWeak',
+  'std_NULL': 'cipherWeak', 'std_aNULL': 'cipherWeak',
+  'std_EXPORT': 'cipherWeak', 'std_LOW': 'cipherWeak',
+  'std_3DES_IDEA': 'cipherWeak', 'std_OBSOLETED': 'cipherWeak',
+  'std_STRONG_NOFS': 'cipherWeak', 'std_STRONG_FS': 'cipherWeak',
+  // certificate
+  'cert_': 'certificate', 'OCSP_': 'certificate',
+  'CT': 'certificate', 'DNS_CAArecord': 'certificate',
+  // known CVEs
+  'heartbleed': 'cve', 'CCS': 'cve', 'ticketbleed': 'cve',
+  'ROBOT': 'cve', 'secure_renego': 'cve', 'secure_client_renego': 'cve',
+  'CRIME_TLS': 'cve', 'BREACH': 'cve', 'POODLE_SSL': 'cve',
+  'fallback_SCSV': 'cve', 'SWEET32': 'cve', 'FREAK': 'cve', 'DROWN': 'cve',
+  'LOGJAM': 'cve', 'LOGJAM-common_primes': 'cve',
+  'BEAST_CBC_TLS1': 'cve', 'BEAST': 'cve', 'LUCKY13': 'cve',
+  'winshock': 'cve', 'RC4': 'cve',
+  // headers
+  'HSTS': 'headers', 'HSTS_preload': 'headers', 'HSTS_time': 'headers',
+  'HPKP': 'headers', 'cookie_secure': 'headers', 'cookie_httponly': 'headers',
+  'banner_server': 'headers', 'banner_application': 'headers',
+  'security_headers': 'headers',
+};
+
+/**
+ * Hardcoded fallback used when the SCF mirror is unreachable. Same shape and
+ * intent as the v0 of this connector — one curated control per framework
+ * per family. Less rich than the SCF-driven expansion but enough to keep
+ * the gap-assessment story coherent offline.
+ */
+const FALLBACK_FRAMEWORKS = {
+  protocolWeak: [
+    { framework: 'SOC2-TSC-2017',  control_id: 'CC6.7' },
+    { framework: 'NIST-800-53-r5', control_id: 'SC-8' },
+    { framework: 'NIST-800-53-r5', control_id: 'SC-13' },
+    { framework: 'PCI-DSS-4.0',    control_id: '4.2.1' },
+    { framework: 'ISO-27002-2022', control_id: '8.24' },
+  ],
+  cipherWeak: [
+    { framework: 'SOC2-TSC-2017',  control_id: 'CC6.7' },
+    { framework: 'NIST-800-53-r5', control_id: 'SC-13' },
+    { framework: 'PCI-DSS-4.0',    control_id: '4.2.1.1' },
+    { framework: 'ISO-27002-2022', control_id: '8.24' },
+  ],
+  certificate: [
+    { framework: 'SOC2-TSC-2017',  control_id: 'CC6.1' },
+    { framework: 'NIST-800-53-r5', control_id: 'SC-17' },
+    { framework: 'PCI-DSS-4.0',    control_id: '4.2.1' },
+    { framework: 'ISO-27002-2022', control_id: '8.24' },
+  ],
+  cve: [
+    { framework: 'SOC2-TSC-2017',  control_id: 'CC6.6' },
+    { framework: 'NIST-800-53-r5', control_id: 'RA-5' },
+    { framework: 'NIST-800-53-r5', control_id: 'SI-2' },
+    { framework: 'PCI-DSS-4.0',    control_id: '6.3.3' },
+    { framework: 'ISO-27002-2022', control_id: '8.8' },
+  ],
+  headers: [
+    { framework: 'SOC2-TSC-2017',  control_id: 'CC6.7' },
+    { framework: 'NIST-800-53-r5', control_id: 'SC-8' },
+    { framework: 'ISO-27002-2022', control_id: '8.20' },
+  ],
+};
+
+function uniqueScfIds(table) {
+  const out = new Set();
+  for (const arr of Object.values(table)) for (const id of arr) out.add(id);
+  return [...out];
+}
+
+function familyForTestsslId(id) {
+  if (!id) return null;
+  if (TESTSSL_ID_TO_FAMILY[id]) return TESTSSL_ID_TO_FAMILY[id];
+  let bestKey = null;
+  for (const key of Object.keys(TESTSSL_ID_TO_FAMILY)) {
+    if (id.startsWith(key) && (bestKey === null || key.length > bestKey.length)) {
+      bestKey = key;
+    }
+  }
+  return bestKey ? TESTSSL_ID_TO_FAMILY[bestKey] : null;
+}
+
 /** ---- Normalization: testssl JSON → v1 Finding doc ---- */
 
-function normalizeTargetFindings(raw, target, runId, sourceVersion) {
+function normalizeTargetFindings(raw, target, runId, sourceVersion, expansion) {
   const entries = extractEntries(raw);
   const { host, port } = parseTarget(target);
   const collectedAt = new Date().toISOString();
 
   const evaluations = [];
   const narrative = [];
-  // Track which (framework, control_id, mapping_key) tuples we've already emitted to avoid duplicates.
   const seen = new Set();
 
   for (const entry of entries) {
     const id = String(entry.id || '');
+    const family = familyForTestsslId(id);
+    if (!family) continue;
+
     const status = entrySeverityToStatus(entry);
     const severity = entrySeverityToOurSeverity(entry);
-    const mappings = mapTestsslId(id, entry);
-    if (!mappings.length) continue;
+    const message = (status === 'fail' || status === 'inconclusive') ? formatMessage(entry, id) : undefined;
+    const scfIds = FAMILY_TO_SCF[family] || [];
 
-    for (const m of mappings) {
-      const key = `${m.framework}::${m.control_id}::${id}::${status}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      const ev = {
-        control_framework: m.framework,
-        control_id: m.control_id,
-        status,
-        severity,
-      };
-      if (status === 'fail' || status === 'inconclusive') {
-        ev.message = formatMessage(entry, id);
+    // Always emit one SCF evaluation per (scf_id, finding-id) tuple.
+    for (const scfId of scfIds) {
+      addEvaluation(evaluations, seen, {
+        framework: 'SCF', control_id: scfId, status, severity, message,
+        dedupKey: `SCF::${scfId}::${id}::${status}`,
+      });
+    }
+
+    // Fan out to other frameworks: either via SCF crosswalk expansion, or via
+    // the hardcoded fallback when no expansion is available.
+    if (expansion && expansion.lookup) {
+      for (const scfId of scfIds) {
+        const perFw = expansion.lookup.get(scfId) || {};
+        for (const [fwLabel, controlIds] of Object.entries(perFw)) {
+          for (const controlId of controlIds) {
+            addEvaluation(evaluations, seen, {
+              framework: fwLabel, control_id: controlId, status, severity, message,
+              dedupKey: `${fwLabel}::${controlId}::${id}::${status}`,
+            });
+          }
+        }
       }
-      evaluations.push(ev);
+    } else {
+      for (const m of (FALLBACK_FRAMEWORKS[family] || [])) {
+        addEvaluation(evaluations, seen, {
+          framework: m.framework, control_id: m.control_id, status, severity, message,
+          dedupKey: `${m.framework}::${m.control_id}::${id}::${status}`,
+        });
+      }
     }
 
     if (entry.cve || (status === 'fail' && severity === 'critical')) {
@@ -261,7 +500,7 @@ function normalizeTargetFindings(raw, target, runId, sourceVersion) {
         title: `${id} — ${truncate(entry.finding || '', 100)}`,
         severity,
         description: formatMessage(entry, id),
-        related_control_ids: mappings.map(m => `${m.framework}:${m.control_id}`),
+        related_control_ids: scfIds.map(scfId => `SCF:${scfId}`),
       });
     }
   }
@@ -290,20 +529,27 @@ function normalizeTargetFindings(raw, target, runId, sourceVersion) {
       account_id: null,
     },
     evaluations,
-    findings: narrative.slice(0, 50), // narrative cap to keep documents bounded
+    findings: narrative.slice(0, 50),
     metadata: {
       target,
       host,
       port,
-      mode_was: raw?.scanTime ? 'full' : 'unknown',
+      scf_expansion: expansion ? { scf_version: expansion.scfVersion, frameworks: expansion.frameworkCount } : null,
     },
   };
+}
+
+function addEvaluation(evaluations, seen, { framework, control_id, status, severity, message, dedupKey }) {
+  if (seen.has(dedupKey)) return;
+  seen.add(dedupKey);
+  const ev = { control_framework: framework, control_id, status, severity };
+  if (message) ev.message = message;
+  evaluations.push(ev);
 }
 
 function extractEntries(raw) {
   if (Array.isArray(raw)) return raw;
   if (Array.isArray(raw?.scanResult)) {
-    // Older testssl multi-target shape: scanResult[0].pretests + .protocols + .ciphers + ...
     const out = [];
     for (const target of raw.scanResult) {
       for (const k of Object.keys(target)) {
@@ -351,131 +597,6 @@ function truncate(s, n) {
   return s.length <= n ? s : s.slice(0, n - 1) + '…';
 }
 
-/** ---- Control mapping ----
- * Each function returns an array of {framework, control_id} pairs for a given testssl id.
- * The mapping is intentionally conservative — only well-established crosswalks.
- */
-
-const MAPPINGS = (() => {
-  // Group: protocol support (TLS 1.0/1.1 weak, TLS 1.2/1.3 strong, SSLv2/SSLv3 broken)
-  const protocolWeak = [
-    { framework: 'SOC2-TSC-2017',    control_id: 'CC6.7' },
-    { framework: 'NIST-800-53-r5',   control_id: 'SC-8' },
-    { framework: 'NIST-800-53-r5',   control_id: 'SC-13' },
-    { framework: 'PCI-DSS-4.0',      control_id: '4.2.1' },
-    { framework: 'ISO-27001-2022',   control_id: 'A.8.24' },
-    { framework: 'SCF',              control_id: 'CRY-03' },
-  ];
-  // Group: cipher suite checks
-  const cipherWeak = [
-    { framework: 'SOC2-TSC-2017',    control_id: 'CC6.7' },
-    { framework: 'NIST-800-53-r5',   control_id: 'SC-13' },
-    { framework: 'PCI-DSS-4.0',      control_id: '4.2.1.1' },
-    { framework: 'ISO-27001-2022',   control_id: 'A.8.24' },
-    { framework: 'SCF',              control_id: 'CRY-04' },
-  ];
-  // Group: certificate posture
-  const certificate = [
-    { framework: 'SOC2-TSC-2017',    control_id: 'CC6.1' },
-    { framework: 'NIST-800-53-r5',   control_id: 'SC-17' },
-    { framework: 'PCI-DSS-4.0',      control_id: '4.2.1' },
-    { framework: 'ISO-27001-2022',   control_id: 'A.8.24' },
-    { framework: 'SCF',              control_id: 'CRY-08' },
-  ];
-  // Group: known TLS CVEs / vulnerability management
-  const cve = [
-    { framework: 'SOC2-TSC-2017',    control_id: 'CC6.6' },
-    { framework: 'NIST-800-53-r5',   control_id: 'RA-5' },
-    { framework: 'NIST-800-53-r5',   control_id: 'SI-2' },
-    { framework: 'PCI-DSS-4.0',      control_id: '6.3.3' },
-    { framework: 'ISO-27001-2022',   control_id: 'A.8.8' },
-    { framework: 'SCF',              control_id: 'VPM-03' },
-  ];
-  // Group: HTTP transport security headers
-  const headers = [
-    { framework: 'SOC2-TSC-2017',    control_id: 'CC6.7' },
-    { framework: 'NIST-800-53-r5',   control_id: 'SC-8' },
-    { framework: 'ISO-27001-2022',   control_id: 'A.8.20' },
-    { framework: 'SCF',              control_id: 'CRY-03' },
-  ];
-
-  // Map specific testssl id (or prefix) → group
-  // Keys checked with both exact match and prefix match (longest prefix wins).
-  return {
-    // ---- protocols ----
-    'SSLv2': protocolWeak,
-    'SSLv3': protocolWeak,
-    'TLS1':  protocolWeak,
-    'TLS1_1': protocolWeak,
-    'TLS1_2': protocolWeak,   // mapped — but if "offered" then passes; "not offered" is a fail
-    'TLS1_3': protocolWeak,
-    // ---- ciphers ----
-    'cipher_negotiated': cipherWeak,
-    'cipher_order':      cipherWeak,
-    'cipherlist_':       cipherWeak, // prefix: cipherlist_NULL, cipherlist_LOW, etc.
-    'std_NULL':          cipherWeak,
-    'std_aNULL':         cipherWeak,
-    'std_EXPORT':        cipherWeak,
-    'std_LOW':           cipherWeak,
-    'std_3DES_IDEA':     cipherWeak,
-    'std_OBSOLETED':     cipherWeak,
-    'std_STRONG_NOFS':   cipherWeak,
-    'std_STRONG_FS':     cipherWeak,
-    // ---- certificate ----
-    'cert_': certificate, // prefix
-    'OCSP_': certificate, // prefix
-    'CT':    certificate,
-    'DNS_CAArecord': certificate,
-    // ---- known CVEs ----
-    'heartbleed':           cve,
-    'CCS':                  cve,
-    'ticketbleed':          cve,
-    'ROBOT':                cve,
-    'secure_renego':        cve,
-    'secure_client_renego': cve,
-    'CRIME_TLS':            cve,
-    'BREACH':               cve,
-    'POODLE_SSL':           cve,
-    'fallback_SCSV':        cve,
-    'SWEET32':              cve,
-    'FREAK':                cve,
-    'DROWN':                cve,
-    'LOGJAM':               cve,
-    'LOGJAM-common_primes': cve,
-    'BEAST_CBC_TLS1':       cve,
-    'BEAST':                cve,
-    'LUCKY13':              cve,
-    'winshock':             cve,
-    'RC4':                  cve,
-    // ---- security headers ----
-    'HSTS':                 headers,
-    'HSTS_preload':         headers,
-    'HSTS_time':            headers,
-    'HPKP':                 headers,
-    'cookie_secure':        headers,
-    'cookie_httponly':      headers,
-    'banner_server':        headers,
-    'banner_application':   headers,
-    'security_headers':     headers,
-  };
-})();
-
-function mapTestsslId(id, _entry) {
-  if (!id) return [];
-  // Exact match first
-  if (MAPPINGS[id]) return MAPPINGS[id];
-  // Longest-prefix match
-  let bestKey = null;
-  for (const key of Object.keys(MAPPINGS)) {
-    if (key.endsWith('_') || (!MAPPINGS[id] && id.startsWith(key + '_'))) {
-      if (id.startsWith(key) && (bestKey === null || key.length > bestKey.length)) {
-        bestKey = key;
-      }
-    }
-  }
-  return bestKey ? MAPPINGS[bestKey] : [];
-}
-
 /** ---- Utils ---- */
 
 function makeRunId() {
@@ -493,7 +614,6 @@ function fail(code, msg) {
 }
 
 function parseYaml(text) {
-  // Minimal YAML for the small config shape we support: key: value, lists with "- " items.
   const out = {};
   let listKey = null;
   for (const line of text.split('\n')) {

--- a/plugins/connectors/testssl-inspector/skills/testssl-inspector-expert/SKILL.md
+++ b/plugins/connectors/testssl-inspector/skills/testssl-inspector-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testssl-inspector-expert
-description: Interpret testssl-inspector normalized findings, recommend remediations, and tie evidence back to SOC 2 / NIST 800-53 / PCI DSS 4.0.1 / ISO 27001 / SCF controls.
+description: Interpret testssl-inspector normalized findings, recommend remediations, and tie evidence back to SCF anchor controls plus SOC 2 / NIST 800-53 r5 / PCI DSS 4.0.1 / ISO 27002:2022 equivalents derived from SCF crosswalks.
 license: MIT
 ---
 
@@ -23,7 +23,7 @@ Most fails fall into one of five families. The remediation pattern is the same w
 
 ### Family 1 — Weak protocol offered
 
-IDs: `SSLv2`, `SSLv3`, `TLS1`, `TLS1_1`. Maps to SOC 2 CC6.7, NIST SC-8/SC-13, PCI 4.2.1, ISO A.8.24, SCF CRY-03.
+IDs: `SSLv2`, `SSLv3`, `TLS1`, `TLS1_1`. SCF anchors: `CRY-01` (Use of Cryptographic Controls), `CRY-03` (Transmission of Sensitive Data), `NET-09` (Session Authenticity). SCF crosswalk fans these out at scan time — typical resolved targets include NIST `SC-08`, `SC-08(01)`, `SC-08(02)`, `SC-13`, `SC-23`, `SI-07(06)`; SOC 2 `CC6.1`, `CC6.7`; PCI `4.2`, `4.2.1`, `4.2.1.2`, `8.3.2`; ISO 27002 `5.14`, `8.24`, `8.26`.
 
 Remediation:
 
@@ -32,7 +32,7 @@ Remediation:
 
 ### Family 2 — Weak ciphers in the offered list
 
-IDs: `cipher_negotiated`, `cipherlist_*` (`NULL`, `aNULL`, `EXPORT`, `LOW`, `3DES_IDEA`, `OBSOLETED`), `RC4`, `std_*` variants. Maps to CC6.7, SC-13, PCI 4.2.1.1, A.8.24, SCF CRY-04.
+IDs: `cipher_negotiated`, `cipherlist_*` (`NULL`, `aNULL`, `EXPORT`, `LOW`, `3DES_IDEA`, `OBSOLETED`), `RC4`, `std_*` variants. SCF anchors: `CRY-01.2` (Algorithm Selection), `CRY-05` (Cryptographic Protection). Resolved targets typically include NIST `SC-13`, `SC-28`, `SC-28(01)`; SOC 2 `CC6.1`, `CC6.7`; PCI `3.5`, `3.5.1.2`, `3.5.1.3`, `8.3.2`; ISO 27002 `8.24`.
 
 Remediation:
 
@@ -41,7 +41,7 @@ Remediation:
 
 ### Family 3 — Certificate posture
 
-IDs: `cert_expirationStatus`, `cert_notAfter`, `cert_signatureAlgorithm`, `cert_keySize`, `cert_chain_of_trust`, `OCSP_*`, `CT`, `DNS_CAArecord`. Maps to CC6.1, SC-17, PCI 4.2.1, A.8.24, SCF CRY-08.
+IDs: `cert_expirationStatus`, `cert_notAfter`, `cert_signatureAlgorithm`, `cert_keySize`, `cert_chain_of_trust`, `OCSP_*`, `CT`, `DNS_CAArecord`. SCF anchor: `CRY-08` (Public Key Infrastructure). Resolved targets include NIST `SC-12` (Key Establishment & Management) and `SC-17` (PKI Certificates); SOC 2 `CC6.1`.
 
 Remediation depends on the specific failure:
 
@@ -53,7 +53,7 @@ Remediation depends on the specific failure:
 
 ### Family 4 — Known TLS CVEs
 
-IDs: `heartbleed`, `CCS`, `ticketbleed`, `ROBOT`, `secure_renego`, `secure_client_renego`, `CRIME_TLS`, `BREACH`, `POODLE_SSL`, `fallback_SCSV`, `SWEET32`, `FREAK`, `DROWN`, `LOGJAM`, `BEAST`, `LUCKY13`, `RC4`, `winshock`. Maps to CC6.6, RA-5, SI-2, PCI 6.3.3, A.8.8, SCF VPM-03.
+IDs: `heartbleed`, `CCS`, `ticketbleed`, `ROBOT`, `secure_renego`, `secure_client_renego`, `CRIME_TLS`, `BREACH`, `POODLE_SSL`, `fallback_SCSV`, `SWEET32`, `FREAK`, `DROWN`, `LOGJAM`, `BEAST`, `LUCKY13`, `RC4`, `winshock`. SCF anchors: `VPM-01` (Vulnerability & Patch Management), `VPM-06` (Vulnerability Scanning). Resolved targets include NIST `SI-02`, `SI-03`, `RA-05`; SOC 2 `CC7.1` and `CC3.x` POFs; PCI `6.3`, `6.3.1`, `6.3.3`, `11.3`, `11.3.1`; ISO 27002 `8.8`.
 
 These are not configuration tuning — they're vulnerability remediation. Treat any non-`OK` finding here as an audit-tracked vuln with a remediation deadline. Most are addressed by:
 
@@ -63,7 +63,7 @@ These are not configuration tuning — they're vulnerability remediation. Treat 
 
 ### Family 5 — HTTP transport headers
 
-IDs: `HSTS`, `HSTS_preload`, `HSTS_time`, `HPKP`, `cookie_secure`, `cookie_httponly`, `banner_*`, `security_headers`. Maps to CC6.7, SC-8, A.8.20, SCF CRY-03.
+IDs: `HSTS`, `HSTS_preload`, `HSTS_time`, `HPKP`, `cookie_secure`, `cookie_httponly`, `banner_*`, `security_headers`. SCF anchors: `CRY-03` (Transmission of Sensitive Data), `WEB-03` (Web App Hardening), `NET-09` (Session Authenticity). Resolved targets include NIST `SC-08`, `SC-08(01)`, `SC-07(17)`, `SC-23`; PCI `4.2`, `6.4`, `6.4.1`.
 
 Remediation:
 

--- a/tests/fixtures/findings/testssl-inspector/001-clean-modern.json
+++ b/tests/fixtures/findings/testssl-inspector/001-clean-modern.json
@@ -31,8 +31,8 @@
       "severity": "info"
     },
     {
-      "control_framework": "ISO-27001-2022",
-      "control_id": "A.8.24",
+      "control_framework": "ISO-27002-2022",
+      "control_id": "8.24",
       "status": "pass",
       "severity": "info"
     },

--- a/tests/fixtures/findings/testssl-inspector/002-weak-protocol.json
+++ b/tests/fixtures/findings/testssl-inspector/002-weak-protocol.json
@@ -41,11 +41,11 @@
       "message": "TLS 1.0 offered — testssl id TLS1. PCI DSS 4.0.1 4.2.1 explicitly forbids SSL and early TLS (1.0/1.1)."
     },
     {
-      "control_framework": "ISO-27001-2022",
-      "control_id": "A.8.24",
+      "control_framework": "ISO-27002-2022",
+      "control_id": "8.24",
       "status": "fail",
       "severity": "high",
-      "message": "TLS 1.0 offered — testssl id TLS1. A.8.24 requires cryptography to be used in accordance with the organization's policy and applicable agreements."
+      "message": "TLS 1.0 offered — testssl id TLS1. ISO 27002:2022 §8.24 requires cryptography to be used in accordance with the organization's policy and applicable agreements."
     },
     {
       "control_framework": "SCF",
@@ -66,7 +66,7 @@
         "NIST-800-53-r5:SC-8",
         "NIST-800-53-r5:SC-13",
         "PCI-DSS-4.0:4.2.1",
-        "ISO-27001-2022:A.8.24",
+        "ISO-27002-2022:8.24",
         "SCF:CRY-03"
       ]
     }

--- a/tests/fixtures/findings/testssl-inspector/003-heartbleed.json
+++ b/tests/fixtures/findings/testssl-inspector/003-heartbleed.json
@@ -41,11 +41,11 @@
       "message": "Heartbleed (CVE-2014-0160) — vulnerable, info leak. PCI 6.3.3 requires high-risk vulnerabilities be addressed within 1 month."
     },
     {
-      "control_framework": "ISO-27001-2022",
-      "control_id": "A.8.8",
+      "control_framework": "ISO-27002-2022",
+      "control_id": "8.8",
       "status": "fail",
       "severity": "critical",
-      "message": "Heartbleed (CVE-2014-0160) — vulnerable, info leak. A.8.8 requires management of technical vulnerabilities."
+      "message": "Heartbleed (CVE-2014-0160) — vulnerable, info leak. ISO 27002:2022 §8.8 requires management of technical vulnerabilities."
     },
     {
       "control_framework": "SCF",
@@ -66,7 +66,7 @@
         "NIST-800-53-r5:RA-5",
         "NIST-800-53-r5:SI-2",
         "PCI-DSS-4.0:6.3.3",
-        "ISO-27001-2022:A.8.8",
+        "ISO-27002-2022:8.8",
         "SCF:VPM-03"
       ]
     }


### PR DESCRIPTION
Follow-up to #158. Replaces the hand-coded multi-framework mapping table with an SCF-anchored model: each testssl finding family maps to one or more SCF control IDs, and the equivalent NIST 800-53 r5 / SOC 2 TSC 2017 / PCI DSS 4.0.1 / ISO 27002:2022 controls are derived at scan time via the SCF crosswalk at \`grcengclub.github.io/scf-api/\`.

## SCF anchors

| testssl finding family | SCF anchors |
|---|---|
| Weak protocols (SSLv2/3, TLS 1.0/1.1) | \`CRY-01\`, \`CRY-03\`, \`NET-09\` |
| Weak ciphers (NULL, EXPORT, 3DES, RC4, anon) | \`CRY-01.2\`, \`CRY-05\` |
| Certificate posture | \`CRY-08\` |
| Known CVEs (Heartbleed, ROBOT, POODLE, SWEET32, FREAK, LOGJAM, DROWN, ...) | \`VPM-01\`, \`VPM-06\` |
| HTTP transport headers (HSTS, HPKP, cookie flags) | \`CRY-03\`, \`WEB-03\`, \`NET-09\` |

## Example expansion (TLS 1.0 offered)

Before (v0, hand-coded):
- SOC2 \`CC6.7\` · NIST \`SC-8\`, \`SC-13\` · PCI \`4.2.1\` · ISO \`A.8.24\` · SCF \`CRY-03\` — 6 evaluations

After (v1, SCF-driven):
- SCF \`CRY-01\`, \`CRY-03\`, \`NET-09\` — 3 evals
- NIST \`SC-08\`, \`SC-08(01)\`, \`SC-08(02)\`, \`SC-13\`, \`SC-23\`, \`SI-07(06)\` — 6 evals
- SOC 2 \`CC6.1\`, \`CC6.7\` — 2 evals
- PCI \`4.2\`, \`4.2.1\`, \`4.2.1.2\`, \`8.3.2\`, \`A2.1\`, \`A2.1.1\` — 6 evals
- ISO 27002 \`5.14\`, \`8.24\`, \`8.26\` — 3 evals
- Total: 20 evaluations on one finding — comprehensive auditor coverage

## Why ISO 27002:2022 instead of ISO 27001:2022

SCF's public ISO 27001:2022 crosswalk has only 51 mappings (it's the ISMS management standard — governance-heavy) and **none** of our CRY/NET/VPM/WEB anchors land in it. ISO 27002:2022 has 316 mappings and is where the technical Annex A controls live. Numbering is identical to ISO 27001:2022 Annex A (8.24, 8.8, etc.) — same standards body, same controls, different parent document.

## Fallback path

If the SCF mirror is unreachable and no cache exists, the connector falls back to the v0 hardcoded mapping (one canonical control per framework per family). You'll see \`(scf expansion unavailable; framework fallback used)\` in the summary line when it kicks in.

## New flags

- \`--scf-only\`: emit only SCF evaluations, skip fan-out
- \`--offline\`: never make network calls; use cached crosswalks if present, else hardcoded fallback

## Caching

Shares \`~/.cache/claude-grc/scf/<version>/\` with grc-engineer's \`scf-client.js\`. 7-day TTL. Falls back to stale cache if the mirror is unreachable.

## Test plan

- [x] \`node --check\` passes on the rewritten scan.js
- [x] \`bash tests/validate-plugin-manifests.sh\` — 63 manifests valid
- [x] \`bash tests/validate-contract-fixtures.sh\` — 49 fixtures valid (3 testssl-inspector fixtures relabeled to ISO-27002-2022/8.x)
- [x] Live crosswalk fetch against grcengclub.github.io/scf-api confirms all 9 SCF anchors resolve to expected NIST/SOC2/PCI controls (validated SCF version: 2026.1)
- [x] CLI smoke tests with \`--scf-only\` and \`--offline\` exercise the new code paths cleanly