### PR TITLE
Issues/122

### DIFF
--- a/plugins/frameworks/nist-csf-20/commands/assess.md
+++ b/plugins/frameworks/nist-csf-20/commands/assess.md
@@ -175,7 +175,7 @@ These are illustrative Current → Target Profile snapshots for three common sce
 | PR | PR.DS-01 | Partially implemented — EHR encrypted; medical devices and PACS not consistently | Implemented — encryption enforced or compensating controls documented for all ePHI at rest | 45 CFR §164.312(a)(2)(iv) |
 | PR | PR.AT-01 | Implemented — annual HIPAA training | Implemented — role-based training for clinical, administrative, and IT staff | 45 CFR §164.308(a)(5) |
 | DE | DE.CM-03 | Partially implemented — audit logging on EHR, no UEBA | Implemented — UEBA or equivalent anomalous-access detection on all ePHI systems | 45 CFR §164.312(b) |
-| RS | RS.CO-02 | Implemented — breach notification process for HHS/OCR | Implemented — expand to cover state AG notifications and media where required | 45 CFR §164.408–410 |
+| RS | RS.CO-02 | Implemented — breach notification process for HHS/OCR | Implemented — expand to cover state AG notifications and media where required | 45 CFR §§164.404–410 |
 
 **Reuse guidance**: HIPAA Security Rule audit evidence (risk analyses, training records, BAAs, access logs, encryption configurations) counts directly as CSF evidence for the corresponding Subcategories. Do not collect twice.
 

--- a/plugins/frameworks/nist-csf-20/commands/assess.md
+++ b/plugins/frameworks/nist-csf-20/commands/assess.md
@@ -8,7 +8,7 @@ Runs a Profile gap assessment against **NIST Cybersecurity Framework v2.0** by d
 
 ## Usage
 
-```
+```text
 /nist-csf-20:assess [--function=<GV|ID|PR|DE|RS|RC>] [--profile=<current|target|gap>] [--sources=<connector-list>]
 ```
 
@@ -36,7 +36,7 @@ If `/nist-csf-20:scope` has been run, this command will pick up the recorded Fun
 
 Under the hood:
 
-```
+```text
 /grc-engineer:gap-assessment "general-nist-csf-2-0" [--sources=<connector-list>]
 ```
 
@@ -96,7 +96,7 @@ Specify via `--format=<text|json|csv>`.
 
 ## Examples
 
-```
+```bash
 # Full Profile gap assessment (all six Functions, current vs target)
 /nist-csf-20:assess
 
