### PR TITLE
Vouch FideleDonadje and kfcain

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -14,7 +14,9 @@ anandsundar
 devamshah
 dexcopeland
 ethanolivertroy
+FideleDonadje
 funkeomolere trusted contributor
 jeftekhari
+kfcain
 networkbm trusted contributor — first PR (#64)
 abdie-grcengineer

--- a/.github/workflows/vouch-manage.yml
+++ b/.github/workflows/vouch-manage.yml
@@ -37,5 +37,6 @@ jobs:
           vouch-keyword: "!vouch"
           denounce-keyword: "!denounce"
           unvouch-keyword: "!unvouch"
+          pull-request: "true"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This PR adds two new contributors to the vouched list so they can open PRs without automatic closure.

- `FideleDonadje` — vouched via <https://github.com/GRCEngClub/claude-grc-engineering/pull/178#issuecomment-4471231168>
- `kfcain` — vouched via <https://github.com/GRCEngClub/claude-grc-engineering/issues/177#issuecomment-4471231260>

Both were triggered by `!vouch` comments from @ethanolivertroy. The automated vouch workflow currently fails because `main` is protected and the workflow is configured with `pull-request: false`; see follow-up fix in this PR or a separate PR.