### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,23 @@
 # AGENTS.md
 
-See `CLAUDE.md` for the full architecture overview (plugin structure, frameworks, connectors, and the Finding data contract). This file captures durable, non-obvious notes for working in this repo.
+See `CLAUDE.md` for the full architecture overview (plugin structure, frameworks, connectors, and the Finding data contract). This file captures durable, non-obvious notes for coding agents working in this repo.
 
-## Cursor Cloud specific instructions
+## Repo shape
 
 This repo is a Claude Code plugin marketplace: mostly Markdown/YAML/JSON plugin content, plus a root Node.js (ESM) toolkit of CLI scripts, a schema/contract test suite, and a few independent React/Vite apps. There is no backend service or database; "running the app" means running the Node CLI scripts, the test suite, the optional local dashboard server, and/or the Vite frontends.
 
-- Runtime: Node.js (CI pins Node 20; the environment here ran fine on Node 22). Single `npm install` at the repo root installs all toolkit + test deps. There are no committed lockfiles, so installs resolve latest within semver ranges.
+## Setup, tests, and checks
+
+- Runtime: Node.js (CI pins Node 20; Node 22 works). Single `npm install` at the repo root installs all toolkit + test deps. There are no committed lockfiles, so installs resolve latest within semver ranges.
 - Tests/lint/build commands are defined in the root `package.json` scripts and `.github/workflows/`; prefer those as the source of truth. Core checks: `npm run test:contract`, `npm run test:plugin-manifests`, `npm run test:grc-diagrams`, `npm run test:contract:findings`, `npm run test:wiz-inspector`. Markdown lint matches the pre-commit hook: `npx markdownlint-cli2@0.18.1` (config in `.markdownlint-cli2.jsonc`); note the repo currently has some pre-existing `MD022` warnings.
+
+## Gotchas
+
 - Network-dependent scripts: `frameworks.js` (and other scripts that fetch the SCF API at `grcengclub.github.io/scf-api`) fail in restricted-egress environments with `SCF fetch failed and no cached copy`. This is an environment limitation, not a code bug. For an offline core-functionality smoke test use `node plugins/grc-engineer/scripts/map-control.js <iac-file> soc2` (also supports `iso27001`, `nist800-53`) — it maps IaC patterns (e.g. `aws_iam_role`, `aws_security_group`, `kms_key_id`, `encrypted = true`) to controls with no network access.
 - Known pre-existing breakage: `scan-iac.js` and `test-control.js` use CommonJS `require(...)` while the root `package.json` is `"type": "module"`, so running them directly throws `require is not defined in ES module scope`. Don't treat this as something your change broke.
 - Optional local dashboard: `node plugins/dashboards/compliance-posture/scripts/serve.js --demo --host=127.0.0.1 --port=8787`. Args MUST use `--key=value` syntax (space-separated like `--host 127.0.0.1` is mis-parsed and the server fails to bind). `--demo` serves built-in sample runs so no `grc-data/` is needed.
 - Optional React/Vite apps are independent npm projects (not wired into the root via workspaces); each needs its own `npm install` in its directory: `demo/claude-grc-portfolio` (Vite dev on port 5173, `npm run dev`/`npm run build`) and `plugins/trust-center/frontend` (its backend is AWS serverless / deploy-only, not runnable locally).
+
+## Cursor Cloud specific instructions
+
+All of the notes above apply to Cursor Cloud agents. In particular, Cursor Cloud VMs run with restricted egress, so expect the SCF-fetching scripts to fail as described in Gotchas and use the offline smoke test instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+See `CLAUDE.md` for the full architecture overview (plugin structure, frameworks, connectors, and the Finding data contract). This file captures durable, non-obvious notes for working in this repo.
+
+## Cursor Cloud specific instructions
+
+This repo is a Claude Code plugin marketplace: mostly Markdown/YAML/JSON plugin content, plus a root Node.js (ESM) toolkit of CLI scripts, a schema/contract test suite, and a few independent React/Vite apps. There is no backend service or database; "running the app" means running the Node CLI scripts, the test suite, the optional local dashboard server, and/or the Vite frontends.
+
+- Runtime: Node.js (CI pins Node 20; the environment here ran fine on Node 22). Single `npm install` at the repo root installs all toolkit + test deps. There are no committed lockfiles, so installs resolve latest within semver ranges.
+- Tests/lint/build commands are defined in the root `package.json` scripts and `.github/workflows/`; prefer those as the source of truth. Core checks: `npm run test:contract`, `npm run test:plugin-manifests`, `npm run test:grc-diagrams`, `npm run test:contract:findings`, `npm run test:wiz-inspector`. Markdown lint matches the pre-commit hook: `npx markdownlint-cli2@0.18.1` (config in `.markdownlint-cli2.jsonc`); note the repo currently has some pre-existing `MD022` warnings.
+- Network-dependent scripts: `frameworks.js` (and other scripts that fetch the SCF API at `grcengclub.github.io/scf-api`) fail in restricted-egress environments with `SCF fetch failed and no cached copy`. This is an environment limitation, not a code bug. For an offline core-functionality smoke test use `node plugins/grc-engineer/scripts/map-control.js <iac-file> soc2` (also supports `iso27001`, `nist800-53`) — it maps IaC patterns (e.g. `aws_iam_role`, `aws_security_group`, `kms_key_id`, `encrypted = true`) to controls with no network access.
+- Known pre-existing breakage: `scan-iac.js` and `test-control.js` use CommonJS `require(...)` while the root `package.json` is `"type": "module"`, so running them directly throws `require is not defined in ES module scope`. Don't treat this as something your change broke.
+- Optional local dashboard: `node plugins/dashboards/compliance-posture/scripts/serve.js --demo --host=127.0.0.1 --port=8787`. Args MUST use `--key=value` syntax (space-separated like `--host 127.0.0.1` is mis-parsed and the server fails to bind). `--demo` serves built-in sample runs so no `grc-data/` is needed.
+- Optional React/Vite apps are independent npm projects (not wired into the root via workspaces); each needs its own `npm install` in its directory: `demo/claude-grc-portfolio` (Vite dev on port 5173, `npm run dev`/`npm run build`) and `plugins/trust-center/frontend` (its backend is AWS serverless / deploy-only, not runnable locally).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For a first run without cloud credentials, use GitHub as the evidence source:
 
 Full walkthrough: [docs/QUICKSTART.md](docs/QUICKSTART.md).
 