@@ -114,6 +114,72 @@ Specify via `--format=<text|json|csv>`.
 # Pull connector evidence
 /nist-csf-20:assess --sources=aws-inspector,github-inspector,okta-inspector
 ```
+
+## Profile examples
+
+These are illustrative Current → Target Profile snapshots for three common scenarios. Use them as a calibration reference when authoring or reviewing Profiles — not as defaults to copy verbatim, since risk tolerance and resourcing vary.
+
+### Scenario 1: Mid-market company building its first formal program
+
+**Context**: 300-person SaaS company, no prior formal cybersecurity program, no mandatory regulation (not HIPAA/PCI), cyber insurance renewal driving the engagement.
+**Tier — Current**: 1 (Partial) | **Tier — Target**: 3 (Repeatable), 18–24 month horizon
+
+| Function | Subcategory | Current state | Target state |
+| --- | --- | --- | --- |
+| GV | GV.OC-01 | Not implemented — no written cybersecurity strategy | Implemented — cybersecurity strategy approved by CEO, reviewed annually |
+| GV | GV.RM-02 | Not implemented — no risk appetite statement | Implemented — board-approved risk appetite statement in place |
+| GV | GV.RR-02 | Partially implemented — CISO role exists but RACI informal | Implemented — formal RACI, CISO charter, board oversight charter |
+| ID | ID.AM-01 | Partially implemented — spreadsheet, not automated | Implemented — CMDB with automated discovery, reconciled quarterly |
+| ID | ID.RA-01 | Not implemented — no formal vulnerability scanning | Implemented — authenticated scans monthly, critical vulns remediated within SLA |
+| PR | PR.AA-03 | Partially implemented — MFA on email only | Implemented — MFA enforced on all user-facing systems and privileged access |
+| PR | PR.DS-01 | Not implemented — S3 buckets unencrypted in some environments | Implemented — encryption at rest enforced by policy across all storage |
+| DE | DE.CM-01 | Not implemented — no centralized logging | Implemented — SIEM ingesting all critical log sources, 90-day retention |
+| RS | RS.MA-01 | Not implemented — no written IR plan | Implemented — IR plan written, tabletop exercised annually |
+| RC | RC.RP-01 | Not implemented — no BCDR plan | Implemented — BCDR plan tested, RTO/RPO defined and met in last test |
+
+**Quick wins (high ROI, low effort)**: GV.PO-01 (write policies), PR.AA-03 (expand MFA), ID.AM-01 (automate asset inventory), RS.MA-01 (document IR plan).
+
+---
+
+### Scenario 2: Federal contractor preparing for a CSF-aligned solicitation
+
+**Context**: 1,200-person defense services firm, existing NIST SP 800-171 / CMMC Level 2 work underway. A new civilian agency contract requires a CSF Profile submission.
+**Tier — Current**: 2 (Risk Informed) | **Tier — Target**: 3 (Repeatable), aligned with existing CMMC timeline
+
+| Function | Subcategory | Current state | Target state |
+| --- | --- | --- | --- |
+| GV | GV.OC-03 | Implemented — regulatory register maintained (DFARS, CMMC, FAR) | Implemented — expand to cover new civilian agency requirements |
+| GV | GV.SC-04 | Partially implemented — critical subcontractors identified informally | Implemented — tiered supplier inventory with criticality scores, reviewed annually |
+| GV | GV.SC-07 | Not implemented — no ongoing vendor risk monitoring cadence | Implemented — annual supplier reassessment for Tier 1 vendors, quarterly for critical |
+| ID | ID.RA-09 | Partially implemented — software SCA in CI/CD, hardware not covered | Implemented — hardware provenance checks in procurement; SBOM produced for all deliverables |
+| PR | PR.AA-05 | Implemented — RBAC defined in 800-171 SSP | Implemented — reuse 800-171 evidence wholesale via Informative Reference |
+| PR | PR.PS-06 | Partially implemented — SAST in pipeline, no DAST | Implemented — SAST + DAST in CI/CD, results reviewed before release |
+| DE | DE.CM-09 | Implemented — EDR deployed on all endpoints | Implemented — extend to cover OT/ICS assets in scope |
+| RS | RS.AN-07 | Not implemented — no formal after-action effectiveness scoring | Implemented — RCA template with effectiveness metrics completed within 30 days of major incidents |
+
+**Note**: Most 800-53 Rev. 5 control evidence maps directly to CSF Subcategories via Informative References. Reuse existing SSP and POA&M artifacts; avoid re-collecting evidence already gathered for 800-171/CMMC work.
+
+---
+
+### Scenario 3: Healthcare organization using CSF as the umbrella above HIPAA
+
+**Context**: Regional health system, 4,500 employees, subject to HIPAA Security Rule. Using CSF to give the board a single-page cybersecurity view and to structure the annual HIPAA Security Risk Analysis.
+**Tier — Current**: 2 (Risk Informed) | **Tier — Target**: 3 (Repeatable), driven by HHS OCR audit preparation
+
+| Function | Subcategory | Current state | Target state | HIPAA mapping |
+| --- | --- | --- | --- | --- |
+| GV | GV.OC-03 | Implemented — HIPAA regulatory register maintained | Implemented — expand to cover state breach notification laws and 42 CFR Part 2 | 45 CFR §164.306 |
+| GV | GV.RM-01 | Partially implemented — risk analysis done, but not tied to formal risk appetite | Implemented — risk appetite statement board-approved, SRA output feeds risk register | 45 CFR §164.308(a)(1) |
+| ID | ID.RA-01 | Implemented — vulnerability scans quarterly on ePHI systems | Implemented — extend to medical devices and OT systems | 45 CFR §164.308(a)(1) |
+| ID | ID.AM-03 | Partially implemented — data flows documented for primary EHR, not all integrations | Implemented — full ePHI data flow map updated annually and on architecture change | 45 CFR §164.308(a)(1) |
+| PR | PR.DS-01 | Partially implemented — EHR encrypted; medical devices and PACS not consistently | Implemented — encryption enforced or compensating controls documented for all ePHI at rest | 45 CFR §164.312(a)(2)(iv) |
+| PR | PR.AT-01 | Implemented — annual HIPAA training | Implemented — role-based training for clinical, administrative, and IT staff | 45 CFR §164.308(a)(5) |
+| DE | DE.CM-03 | Partially implemented — audit logging on EHR, no UEBA | Implemented — UEBA or equivalent anomalous-access detection on all ePHI systems | 45 CFR §164.312(b) |
+| RS | RS.CO-02 | Implemented — breach notification process for HHS/OCR | Implemented — expand to cover state AG notifications and media where required | 45 CFR §164.408–410 |
+
+**Reuse guidance**: HIPAA Security Rule audit evidence (risk analyses, training records, BAAs, access logs, encryption configurations) counts directly as CSF evidence for the corresponding Subcategories. Do not collect twice.
+
+---
 
 ## Related commands
 

--- a/plugins/frameworks/nist-csf-20/commands/assess.md
+++ b/plugins/frameworks/nist-csf-20/commands/assess.md
@@ -155,7 +155,7 @@ These are illustrative Current → Target Profile snapshots for three common sce
 | PR | PR.AA-05 | Implemented — RBAC defined in 800-171 SSP | Implemented — reuse 800-171 evidence wholesale via Informative Reference |
 | PR | PR.PS-06 | Partially implemented — SAST in pipeline, no DAST | Implemented — SAST + DAST in CI/CD, results reviewed before release |
 | DE | DE.CM-09 | Implemented — EDR deployed on all endpoints | Implemented — extend to cover OT/ICS assets in scope |
-| RS | RS.AN-07 | Not implemented — no formal after-action effectiveness scoring | Implemented — RCA template with effectiveness metrics completed within 30 days of major incidents |
+| RS | RS.AN-07 | Not implemented — no formal forensic evidence handling procedure | Implemented — forensic evidence collection procedure with chain-of-custody records and integrity hashing in place |
 
 **Note**: Most 800-53 Rev. 5 control evidence maps directly to CSF Subcategories via Informative References. Reuse existing SSP and POA&M artifacts; avoid re-collecting evidence already gathered for 800-171/CMMC work.
 

--- a/plugins/frameworks/nist-csf-20/commands/evidence-checklist.md
+++ b/plugins/frameworks/nist-csf-20/commands/evidence-checklist.md
@@ -1,16 +1,16 @@
 ---
-description: NIST CSF 2.0 evidence checklist organized by Function (GV / ID / PR / DE / RS / RC) with representative Subcategories
+description: NIST CSF 2.0 evidence checklist organized by Function (GV / ID / PR / DE / RS / RC) covering all 106 Subcategories
 ---
 
 # NIST CSF 2.0 Evidence Checklist
 
-Baseline evidence checklist for a **NIST Cybersecurity Framework v2.0** Profile assessment. CSF is outcomes-based, not control-based — evidence demonstrates that an outcome (a Subcategory) is achieved, regardless of *how*. This checklist is organized by the six Functions, with a few representative Subcategories per Function and the artifacts an assessor or board reviewer typically expects to see.
+Baseline evidence checklist for a **NIST Cybersecurity Framework v2.0** Profile assessment. CSF is outcomes-based, not control-based — evidence demonstrates that an outcome (a Subcategory) is achieved, regardless of *how*. This checklist is organized by the six Functions and covers all 106 official Subcategories with the artifacts an assessor or board reviewer typically expects to see.
 
 > **Never commit evidence artifacts to source control.** Configuration exports, access logs, and incident records frequently contain sensitive operational detail. Use an encrypted, access-controlled evidence locker. The repo's default `.gitignore` should already cover `evidence/`.
 
 ## Usage
 
-```
+```text
 /nist-csf-20:evidence-checklist [--function=<GV|ID|PR|DE|RS|RC>] [--format=table|markdown|csv]
 ```
 
@@ -39,90 +39,253 @@ Reference-depth practitioners should accept multiple forms of evidence per Subca
 
 Govern is the new 2.0 Function and the one boards care most about. Govern evidence is mostly **document + sign-off**, not technical config exports.
 
