### PR TITLE
docs: replace dead Claude Cowork support article with live claude.com docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For a first run without cloud credentials, use GitHub as the evidence source:
 
 Full walkthrough: [docs/QUICKSTART.md](docs/QUICKSTART.md).
 
-Using Claude Desktop or Claude Cowork instead of Claude Code? Start with [docs/CLAUDE-COWORK.md](docs/CLAUDE-COWORK.md). Anthropic's security and compliance posture is documented at [trust.anthropic.com](https://trust.anthropic.com/), and the Claude Cowork third-party platform guide is here: [Use Claude Cowork with third-party platforms](https://support.claude.com/en/articles/14680729-use-claude-cowork-with-third-party-platforms).
+Using Claude Desktop or Claude Cowork instead of Claude Code? Start with [docs/CLAUDE-COWORK.md](docs/CLAUDE-COWORK.md). Anthropic's security and compliance posture is documented at [trust.anthropic.com](https://trust.anthropic.com/), and the Claude Cowork third-party platform guide is here: [Claude Desktop on third-party platforms](https://claude.com/docs/cowork/3p/overview).
 
 ## Common workflows
 
@@ -120,7 +120,7 @@ For the full architecture and schema example, see [docs/ARCHITECTURE.md](docs/AR
 - [docs/ENTERPRISE-DEPLOYMENT.md](docs/ENTERPRISE-DEPLOYMENT.md): AWS Bedrock, Claude Platform on AWS, and Google Vertex AI guidance
 - [docs/CLAUDE-COWORK.md](docs/CLAUDE-COWORK.md): Claude Desktop and Claude Cowork file-oriented usage, including third-party platform handoff notes
 - [Anthropic Trust Center](https://trust.anthropic.com/): Anthropic security, compliance, and trust resources
-- [Use Claude Cowork with third-party platforms](https://support.claude.com/en/articles/14680729-use-claude-cowork-with-third-party-platforms): official Cowork platform guidance
+- [Claude Desktop on third-party platforms](https://claude.com/docs/cowork/3p/overview): official Cowork platform guidance
 - [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md): how to contribute connectors, framework guidance, and docs
 - [docs/SCF-ATTRIBUTION.md](docs/SCF-ATTRIBUTION.md): SCF licensing and attribution
 

--- a/docs/CLAUDE-COWORK.md
+++ b/docs/CLAUDE-COWORK.md
@@ -9,7 +9,7 @@ scripts, command runbooks, and reusable skill instructions.
 Official resources:
 
 - Claude Cowork overview: <https://www.anthropic.com/product/claude-cowork>
-- Claude Cowork third-party platform guide: <https://support.claude.com/en/articles/14680729-use-claude-cowork-with-third-party-platforms>
+- Claude Cowork third-party platform guide: <https://claude.com/docs/cowork/3p/overview>
 - Anthropic Trust Center: <https://trust.anthropic.com/>
 
 ## What Works Well


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The support.claude.com article `14680729-use-claude-cowork-with-third-party-platforms` was removed from support.claude.com and now returns 404. It is referenced in `README.md` (twice) and `docs/CLAUDE-COWORK.md`, which makes the lychee link-check workflow fail on `main` (see the [failed run](https://github.com/GRCEngClub/claude-grc-engineering/actions/runs/28371997036)) and on any PR whose link scan includes those files (currently blocking #199).

This replaces all three references with the live official guide at https://claude.com/docs/cowork/3p/overview ("Claude Desktop on third-party platforms"), which is the current home of the Cowork third-party platform documentation.

## Type of change

- [ ] Connector
- [ ] Framework plugin
- [ ] Persona plugin
- [x] Documentation
- [ ] Community / governance
- [ ] CI / automation
- [ ] Other

## Schema impact

- [x] No schema changes
- [ ] `schemas/finding.schema.json` changed
- [ ] Another schema or contract surface changed

## Test plan

- Verified the old URL returns 404 (confirmed in the lychee failure log on `main`).
- Verified the replacement URL `https://claude.com/docs/cowork/3p/overview` is live and is the official third-party platform guide.
- `rg support\.claude\.com` returns no remaining references in the repo.

```text
$ rg 'support\.claude\.com' --files-with-matches
(no matches)
```

## CHANGELOG

- [x] No CHANGELOG entry needed
- [ ] I added a CHANGELOG entry
- [ ] A maintainer should add the CHANGELOG entry during merge

## Notes for reviewers

Note: PR #198 works around the same dead link by excluding it in `lychee.toml`. Once this PR merges, that exclusion becomes unnecessary (but is harmless — the excluded URL no longer appears anywhere).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ee4105b-e812-4826-9372-b8b3af334819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ee4105b-e812-4826-9372-b8b3af334819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several links to point to the latest official Claude Cowork guidance and trust/security resources.
  * Replaced older support article references with the current Claude documentation overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->