### PR TITLE
Add v1 finding fixtures for gcp-inspector (#161)

### DIFF
--- a/tests/fixtures/findings/gcp-inspector/001-bucket-uniform-access-pass.json
+++ b/tests/fixtures/findings/gcp-inspector/001-bucket-uniform-access-pass.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0.0",
+  "source": "gcp-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-gcp-pass",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "gcp_storage_bucket",
+    "id": "prod-data-bucket",
+    "uri": "//storage.googleapis.com/projects/_/buckets/prod-data-bucket",
+    "region": "us-central1",
+    "account_id": "my-project"
+  },
+  "evaluations": [
+    { "control_framework": "SCF", "control_id": "DCH-01.2", "status": "pass", "severity": "info" }
+  ]
+}

--- a/tests/fixtures/findings/gcp-inspector/002-service-account-owner-role-fail.json
+++ b/tests/fixtures/findings/gcp-inspector/002-service-account-owner-role-fail.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "source": "gcp-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-gcp-fail",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "gcp_iam_binding",
+    "id": "projects/my-project/roles/owner",
+    "uri": "//cloudresourcemanager.googleapis.com/projects/my-project",
+    "region": null,
+    "account_id": "my-project"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "IAC-07.2",
+      "status": "fail",
+      "severity": "high",
+      "message": "Primitive role roles/owner is granted to a user account at the project level, violating least privilege.",
+      "remediation": {
+        "summary": "Replace the primitive roles/owner grant with narrowly scoped predefined roles for each user.",
+        "ref": "grc-engineer://generate-implementation/primitive_roles/gcp",
+        "effort_hours": 0.5,
+        "automation": "manual"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/findings/gcp-inspector/003-audit-logs-quota-inconclusive.json
+++ b/tests/fixtures/findings/gcp-inspector/003-audit-logs-quota-inconclusive.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "source": "gcp-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-gcp-inconclusive",
+  "collected_at": "2026-04-30T00:00:00Z",
+  "resource": {
+    "type": "gcp_audit_config",
+    "id": "projects/my-project/auditConfig",
+    "uri": "//cloudresourcemanager.googleapis.com/projects/my-project",
+    "region": null,
+    "account_id": "my-project"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "MON-02",
+      "status": "inconclusive",
+      "severity": "medium",
+      "message": "GCP Logging API quota was exhausted (HTTP 429); could not determine whether Admin Activity audit logs are routed to a retained sink. Re-run after quota resets."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #161

Adds three v1 Finding fixtures for the gcp-inspector connector under
`tests/fixtures/findings/gcp-inspector/`, covering the status mix the connector
produces:

- `001-bucket-uniform-access-pass.json` — GCS bucket with uniform bucket-level
  access (SCF DCH-01.2, pass)
- `002-service-account-owner-role-fail.json` — primitive `roles/owner` granted
  to a user (SCF IAC-07.2, fail, high, with remediation)
- `003-audit-logs-quota-inconclusive.json` — audit-log check blocked by GCP
  Logging API quota (SCF MON-02, inconclusive)

Each fixture conforms to `schemas/finding.schema.json` (schema_version 1.0.0,
gcp_* resource type with self-link uri, ≥1 evaluation), follows the
`NNN-short-description.json` naming pattern, and one exercises a remediation
block. Control IDs and resource types match the checks defined in the
gcp-inspector `collect.md`.

Verified locally: `bash tests/validate-contract-fixtures.sh` → all fixtures valid.