-| Representative Subcategory | What it asks for | Evidence the assessor / board expects |
-|---|---|---|
-| **GV.OC-01** — mission understands cybersecurity risk | Cybersecurity tied to the organization's mission | Cybersecurity strategy document referencing mission; board / executive sign-off |
-| **GV.OC-03** — legal/regulatory cybersecurity requirements identified | Catalog of regulatory obligations (HIPAA, PCI DSS, GLBA, state breach laws, sector regulators) | Regulatory inventory / register; ownership map; review cadence record |
-| **GV.RM-01** — risk tolerance and appetite established | Documented risk tolerance / appetite statements | Approved risk appetite statement; integration record with enterprise risk function |
-| **GV.RR-02** — roles, responsibilities, authorities for cybersecurity established | RACI for cybersecurity decisions | Cybersecurity RACI / org chart; CISO charter; board cybersecurity oversight charter |
-| **GV.PO-01** — policies for managing cybersecurity risk are established | Written, approved cybersecurity policies | Policy library with version control, approval signatures, and review history |
-| **GV.OV-01** — cybersecurity strategy results inform improvements | Board / audit committee oversight of strategy | Board cybersecurity reporting deck; audit committee minutes; independent review report |
-| **GV.SC-01** — cyber supply chain risk management process established | C-SCRM program documentation | Vendor risk management policy; tiered vendor inventory; due diligence templates |
-| **GV.SC-05** — supply chain requirements addressed in contracts | Contract language for vendor cybersecurity | Standard cybersecurity contract clauses; sample executed vendor agreements |
+#### GV.OC — Organizational Context
+
+| Subcategory | What it asks for | Evidence the assessor / board expects |
+| --- | --- | --- |
+| **GV.OC-01** — organizational mission informs cybersecurity risk management | Cybersecurity strategy tied to the organization's mission | Cybersecurity strategy document referencing mission; board / executive sign-off |
+| **GV.OC-02** — internal and external stakeholders' needs and expectations understood | Stakeholder map covering internal teams, regulators, customers, and partners | Stakeholder register; engagement records; CISO / board communication logs showing stakeholder inputs considered |
+| **GV.OC-03** — legal, regulatory, and contractual cybersecurity requirements identified and managed | Catalog of regulatory obligations (HIPAA, PCI DSS, GLBA, state breach laws, sector regulators) | Regulatory inventory / register; ownership map; review cadence record |
+| **GV.OC-04** — critical services and capabilities external stakeholders depend on are understood | Service dependency map communicated to leadership and relevant teams | Service dependency documentation; customer / partner SLA register; critical service inventory |
+| **GV.OC-05** — outcomes and services the organization depends on from others are understood | Inventory of third-party dependencies including cloud, SaaS, and critical vendors | Third-party dependency register; critical vendor inventory; single-point-of-failure analysis |
+
+#### GV.RM — Risk Management Strategy
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **GV.RM-01** — risk management objectives established and agreed to by stakeholders | Documented and approved risk management objectives | Approved risk management objectives document; stakeholder sign-off records |
+| **GV.RM-02** — risk appetite and risk tolerance statements established, communicated, and maintained | Formal risk appetite and tolerance statements | Approved risk appetite / tolerance statement; board or executive approval record; evidence of communication to relevant teams |
+| **GV.RM-03** — cybersecurity risk integrated into enterprise risk management | Cyber risk entries in the enterprise risk register | ERM process documentation showing cyber integration; integrated risk register with cyber entries; ERM committee minutes including cyber items |
+| **GV.RM-04** — strategic direction for risk response options established and communicated | Documented framework for choosing among risk response options (accept / transfer / mitigate / avoid) | Risk response strategy or decision framework document; communication records to responsible parties |
+| **GV.RM-05** — lines of communication for cybersecurity risks established across the organization | Escalation and communication paths for cyber risk, including third-party risks | Cybersecurity risk escalation matrix; supplier risk communication workflow; CISO reporting cadence to board documentation |
+| **GV.RM-06** — standardized method for calculating, documenting, categorizing, and prioritizing cybersecurity risks established | Documented risk scoring or quantification methodology | Risk methodology document; calibration or validation records; sample risk register entries demonstrating methodology applied consistently |
+| **GV.RM-07** — strategic opportunities (positive risks) characterized and included in risk discussions | Evidence that upside / opportunity risks are considered alongside threats | Risk committee or board minutes showing positive risks discussed; opportunity register or positive risk entries in risk register |
+
+#### GV.RR — Roles, Responsibilities, and Authorities
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **GV.RR-01** — leadership accountable for cybersecurity risk and fosters a risk-aware culture | Formal accountability at the board and executive level; visible tone-at-the-top for cybersecurity | Board / executive accountability statement; CISO charter; board cybersecurity committee charter; leadership messaging on security culture |
+| **GV.RR-02** — roles, responsibilities, and authorities for cybersecurity established, communicated, and enforced | RACI for cybersecurity decisions at program and operational level | Cybersecurity RACI / org chart; CISO charter; board cybersecurity oversight charter |
+| **GV.RR-03** — adequate resources allocated commensurate with cybersecurity risk strategy | Cybersecurity budget and staffing aligned to risk posture and strategic priorities | Budget approval records showing cybersecurity allocation; headcount and tooling plans; resource sufficiency review tied to risk appetite |
+| **GV.RR-04** — cybersecurity included in human resources practices | HR lifecycle processes (hiring, onboarding, offboarding) incorporate cybersecurity requirements | HR policy referencing cybersecurity requirements; background check records; onboarding security training completion evidence; offboarding access revocation process documentation |
+
+#### GV.PO — Policy
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **GV.PO-01** — policies for managing cybersecurity risks established, communicated, and enforced | Written, approved cybersecurity policies covering the full risk management scope | Policy library with version control, approval signatures, and review history |
+| **GV.PO-02** — cybersecurity risk policies reviewed, updated, and enforced to reflect changes | Evidence policies are refreshed in response to threats, technology, and organizational changes | Policy revision history; scheduled review records; change log showing updates triggered by new threats or regulatory changes; communication records for policy updates |
+
+#### GV.OV — Oversight
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **GV.OV-01** — cybersecurity strategy results reviewed to inform and adjust direction | Board or audit committee receives and acts on cybersecurity strategy performance data | Board cybersecurity reporting deck; audit committee minutes; independent review or assurance report |
+| **GV.OV-02** — cybersecurity risk management strategy reviewed and adjusted to ensure coverage | Evidence that strategy is revisited when requirements or risk landscape changes | Strategy review meeting minutes; updated strategy documents; records of adjustments made in response to new risks, incidents, or regulatory changes |
+| **GV.OV-03** — cybersecurity risk management performance evaluated and reviewed | KPIs, metrics, or program health reviews used to assess and improve performance | KPI / metric dashboard; executive or board performance review records; program effectiveness reports; benchmark comparisons or third-party assessments |
+
+#### GV.SC — Cybersecurity Supply Chain Risk Management
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **GV.SC-01** — cybersecurity supply chain risk management program established | C-SCRM program with documented strategy, objectives, policies, and processes | Vendor risk management policy; tiered vendor inventory; due diligence templates |
+| **GV.SC-02** — cybersecurity roles for suppliers, customers, and partners established and coordinated | Clear accountability for supply chain cybersecurity internally and with third parties | Vendor RACI; third-party cybersecurity responsibility matrix; partner agreements referencing security roles and coordination |
+| **GV.SC-03** — C-SCRM integrated into enterprise risk management and improvement processes | Supply chain risks visible in ERM and feeding continuous improvement cycles | Process documentation showing C-SCRM feeds into ERM; integrated risk register with supply chain entries; evidence of supply chain risk inputs to improvement activities |
+| **GV.SC-04** — suppliers known and prioritized by criticality | Tiered vendor inventory with criticality rationale | Tiered vendor inventory; criticality scoring criteria and methodology; critical vendor shortlist with documented rationale |
+| **GV.SC-05** — supply chain cybersecurity requirements addressed in contracts | Standard cybersecurity contract clauses in supplier agreements | Standard cybersecurity contract clauses; sample executed vendor agreements referencing security requirements |
+| **GV.SC-06** — planning and due diligence performed before entering new supplier relationships | Pre-engagement vetting process for new vendors | Pre-engagement vendor assessment checklist; due diligence questionnaires and vendor responses; approval records for new vendor relationships |
+| **GV.SC-07** — risks from suppliers monitored throughout the relationship | Ongoing vendor risk monitoring and re-assessment cadence | Ongoing vendor risk monitoring schedule; periodic vendor assessment records; risk re-evaluation trigger criteria and evidence of application |
+| **GV.SC-08** — suppliers included in incident planning, response, and recovery | Third parties incorporated into IR exercises and response activities | IR plan sections referencing key third-party suppliers; tabletop exercise records involving critical vendors; vendor IR contact list and notification procedures |
+| **GV.SC-09** — supply chain security practices integrated and monitored through the product/service life cycle | SCRM embedded across the full technology acquisition and management lifecycle | SCRM lifecycle process documentation; component integrity verification records; hardware / software provenance tracking evidence |
+| **GV.SC-10** — C-SCRM plans include provisions for end-of-partnership activities | Offboarding and wind-down security steps covered in contracts and internal processes | Contract offboarding / termination clauses referencing security; end-of-relationship security checklist; access revocation and data return / destruction records post-contract |
+
+---
 
 ### Identify (ID) — context, assets, risk assessment, improvement
 
 Identify evidence is mostly **inventories and assessments**.
 
