### PR TITLE
Add Okta inspector v1 finding fixtures

### DIFF
--- a/tests/fixtures/findings/okta-inspector/001-mfa-policy-pass.json
+++ b/tests/fixtures/findings/okta-inspector/001-mfa-policy-pass.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "1.0.0",
+  "source": "okta-inspector",
+  "source_version": "0.1.0-fixture",
+  "run_id": "okta-fixture-0001",
+  "collected_at": "2026-04-14T10:00:00Z",
+  "resource": {
+    "type": "okta_org_mfa_posture",
+    "id": "mfa-00oacmeprod",
+    "uri": "https://acme.okta.com/admin/access/policies",
+    "region": null,
+    "account_id": "00oacmeprod",
+    "tags": {
+      "environment": "production"
+    }
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "IAC-01.2",
+      "status": "pass",
+      "severity": "info",
+      "message": "An active MFA enrollment policy requires WebAuthn enrollment for all users.",
+      "evidence_refs": [
+        "okta-inspector/okta-fixture-0001/policies-mfa.json"
+      ],
+      "assessed_at": "2026-04-14T10:00:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/findings/okta-inspector/002-password-policy-fail.json
+++ b/tests/fixtures/findings/okta-inspector/002-password-policy-fail.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0.0",
+  "source": "okta-inspector",
+  "source_version": "0.1.0-fixture",
+  "run_id": "okta-fixture-0002",
+  "collected_at": "2026-04-14T10:05:00Z",
+  "resource": {
+    "type": "okta_password_policy",
+    "id": "pwdplcy-default",
+    "uri": "https://acme.okta.com/admin/access/policies",
+    "region": null,
+    "account_id": "00oacmeprod",
+    "tags": {
+      "policy": "default"
+    }
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "IAC-06",
+      "status": "fail",
+      "severity": "high",
+      "message": "Password policy 'Default Policy' is below baseline: minLength=8 (<14), maxAgeDays=unset (>90), historyCount=5 (<24).",
+      "remediation": {
+        "summary": "Raise the password length baseline to at least 14 characters, enforce age and history requirements, and retain complexity checks for legacy passwords.",
+        "ref": "grc-engineer://generate-implementation/password_policy/okta",
+        "effort_hours": 0.25,
+        "automation": "semi_automated"
+      },
+      "evidence_refs": [
+        "okta-inspector/okta-fixture-0002/password-policies.json"
+      ],
+      "assessed_at": "2026-04-14T10:05:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/findings/okta-inspector/003-system-log-rate-limited.json
+++ b/tests/fixtures/findings/okta-inspector/003-system-log-rate-limited.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0.0",
+  "source": "okta-inspector",
+  "source_version": "0.1.0-fixture",
+  "run_id": "okta-fixture-0003",
+  "collected_at": "2026-04-14T10:10:00Z",
+  "resource": {
+    "type": "okta_system_log",
+    "id": "system-log-00oacmeprod",
+    "uri": "https://acme.okta.com/api/v1/logs",
+    "region": null,
+    "account_id": "00oacmeprod"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "MON-02",
+      "status": "inconclusive",
+      "severity": "low",
+      "message": "System log retention could not be confirmed because the Okta API returned HTTP 429 rate limiting during collection.",
+      "remediation": {
+        "summary": "Re-run the collection after the rate-limit window resets or reduce concurrent Okta API activity before relying on log-retention evidence.",
+        "ref": "https://developer.okta.com/docs/reference/rl-global-mgmt/",
+        "effort_hours": 0.1,
+        "automation": "manual"
+      },
+      "evidence_refs": [
+        "okta-inspector/okta-fixture-0003/system-log-rate-limit.txt"
+      ],
+      "assessed_at": "2026-04-14T10:10:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
Adds three Okta inspector v1 finding fixtures covering the contract cases requested in issue #160: a passing MFA posture finding, a failing password policy with structured remediation, and an inconclusive system log collection case for rate limiting. The fixtures follow the existing naming pattern, use okta-prefixed resource types, and validate against the shared finding schema with the repository fixture validation script.