-Using Claude Desktop or Claude Cowork instead of Claude Code? Start with [docs/CLAUDE-COWORK.md](docs/CLAUDE-COWORK.md). Anthropic's security and compliance posture is documented at [trust.anthropic.com](https://trust.anthropic.com/), and the Claude Cowork third-party platform guide is here: [Use Claude Cowork with third-party platforms](https://support.claude.com/en/articles/14680729-use-claude-cowork-with-third-party-platforms).
+Using Claude Desktop or Claude Cowork instead of Claude Code? Start with [docs/CLAUDE-COWORK.md](docs/CLAUDE-COWORK.md). Anthropic's security and compliance posture is documented at [trust.anthropic.com](https://trust.anthropic.com/), and the Claude Cowork third-party platform guide is here: [Claude Desktop on third-party platforms](https://claude.com/docs/cowork/3p/overview).
 
 ## Common workflows
 
@@ -120,7 +120,7 @@ For the full architecture and schema example, see [docs/ARCHITECTURE.md](docs/AR
 - [docs/ENTERPRISE-DEPLOYMENT.md](docs/ENTERPRISE-DEPLOYMENT.md): AWS Bedrock, Claude Platform on AWS, and Google Vertex AI guidance
 - [docs/CLAUDE-COWORK.md](docs/CLAUDE-COWORK.md): Claude Desktop and Claude Cowork file-oriented usage, including third-party platform handoff notes
 - [Anthropic Trust Center](https://trust.anthropic.com/): Anthropic security, compliance, and trust resources
-- [Use Claude Cowork with third-party platforms](https://support.claude.com/en/articles/14680729-use-claude-cowork-with-third-party-platforms): official Cowork platform guidance
+- [Claude Desktop on third-party platforms](https://claude.com/docs/cowork/3p/overview): official Cowork platform guidance
 - [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md): how to contribute connectors, framework guidance, and docs
 - [docs/SCF-ATTRIBUTION.md](docs/SCF-ATTRIBUTION.md): SCF licensing and attribution
 

--- a/docs/CLAUDE-COWORK.md
+++ b/docs/CLAUDE-COWORK.md
@@ -9,7 +9,7 @@ scripts, command runbooks, and reusable skill instructions.
 Official resources:
 
 - Claude Cowork overview: <https://www.anthropic.com/product/claude-cowork>
-- Claude Cowork third-party platform guide: <https://support.claude.com/en/articles/14680729-use-claude-cowork-with-third-party-platforms>
+- Claude Cowork third-party platform guide: <https://claude.com/docs/cowork/3p/overview>
 - Anthropic Trust Center: <https://trust.anthropic.com/>
 
 ## What Works Well


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this repo (Claude Code GRC plugin marketplace) and documents durable, non-obvious startup/run notes for future cloud agents.

This repo is mostly Markdown/YAML/JSON plugin content plus a root Node.js (ESM) toolkit of CLI scripts, a schema/contract test suite, and a few independent React/Vite apps. There is no backend service or database.

## Changes

- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering: runtime (Node 20 in CI / 22 verified), `npm install` at root, where test/lint/build commands live, network-dependent SCF scripts (`frameworks.js`) that fail under restricted egress, a pre-existing CommonJS-under-ESM breakage in `scan-iac.js`/`test-control.js`, correct `--key=value` args for the dashboard server, and the independent Vite apps.

## Verification

- `npm install` (root)
- `npm run test:contract`, `npm run test:plugin-manifests`, `npm run test:grc-diagrams`, `npm run test:contract:findings`, `npm run test:wiz-inspector` — all pass
- `node plugins/grc-engineer/scripts/map-control.js <tf> soc2` — offline core CLI maps 8 controls
- `demo/claude-grc-portfolio`: `npm install` + `npm run build` + `npm run dev` (port 5173)
- compliance-posture dashboard server (`--demo`, port 8787)

No application code changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ea80bb8-81a4-4c23-972d-ab39f931becc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ea80bb8-81a4-4c23-972d-ab39f931becc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated repository guidance with clearer setup, testing, and local development instructions, including notes for offline smoke testing and common script execution caveats.
  * Refreshed README and related docs links for Claude Cowork third-party platform resources to point to the official documentation page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->