-| Representative Subcategory | What it asks for | Evidence |
-|---|---|---|
+#### ID.AM — Asset Management
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
 | **ID.AM-01** — hardware inventory maintained | Asset inventory of physical devices | Asset inventory export (CMDB / IT asset management tool); reconciliation cadence record |
-| **ID.AM-02** — software inventory maintained | Software inventory | Software asset management export; SBOM (software bill of materials) where applicable |
-| **ID.AM-03** — data flows mapped | Data flow diagrams and data inventory | Data flow diagrams; data classification register; data lineage documentation |
-| **ID.AM-05** — assets prioritized based on classification, criticality, business value | Asset criticality / classification scheme | Asset classification scheme; tier assignment per system; review record |
-| **ID.RA-01** — vulnerabilities in assets identified, validated, recorded | Vulnerability management process | Vulnerability scan reports; remediation ticket samples; SLA / process documentation |
-| **ID.RA-05** — threats, vulnerabilities, likelihoods, impacts used to determine risk | Risk assessment methodology and outputs | Risk assessment report; risk register; methodology documentation (often NIST SP 800-30 aligned) |
-| **ID.IM-01** — improvements identified from evaluations | Lessons-learned and continuous improvement | Post-incident review reports; security program review minutes; improvement backlog |
+| **ID.AM-02** — software, services, and systems inventory maintained | Software and services asset management | Software asset management export; SBOM (software bill of materials) where applicable |
+| **ID.AM-03** — authorized network communication and data flows documented | Data flow diagrams and network communication maps | Data flow diagrams; data classification register; data lineage documentation |
+| **ID.AM-04** — inventories of services provided by suppliers maintained | Catalog of third-party and cloud services in use | Supplier service catalog; SaaS / IaaS / PaaS inventory; contract register tied to service inventory |
+| **ID.AM-05** — assets prioritized based on classification, criticality, resources, and impact on the mission | Asset criticality / classification scheme applied and maintained | Asset classification scheme; tier or criticality assignment per system; review record |
+| **ID.AM-07** — inventories of data and metadata maintained for designated data types | Data inventory and classification records | Data inventory / register; data classification records; metadata tagging evidence; data map |
+| **ID.AM-08** — assets managed throughout their life cycles | Asset lifecycle management covering acquisition through decommission | Asset lifecycle policy; decommission and disposal records; end-of-life hardware / software disposition evidence (certificate of destruction where applicable) |
+
+#### ID.RA — Risk Assessment
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **ID.RA-01** — vulnerabilities in assets identified, validated, and recorded | Vulnerability management process and outputs | Vulnerability scan reports; remediation ticket samples; SLA / process documentation |
+| **ID.RA-02** — cyber threat intelligence received from information sharing forums and sources | Active participation in threat intelligence sharing | Threat intel feed subscriptions (ISAC membership, government feeds such as CISA); threat reports received; threat intel integration or processing logs |
+| **ID.RA-03** — internal and external threats identified and recorded | Threat catalog or threat model maintained | Threat catalogue or threat modeling outputs; threat identification records in risk register; threat landscape review documentation |
+| **ID.RA-04** — potential impacts and likelihoods of threats exploiting vulnerabilities identified | Likelihood and impact analysis for identified risks | Risk assessment methodology outputs with likelihood / impact scoring; risk heat maps or risk matrices |
+| **ID.RA-05** — threats, vulnerabilities, likelihoods, and impacts used to inform risk response prioritization | Risk assessment drives prioritized response | Risk assessment report; risk register with prioritization rationale; methodology documentation (often NIST SP 800-30 aligned) |
+| **ID.RA-06** — risk responses chosen, prioritized, planned, tracked, and communicated | Risk treatment decisions documented and tracked through to completion | Risk treatment decisions in risk register; remediation plans and status reports; stakeholder communication records on risk response |
+| **ID.RA-07** — changes and exceptions managed, assessed for risk impact, recorded, and tracked | Change management and exception processes include risk assessment step | Change management records showing risk review; exception request logs with risk assessments; tracking records for open exceptions |
+| **ID.RA-08** — processes for receiving, analyzing, and responding to vulnerability disclosures established | Vulnerability disclosure or responsible disclosure program | Vulnerability disclosure policy (VDP) or responsible disclosure process documentation; bug bounty program documentation (if applicable); disclosure intake and response records |
+| **ID.RA-09** — authenticity and integrity of hardware and software assessed before acquisition and use | Supply chain integrity checks in procurement | Procurement security requirements; software composition analysis (SCA) results; hardware provenance checks; signing / verification records |
+| **ID.RA-10** — critical suppliers assessed before acquisition | Security vetting of critical vendors prior to onboarding | Pre-acquisition vendor security assessment records; supplier vetting questionnaire responses; risk rating documentation for critical suppliers |
+
+#### ID.IM — Improvement
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **ID.IM-01** — improvements identified from evaluations | Formal evaluations feed a documented improvement process | Post-assessment review reports; security program review minutes; improvement backlog or tracking record |
+| **ID.IM-02** — improvements identified from security tests and exercises | Penetration tests, red team exercises, and tabletop exercises yield tracked improvements | Penetration test reports; red team or tabletop exercise after-action reports; improvement items with owner and target date |
+| **ID.IM-03** — improvements identified from execution of operational processes, procedures, and activities | Lessons learned from operational reviews integrated into the improvement cycle | Operational review improvement logs; process performance review records; recurring finding tracking across monitoring cycles |
+| **ID.IM-04** — incident response plans and other cybersecurity plans that affect operations are established, communicated, maintained, and improved | Cybersecurity plans beyond the IR plan are kept current and shared with relevant parties | IR plan with version history and communication records; business continuity / BCDR plan; sector-specific operational plans; improvement records from exercises and post-incident reviews |
+
+---
 
 ### Protect (PR) — identity, training, data, platform, infrastructure
 
 Protect evidence is the largest bucket and is mostly **technical configuration plus operational records**.
 
-| Representative Subcategory | What it asks for | Evidence |
-|---|---|---|
-| **PR.AA-01** — identities and credentials managed | Identity and access management baseline | IAM configuration export (cloud IdP / Active Directory / Entra / Okta); user provisioning workflow documentation |
-| **PR.AA-03** — users, services, hardware authenticated commensurate with risk | Authentication strength | MFA enrollment / enforcement reports; authentication policy; service-account inventory |
-| **PR.AA-05** — access permissions managed per least privilege and separation of duties | Role-based access and separation of duties | RBAC role definitions; access review records; SoD conflict matrix |
-| **PR.AT-01** — personnel awareness training | Security awareness training program | Training completion reports; training content / curriculum; phishing simulation results |
-| **PR.DS-01** — data-at-rest protected | Encryption at rest | Encryption configuration evidence (KMS keys, storage encryption settings); key rotation records |
-| **PR.DS-02** — data-in-transit protected | Encryption in transit | TLS configuration evidence; cert inventory; mTLS / VPN configuration where applicable |
-| **PR.DS-10** — data integrity protected | Integrity controls | Hash / signature verification logs; tamper-evident logging; change-detection alerts |
-| **PR.PS-01** — configuration baselines maintained | System hardening baselines | CIS Benchmark scan reports; STIG compliance reports; configuration management tool (Puppet/Chef/Ansible/Terraform) state |
-| **PR.PS-04** — log records generated and made available | Logging coverage | Logging architecture diagram; log source inventory; SIEM ingestion proof |
-| **PR.PS-06** — secure software development practices | Secure SDLC | SAST / DAST scan results; code review records; security gates in CI/CD pipeline |
-| **PR.IR-01** — networks and environments protected from unauthorized access | Network segmentation and perimeter | Network architecture diagrams; security group / firewall rule exports; segmentation test results |
-| **PR.IR-04** — adequate resource capacity ensures availability | Capacity and resilience | Capacity planning documents; load test results; auto-scaling configuration |
+#### PR.AA — Identity Management, Authentication, and Access Control
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **PR.AA-01** — identities and credentials managed by the organization | Identity and access management baseline | IAM configuration export (cloud IdP / Active Directory / Entra / Okta); user provisioning workflow documentation |
+| **PR.AA-02** — identities proofed and bound to credentials based on context of interactions | Identity proofing process matched to risk level of the interaction | Identity proofing process documentation; credential issuance records; identity verification audit log samples |
+| **PR.AA-03** — users, services, and hardware authenticated commensurate with risk | Authentication strength appropriate to the sensitivity of resources | MFA enrollment / enforcement reports; authentication policy; service-account inventory |
+| **PR.AA-04** — identity assertions protected, conveyed, and verified | Federation and single sign-on security controls in place | SAML / OIDC / OAuth configuration evidence; federation trust records; token validation logs; SSO assertion integrity controls documentation |
+| **PR.AA-05** — access permissions managed per least privilege and separation of duties | Role-based access and SoD controls defined, enforced, and reviewed | RBAC role definitions; access review records; SoD conflict matrix |
+| **PR.AA-06** — physical access to assets managed, monitored, and enforced commensurate with risk | Physical access controls for facilities, data centers, and sensitive areas | Physical access control system configuration; badge access logs; visitor logs; data center physical security audit or inspection records |
+
+#### PR.AT — Awareness and Training
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **PR.AT-01** — personnel provided with security awareness and training | Security awareness training program for all staff | Training completion reports; training content / curriculum; phishing simulation results |
+| **PR.AT-02** — individuals in specialized roles provided with role-specific training | Targeted training for security, development, IR, and other roles with elevated risk | Role-specific security training completion records; CISO, developer, and IR team training evidence; relevant certifications held |
+
+#### PR.DS — Data Security
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **PR.DS-01** — data-at-rest protected | Encryption at rest across storage and databases | Encryption configuration evidence (KMS keys, storage encryption settings); key rotation records |
+| **PR.DS-02** — data-in-transit protected | Encryption in transit across all communication channels | TLS configuration evidence; cert inventory; mTLS / VPN configuration where applicable |
+| **PR.DS-10** — data-in-use protected | Controls protecting data during active processing | Hash / signature verification logs; tamper-evident logging; memory protection or secure enclave configuration where applicable |
+| **PR.DS-11** — backups created, protected, maintained, and tested | Backup program covering creation, integrity, protection, and periodic restoration testing | Backup policy; backup completion logs; restoration test records; offsite or cloud backup configuration; backup access control evidence |
+
+#### PR.PS — Platform Security
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **PR.PS-01** — configuration baselines maintained | System hardening baselines applied and monitored | CIS Benchmark scan reports; STIG compliance reports; configuration management tool (Puppet / Chef / Ansible / Terraform) state |
+| **PR.PS-02** — software maintained, replaced, and removed commensurate with risk | Patch management and software lifecycle discipline | Patch management records; software EOL tracking; decommission logs; unsupported software inventory with exception approvals |
+| **PR.PS-03** — hardware maintained, replaced, and removed commensurate with risk | Hardware refresh and disposal process | Hardware EOL / refresh schedule; decommission records; hardware disposal records with certificate of destruction where required |
+| **PR.PS-04** — log records generated and made available for continuous monitoring | Logging coverage across systems and services with logs fed to monitoring tooling | Logging architecture diagram; log source inventory; SIEM ingestion proof |
+| **PR.PS-05** — unauthorized software installation and execution prevented | Application control or allowlisting enforced | Application allowlisting configuration; EDR block records; software restriction policy documentation |
+| **PR.PS-06** — secure software development practices integrated | Secure SDLC with security gates | SAST / DAST scan results; code review records; security gates in CI/CD pipeline |
+
+#### PR.IR — Technology Infrastructure Resilience
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **PR.IR-01** — networks and environments protected from unauthorized logical access | Network segmentation and perimeter security controls | Network architecture diagrams; security group / firewall rule exports; segmentation test results |
+| **PR.IR-02** — technology assets protected from environmental threats | Environmental controls protecting physical infrastructure | Environmental controls evidence (HVAC, fire suppression, flood protection); data center environmental audit records; UPS / power redundancy configuration |
+| **PR.IR-03** — mechanisms implemented to achieve resilience in normal and adverse situations | Failover, redundancy, and DR capabilities tested and validated | Resilience architecture documentation; failover and DR test results; high-availability configuration evidence |
+| **PR.IR-04** — adequate resource capacity maintained for availability | Capacity planning and auto-scaling in place | Capacity planning documents; load test results; auto-scaling configuration |
+
+---
 
 ### Detect (DE) — continuous monitoring, adverse event analysis
 
 Detect evidence is mostly **monitoring config + log samples + alert records**.
 
-| Representative Subcategory | What it asks for | Evidence |
-|---|---|---|
-| **DE.CM-01** — networks and network services monitored to find adverse events | Network monitoring | SIEM dashboard screenshots / exports; NDR / IDS configuration; sample alerts |
-| **DE.CM-03** — personnel activity monitored to find adverse events | UEBA / insider threat detection | UEBA tool configuration; sample anomalous-activity alerts; data access monitoring |
-| **DE.CM-06** — external service provider activities monitored | Third-party access monitoring | Vendor access audit logs; CASB configuration; sample alerts on third-party anomalies |
-| **DE.CM-09** — computing hardware/software, runtime environments, configurations monitored | Endpoint and configuration drift monitoring | EDR configuration; configuration drift reports; sample drift alerts |
-| **DE.AE-02** — potentially adverse events analyzed to better understand activity | Triage and analysis | SOC playbooks; analyst notes / case management records; sample triaged events |
-| **DE.AE-04** — estimated impact and scope of adverse events understood | Impact / scope assessment | Incident severity scoring rubric; sample severity assignments; escalation criteria |
-| **DE.AE-06** — information about adverse events provided to authorized staff/tools | Alert routing | Alert routing rules; on-call / paging configuration; escalation matrix |
+#### DE.CM — Continuous Monitoring
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **DE.CM-01** — networks and network services monitored for adverse events | Network monitoring and intrusion detection | SIEM dashboard screenshots / exports; NDR / IDS configuration; sample alerts |
+| **DE.CM-02** — physical environment monitored for adverse events | Physical security monitoring of facilities | Physical security monitoring logs; CCTV configuration; environmental sensor alerts; physical access anomaly reports |
+| **DE.CM-03** — personnel activity and technology usage monitored for adverse events | User and entity behavior analytics or insider threat detection | UEBA tool configuration; sample anomalous-activity alerts; data access monitoring configuration |
+| **DE.CM-06** — external service provider activities and services monitored | Third-party access and activity monitoring | Vendor access audit logs; CASB configuration; sample alerts on third-party anomalous activity |
+| **DE.CM-09** — computing hardware, software, runtime environments, and their data are monitored | Endpoint and runtime environment monitoring for anomalies | EDR configuration; runtime monitoring tool configuration; sample drift or anomaly alerts |
+
+#### DE.AE — Adverse Event Analysis
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **DE.AE-02** — potentially adverse events analyzed to better understand associated activities | Event triage and analysis capability | SOC playbooks; analyst notes / case management records; sample triaged events |
+| **DE.AE-03** — information correlated from multiple sources | Multi-source log correlation and enrichment | SIEM correlation rule examples; log aggregation architecture diagram; sample multi-source correlated alerts |
+| **DE.AE-04** — estimated impact and scope of adverse events understood | Impact and scope analysis integrated into triage | Incident severity scoring rubric; sample severity assignments; escalation criteria documentation |
+| **DE.AE-06** — information on adverse events provided to authorized staff and tools | Alert routing to the right people and downstream tooling | Alert routing rules; on-call / paging configuration; escalation matrix |
+| **DE.AE-07** — cyber threat intelligence integrated into adverse event analysis | Threat intel enriching alerts and investigations | Threat intel platform (TIP) integration records; enriched alert samples; STIX / TAXII feed configuration |
+| **DE.AE-08** — incidents declared when adverse events meet defined criteria | Formal incident declaration process with documented thresholds | Incident declaration criteria / severity thresholds; sample incident declarations; escalation workflow records |
+
+---
 
 ### Respond (RS) — incident management, analysis, communication, mitigation
 
 Respond evidence is mostly **incident records, runbooks, and after-action reports**.
 
-| Representative Subcategory | What it asks for | Evidence |
-|---|---|---|
-| **RS.MA-01** — incident response plan executed in coordination with relevant third parties | IR plan in use | Incident response plan; sample incident records; tabletop exercise reports |
-| **RS.MA-02** — incidents categorized and prioritized | Incident classification scheme | Severity / category taxonomy; sample categorized incidents |
-| **RS.AN-03** — analysis performed to establish what has happened during an incident | Forensic / analysis capability | Forensic analysis reports; chain-of-custody logs (where applicable); analysis tool inventory |
-| **RS.CO-02** — internal and external stakeholders notified of incidents | Stakeholder notification | Communication plan; sample notification records (internal and external); regulator notification samples (HHS OCR, state AGs, etc., where applicable) |
-| **RS.CO-03** — information shared with designated internal and external stakeholders | Cross-functional coordination | Sample executive briefings; sample post-incident customer notifications |
-| **RS.MI-01** — incidents contained | Containment | Sample containment actions; runbook for containment; quarantine / isolation evidence |
-| **RS.MI-02** — incidents eradicated | Eradication | Eradication runbooks; sample eradication action records (malware removal, account disablement, etc.) |
+#### RS.MA — Incident Management
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **RS.MA-01** — incident response plan executed in coordination with relevant third parties | IR plan in active use during incidents | Incident response plan; sample incident records; tabletop exercise reports |
+| **RS.MA-02** — incident reports triaged and validated | Initial triage process to validate and assess incoming incident reports | Triage workflow documentation; sample triage records showing validation steps; runbook for initial incident intake |
+| **RS.MA-03** — incidents categorized and prioritized | Classification and prioritization scheme applied consistently | Severity / category taxonomy; sample categorized and prioritized incident records |
+| **RS.MA-04** — incidents escalated or elevated as needed | Escalation thresholds and paths defined and followed | Escalation policy / thresholds; sample escalation records; on-call / escalation matrix |
+| **RS.MA-05** — criteria for initiating incident recovery applied | Defined and applied criteria for transitioning from response to recovery | Recovery initiation criteria documentation; sample decisions to initiate recovery with rationale; IR plan section defining recovery triggers |
+
+#### RS.AN — Incident Analysis
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **RS.AN-03** — analysis performed to establish what occurred and root cause of incident | Forensic and root cause analysis capability | Forensic analysis reports; chain-of-custody logs where applicable; root cause analysis (RCA) documentation |
+| **RS.AN-06** — investigation actions recorded with integrity and provenance preserved | Tamper-evident investigation audit trail | Investigation log with integrity controls; chain-of-custody records; forensic tool audit trails showing actions taken |
+| **RS.AN-07** — incident data and metadata are collected, and their integrity and provenance are preserved | Evidence handling practices maintain chain of custody and integrity throughout the investigation | Forensic evidence collection procedures; chain-of-custody records; integrity hash / signing evidence; evidence storage access logs |
+| **RS.AN-08** — an incident's magnitude is estimated and validated | Scope and impact quantification performed and validated during incident response | Incident scope assessment records; magnitude / impact estimates with validation notes; escalation decisions tied to magnitude assessments |
+
+#### RS.CO — Incident Response Reporting and Communication
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **RS.CO-02** — internal and external stakeholders notified of incidents in a timely manner | Stakeholder notification process and records | Communication plan; sample notification records (internal and external); regulator notification samples (HHS OCR, state AGs, etc., where applicable) |
+| **RS.CO-03** — information shared with designated internal and external stakeholders | Cross-functional and external coordination | Sample executive briefings; sample post-incident customer notifications; coordinated disclosure records |
+
+#### RS.MI — Incident Mitigation
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **RS.MI-01** — incidents contained | Containment actions taken and documented | Sample containment actions; containment runbook; quarantine / isolation evidence |
+| **RS.MI-02** — incidents eradicated | Eradication actions taken and documented | Eradication runbooks; sample eradication action records (malware removal, account disablement, etc.) |
+
+---
 
 ### Recover (RC) — recovery plan execution, recovery communication
 
 Recover evidence is mostly **BCDR plans, test reports, and recovery records**.
 
-| Representative Subcategory | What it asks for | Evidence |
-|---|---|---|
-| **RC.RP-01** — recovery portion of incident response plan executed | Recovery plan in use | BCDR plan; sample recovery records; recovery time achieved vs RTO |
-| **RC.RP-02** — recovery actions selected, scoped, prioritized | Recovery prioritization | Recovery priority ranking; sample prioritization decisions during exercises |
-| **RC.RP-03** — integrity of backups and other restoration assets verified before use | Backup integrity | Backup verification logs; sample restoration tests; integrity check evidence |
-| **RC.RP-04** — critical mission functions and cybersecurity risk management considered to establish post-incident operational norms | Post-incident operational baseline | Post-incident operating model; sample reset-state documentation |
-| **RC.RP-06** — end of incident recovery declared and incident-related documentation completed | Recovery closeout | Sample closeout records; lessons-learned reports; incident closure approvals |
-| **RC.CO-03** — recovery activities and progress communicated to designated stakeholders | Recovery communication | Sample recovery status updates; executive / customer / regulator communication records |
+#### RC.RP — Incident Recovery Plan Execution
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **RC.RP-01** — recovery portion of incident response plan executed | Recovery plan in active use | BCDR plan; sample recovery records; recovery time achieved vs. RTO |
+| **RC.RP-02** — recovery actions selected, scoped, prioritized, and performed | Recovery prioritization decisions documented and carried through to execution | Recovery priority ranking; sample prioritization decisions made during exercises or actual incidents; recovery task completion records |
+| **RC.RP-03** — integrity of backups and restoration assets verified before use | Backup integrity validation before restoring | Backup verification logs; sample restoration tests; integrity check evidence |
+| **RC.RP-04** — critical mission functions considered to establish post-incident operational norms | Return-to-operations criteria defined and applied | Post-incident operating model; sample reset-state documentation; criteria for declaring stabilized operations |
+| **RC.RP-05** — integrity of restored assets verified and normal operating status confirmed | Post-restoration validation and sign-off | Restoration verification checklist; system health check records; sign-off records confirming normal operations resumed |
+| **RC.RP-06** — end of incident recovery declared and incident-related documentation completed | Formal recovery closeout process | Sample closeout records; lessons-learned reports; incident closure approvals |
+
+#### RC.CO — Incident Recovery Communication
+
+| Subcategory | What it asks for | Evidence |
+| --- | --- | --- |
+| **RC.CO-03** — recovery activities and progress communicated to designated stakeholders | Internal and external recovery status updates | Sample recovery status updates; executive / customer / regulator communication records |
+| **RC.CO-04** — public updates on incident recovery shared using approved methods and messaging | Controlled public communications during and after recovery | Public communications log; approved messaging templates; records of communications with media, customers, or regulators using approved channels |
+
+---
 
 ## Reusing evidence across frameworks
 
@@ -148,7 +311,7 @@ CSF imposes no specific retention period. In practice, retain evidence for at le
 
 ## Examples
 
-```
+```bash
 # Full evidence checklist (all six Functions)
 /nist-csf-20:evidence-checklist
 

--- a/plugins/frameworks/nist-csf-20/commands/scope.md
+++ b/plugins/frameworks/nist-csf-20/commands/scope.md
@@ -8,7 +8,7 @@ Determines how **NIST Cybersecurity Framework v2.0** should be applied to the or
 
 ## Usage
 
-```
+```text
 /nist-csf-20:scope
 ```
 
@@ -101,7 +101,7 @@ Document the rationale; partial Function scope tends to surface during board rep
 
 After collecting the answers above, produce a scope memo with:
 
-```
+```text
 NIST CSF 2.0 Scope — <Organization Name>
 
 Driver:           <primary driver>

--- a/plugins/frameworks/nist-csf-20/skills/nist-csf-20-expert/SKILL.md
+++ b/plugins/frameworks/nist-csf-20/skills/nist-csf-20-expert/SKILL.md
@@ -98,7 +98,7 @@ Subcategories are the leaf nodes — concrete cybersecurity outcomes phrased as 
 - **DE.CM-01** — Networks and network services are monitored to find potentially adverse events
 - **RS.MA-01** — The incident response plan is executed in coordination with relevant third parties once an incident is declared
 
-Subcategories are the **assessment unit**. When practitioners say "we're at Partial on PR.AA-01 and Repeatable on DE.CM-01," they're scoring at the Subcategory level. This plugin's `evidence-checklist` command is organized by Function → Category → representative Subcategories.
+Subcategories are the **assessment unit**. When practitioners say "we're at Partial on PR.AA-01 and Repeatable on DE.CM-01," they're scoring at the Subcategory level. This plugin's `evidence-checklist` command covers all 106 Subcategories, organized by Function → Category.
 
 ## Implementation Examples (new in 2.0)
 
@@ -224,17 +224,17 @@ Federal contractors and regulated entities should additionally produce mappings 
 
 When using this plugin, the typical workflow is:
 
-```
+```text
 1. /nist-csf-20:scope             # decide what's in scope, pick or build a Target Profile
-2. /nist-csf-20:assess            # run the gap assessment via SCF crosswalk
-3. /nist-csf-20:evidence-checklist # enumerate evidence per Function/Category
+2. /nist-csf-20:evidence-checklist # enumerate evidence per Function/Category
+3. /nist-csf-20:assess            # run the gap assessment via SCF crosswalk
 ```
 
 Underneath, all three commands delegate the control-by-control mechanics to `/grc-engineer:gap-assessment` with SCF framework ID `general-nist-csf-2-0`. This plugin contributes:
 
 - The CSF-specific scope decision tree (Functions in scope, Tier target, Community Profile selection)
 - CSF-specific framing of the gap assessment output (organized by Function and Category, not by SCF family)
-- Evidence patterns organized by Function with representative Subcategories per Function
+- Evidence patterns organized by Function → Category, covering all 106 Subcategories
 
 For citation purposes, refer to the **NIST CSF 2.0 Quick Start Guides** (NIST SP 1300 series — `1300`, `1301`, etc., each addressing a specific audience or topic) and the public NIST CSF 2.0 Reference Tool. Cite by document ID and section number; do not paste their prose verbatim.
 
@@ -275,7 +275,7 @@ Contributors with practitioner experience in any of these workflows are encourag
 
 - `/nist-csf-20:scope` — determine applicability and Profile/Tier targeting
 - `/nist-csf-20:assess` — run a gap assessment via SCF crosswalk
-- `/nist-csf-20:evidence-checklist` — enumerate evidence per Function and representative Subcategories
+- `/nist-csf-20:evidence-checklist` — enumerate evidence per Function and Category across all 106 Subcategories
 
 All three delegate to `/grc-engineer:gap-assessment` with SCF framework ID `general-nist-csf-2-0` for the control-by-control mechanics, and wrap the results in CSF 2.0 vocabulary (Function / Category / Subcategory / Profile / Tier).
 


### PR DESCRIPTION
```
## Summary

1. **Evidence checklist completeness** — the original scaffold covered ~30 representative Subcategories. The checklist now covers all 106 official CSF 2.0 Subcategories, organized by Function → Category, with evidence patterns per Subcategory.

2. **Subcategory accuracy** — compared every Subcategory description in the evidence checklist against the official NIST CSF 2.0 PDF (NIST.CSWP.29). Corrected 10 inaccuracies ranging from completely wrong descriptions to meaningful paraphrase errors:
   - **Completely wrong** (3): `ID.IM-04`, `RS.AN-07`, `RS.AN-08` — descriptions pointed at different outcomes entirely
   - **Substantively inaccurate** (7): `GV.RM-06`, `ID.AM-05`, `ID.IM-03`, `ID.RA-07`, `PR.PS-04`, `DE.CM-09`, `RC.RP-02` — omitted key terms or substituted concepts from adjacent Subcategories

3. **Profile examples** — added three concrete Current → Target Profile snapshots to `assess.md`: mid-market SaaS (Tier 1→3), federal contractor with existing 800-171/CMMC work (Tier 2→3), and regional health system using CSF above HIPAA (Tier 2→3 with CFR mappings column).

Also addressed two open items from the PR #96 CodeRabbit and Greptile reviews:
- **MD040**: added language tags (`text` / `bash`) to 8 unlabeled fenced code blocks across `assess.md`, `scope.md`, `evidence-checklist.md`, and `SKILL.md`
- **Workflow ordering**: corrected the SKILL.md workflow block from `scope → assess → evidence-checklist` to `scope → evidence-checklist → assess`, matching the ordering in `scope.md` and `assess.md`

Fixed `SKILL.md` stale references that described the evidence checklist as covering "representative Subcategories" — updated to "all 106 Subcategories."

## Type of change

- [ ] Connector
- [x] Framework plugin
- [ ] Persona plugin
- [ ] Documentation
- [ ] Community / governance
- [ ] CI / automation
- [ ] Other

## Schema impact

- [x] No schema changes
- [ ] `schemas/finding.schema.json` changed
- [ ] Another schema or contract surface changed

## Key framework facts for reviewer accuracy check

- **106 Subcategories** is the correct count for CSF 2.0 final (February 26, 2024). CSF 1.1 had 108.
- **22 Categories** across 6 Functions (GV, ID, PR, DE, RS, RC).
- `ID.IM-04` outcome: "Incident response plans and other cybersecurity plans that affect operations are established, communicated, maintained, and improved" — not information sharing (closer to `ID.RA-02`).
- `RS.AN-07` outcome: "Incident data and metadata are collected, and their integrity and provenance are preserved" — evidence handling / chain of custody, not post-incident effectiveness review.
- `RS.AN-08` outcome: "An incident's magnitude is estimated and validated" — scope quantification, not incident categorization (which is `RS.MA-03`).

## Test plan

All changes are markdown only (no scripts, no schema). Validation:

- [x] No `TODO:` markers remain in SKILL body or commands
- [x] All fenced code blocks have language tags (MD040)
- [x] All table separator rows use spaced format `| --- |` (MD060)
- [x] Subcategory descriptions verified against NIST.CSWP.29 Appendix A
- [ ] `bash tests/validate-plugin-manifests.sh` — paste output below

```text
Paste validate-plugin-manifests.sh output here.
```

## CHANGELOG

- [ ] No CHANGELOG entry needed
- [ ] I added a CHANGELOG entry
- [x] A maintainer should add the CHANGELOG entry during merge

## Notes for reviewers

The three "completely wrong" Subcategory descriptions (`ID.IM-04`, `RS.AN-07`, `RS.AN-08`) appear to be scaffold errors where descriptions from adjacent Subcategories were assigned to the wrong codes. Reviewer should verify these three against NIST.CSWP.29 Appendix A as the highest-risk corrections.

The two minor corrections (`PR.AA-03` "commensurate with risk", `RS.CO-02` "in a timely manner") were intentionally kept as practitioner-friendly paraphrases rather than strict PDF text — both are implied by the framework and consistent with sector regulator interpretations.

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced NIST CSF 2.0 assessment documentation with improved formatting and code block styling
  * Added profile examples section featuring three Current→Target Tier scenarios with detailed Function/Category/Subcategory breakdowns and reuse guidance
  * Expanded evidence checklist to comprehensively cover all 106 Subcategories organized by Function and Category

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GRCEngClub/claude-grc-engineering/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->