### PR TITLE
fix(security): remove vulnerable ajv-cli dependency

### DIFF
--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -5,7 +5,11 @@ on:
     paths:
       - 'schemas/**'
       - 'tests/fixtures/**'
+      - 'tests/schema-validator.test.mjs'
+      - 'tests/validate-json-schema.cjs'
+      - 'tests/validate-contract-fixtures.sh'
       - 'plugins/connectors/**'
+      - 'package.json'
       - '.github/workflows/contract-test.yml'
   push:
     branches: [main]
@@ -25,8 +29,11 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install ajv-cli + formats
-        run: npm install --no-save ajv-cli@5 ajv-formats@3
+      - name: Install schema validator dependencies
+        run: npm install --no-save ajv@8.20.0 ajv-formats@3.0.1
+
+      - name: Test schema validator
+        run: npm run test:schema-validator
 
       - name: Validate contract fixtures
         run: bash tests/validate-contract-fixtures.sh

--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install schema validator dependencies
-        run: npm install --no-save ajv@8.20.0 ajv-formats@3.0.1
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
 
       - name: Test schema validator
         run: npm run test:schema-validator

--- a/.github/workflows/validate-plugin-manifests.yml
+++ b/.github/workflows/validate-plugin-manifests.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install schema validator dependencies
-        run: npm install --no-save ajv@8.20.0 ajv-formats@3.0.1
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
 
       - name: Test schema validator
         run: npm run test:schema-validator

--- a/.github/workflows/validate-plugin-manifests.yml
+++ b/.github/workflows/validate-plugin-manifests.yml
@@ -8,8 +8,11 @@ on:
       - '.claude-plugin/marketplace.json'
       - 'schemas/plugin.schema.json'
       - 'schemas/marketplace.schema.json'
+      - 'tests/schema-validator.test.mjs'
+      - 'tests/validate-json-schema.cjs'
       - 'tests/validate-plugin-manifests.sh'
       - 'tests/validate-grc-diagram-skills.sh'
+      - 'package.json'
       - '.github/workflows/validate-plugin-manifests.yml'
   push:
     branches: [main]
@@ -19,8 +22,11 @@ on:
       - '.claude-plugin/marketplace.json'
       - 'schemas/plugin.schema.json'
       - 'schemas/marketplace.schema.json'
+      - 'tests/schema-validator.test.mjs'
+      - 'tests/validate-json-schema.cjs'
       - 'tests/validate-plugin-manifests.sh'
       - 'tests/validate-grc-diagram-skills.sh'
+      - 'package.json'
       - '.github/workflows/validate-plugin-manifests.yml'
 
 concurrency:
@@ -38,8 +44,11 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install ajv-cli + formats
-        run: npm install --no-save ajv-cli@5 ajv-formats@3
+      - name: Install schema validator dependencies
+        run: npm install --no-save ajv@8.20.0 ajv-formats@3.0.1
+
+      - name: Test schema validator
+        run: npm run test:schema-validator
 
       - name: Validate every plugin and marketplace manifest
         run: bash tests/validate-plugin-manifests.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,6 @@ repos:
         name: validate finding fixtures
         entry: tests/pre-commit-validate-findings.sh
         language: node
-        additional_dependencies: ["ajv-cli@5.0.0", "ajv-formats@3.0.1"]
+        additional_dependencies: ["ajv@8.20.0", "ajv-formats@3.0.1"]
         files: ^tests/fixtures/findings/.*\.json$
         pass_filenames: true

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "scaffold-framework": "node plugins/grc-engineer/scripts/scaffold-framework.js",
     "generate-coverage": "node plugins/grc-engineer/scripts/generate-coverage.js",
     "test:wiz-inspector": "node --test tests/wiz-inspector-collect.test.js",
+    "test:schema-validator": "node --test tests/schema-validator.test.mjs",
     "test:contract": "bash tests/validate-contract-fixtures.sh",
     "test:grc-diagrams": "bash tests/validate-grc-diagram-skills.sh",
     "test:plugin-manifests": "bash tests/validate-plugin-manifests.sh",
-    "test:contract:findings": "ajv validate --spec=draft2020 -c ajv-formats -s schemas/finding.schema.json -d 'tests/fixtures/findings/**/*.json'"
+    "test:contract:findings": "find tests/fixtures/findings -type f -name '*.json' -print0 | xargs -0 tests/pre-commit-validate-findings.sh"
   },
   "keywords": [
     "grc",
@@ -60,7 +61,7 @@
     "@octokit/rest": "^20.0.2"
   },
   "devDependencies": {
-    "ajv-cli": "^5.0.0",
+    "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1"
   }
 }

--- a/tests/pre-commit-validate-findings.sh
+++ b/tests/pre-commit-validate-findings.sh
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PATH="./node_modules/.bin:$PATH"
-
 if [[ "$#" -eq 0 ]]; then
   exit 0
 fi
 
-if ! command -v ajv >/dev/null 2>&1; then
-  echo "ajv-cli not found. Rebuild the hook env with: pre-commit clean && pre-commit install" >&2
+# pre-commit installs Node dependencies into its isolated global package root.
+# CommonJS honors NODE_PATH, so the same validator works both there and with
+# the repository's local node_modules directory.
+export NODE_PATH="${NODE_PATH:-$(npm root -g)}"
+
+if ! node -e "require('ajv'); require('ajv-formats')" >/dev/null 2>&1; then
+  echo "Ajv not found. Rebuild the hook env with: pre-commit clean && pre-commit install" >&2
   exit 2
 fi
 
+args=(--schema schemas/finding.schema.json --quiet)
 for finding in "$@"; do
-  ajv validate \
-    --spec=draft2020 \
-    -c ajv-formats \
-    -s schemas/finding.schema.json \
-    -d "$finding" \
-    --errors=line
+  args+=(--data "$finding")
 done
+
+node tests/validate-json-schema.cjs "${args[@]}"

--- a/tests/schema-validator.test.mjs
+++ b/tests/schema-validator.test.mjs
@@ -12,6 +12,7 @@ function fixtureFiles() {
   const schema = join(directory, 'schema.json');
   const valid = join(directory, 'valid.json');
   const invalid = join(directory, 'invalid.json');
+  const malformed = join(directory, 'malformed.json');
 
   writeFileSync(schema, JSON.stringify({
     $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -24,8 +25,9 @@ function fixtureFiles() {
   }));
   writeFileSync(valid, JSON.stringify({ name: 'research-companion' }));
   writeFileSync(invalid, JSON.stringify({ name: '', unexpected: true }));
+  writeFileSync(malformed, '{broken');
 
-  return { schema, valid, invalid };
+  return { schema, valid, invalid, malformed };
 }
 
 function runValidator(...args) {
@@ -49,4 +51,13 @@ test('schema validator rejects invalid JSON and reports validation errors', () =
   assert.equal(result.status, 1);
   assert.match(result.stderr, /invalid\.json invalid/);
   assert.match(result.stderr, /must NOT have additional properties|must NOT have fewer than 1 characters/);
+});
+
+test('schema validator names malformed JSON files and exits with an operational error', () => {
+  const { schema, malformed } = fixtureFiles();
+  const result = runValidator('--schema', schema, '--data', malformed);
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /malformed\.json/);
+  assert.match(result.stderr, /invalid JSON/);
 });

--- a/tests/schema-validator.test.mjs
+++ b/tests/schema-validator.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const validator = new URL('./validate-json-schema.cjs', import.meta.url);
+
+function fixtureFiles() {
+  const directory = mkdtempSync(join(tmpdir(), 'schema-validator-'));
+  const schema = join(directory, 'schema.json');
+  const valid = join(directory, 'valid.json');
+  const invalid = join(directory, 'invalid.json');
+
+  writeFileSync(schema, JSON.stringify({
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    required: ['name'],
+    additionalProperties: false,
+    properties: {
+      name: { type: 'string', minLength: 1 },
+    },
+  }));
+  writeFileSync(valid, JSON.stringify({ name: 'research-companion' }));
+  writeFileSync(invalid, JSON.stringify({ name: '', unexpected: true }));
+
+  return { schema, valid, invalid };
+}
+
+function runValidator(...args) {
+  return spawnSync(process.execPath, [validator.pathname, ...args], {
+    encoding: 'utf8',
+  });
+}
+
+test('schema validator accepts valid JSON against a Draft 2020-12 schema', () => {
+  const { schema, valid } = fixtureFiles();
+  const result = runValidator('--schema', schema, '--data', valid);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /valid\.json valid/);
+});
+
+test('schema validator rejects invalid JSON and reports validation errors', () => {
+  const { schema, invalid } = fixtureFiles();
+  const result = runValidator('--schema', schema, '--data', invalid);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /invalid\.json invalid/);
+  assert.match(result.stderr, /must NOT have additional properties|must NOT have fewer than 1 characters/);
+});

--- a/tests/validate-contract-fixtures.sh
+++ b/tests/validate-contract-fixtures.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-PATH="./node_modules/.bin:$PATH"
+validator="tests/validate-json-schema.cjs"
 
 categories=(
   "findings schemas/finding.schema.json"
@@ -30,12 +30,10 @@ for entry in "${categories[@]}"; do
   while IFS= read -r f; do
     [ -z "$f" ] && continue
     total=$((total + 1))
-    if ajv validate \
-      --spec=draft2020 \
-      -c ajv-formats \
-      -s "$schema" \
-      -d "$f" \
-      --errors=line 2>&1; then
+    if node "$validator" \
+      --schema "$schema" \
+      --data "$f" \
+      --quiet 2>&1; then
       echo "  ✓ $f"
     else
       echo "  ✗ $f"

--- a/tests/validate-json-schema.cjs
+++ b/tests/validate-json-schema.cjs
@@ -53,7 +53,14 @@ try {
   let failed = false;
 
   for (const file of options.data) {
-    const valid = validate(readJson(file));
+    let data;
+    try {
+      data = readJson(file);
+    } catch (error) {
+      throw new Error(`${basename(file)} invalid JSON: ${error.message}`);
+    }
+
+    const valid = validate(data);
     if (valid) {
       if (!options.quiet) console.log(`${basename(file)} valid`);
     } else {

--- a/tests/validate-json-schema.cjs
+++ b/tests/validate-json-schema.cjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+const { readFileSync } = require('node:fs');
+const { basename } = require('node:path');
+const Ajv2020 = require('ajv/dist/2020').default;
+const addFormats = require('ajv-formats');
+
+function parseArguments(argv) {
+  const options = { data: [], quiet: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--schema') {
+      options.schema = argv[index + 1];
+      index += 1;
+    } else if (argument === '--data') {
+      options.data.push(argv[index + 1]);
+      index += 1;
+    } else if (argument === '--quiet') {
+      options.quiet = true;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!options.schema) throw new Error('Missing required --schema <file> argument');
+  if (options.data.length === 0) throw new Error('Provide at least one --data <file> argument');
+  return options;
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+function formatErrors(errors = []) {
+  return errors
+    .map((error) => `${error.instancePath || '/'} ${error.message}`)
+    .join('; ');
+}
+
+let options;
+try {
+  options = parseArguments(process.argv.slice(2));
+} catch (error) {
+  console.error(`schema-validator: ${error.message}`);
+  process.exit(2);
+}
+
+try {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(readJson(options.schema));
+  let failed = false;
+
+  for (const file of options.data) {
+    const valid = validate(readJson(file));
+    if (valid) {
+      if (!options.quiet) console.log(`${basename(file)} valid`);
+    } else {
+      failed = true;
+      console.error(`${basename(file)} invalid: ${formatErrors(validate.errors)}`);
+    }
+  }
+
+  process.exit(failed ? 1 : 0);
+} catch (error) {
+  console.error(`schema-validator: ${error.message}`);
+  process.exit(2);
+}

--- a/tests/validate-plugin-manifests.sh
+++ b/tests/validate-plugin-manifests.sh
@@ -9,12 +9,10 @@
 # not a bare string.
 #
 # Run locally:
-#   npm install --no-save ajv-cli@5 ajv-formats@3
+#   npm install
 #   bash tests/validate-plugin-manifests.sh
 
 set -uo pipefail
-
-PATH="./node_modules/.bin:$PATH"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root" || {
@@ -22,8 +20,9 @@ cd "$repo_root" || {
   exit 2
 }
 
-if ! command -v ajv >/dev/null 2>&1; then
-  echo "ajv-cli not found. Install with: npm install --no-save ajv-cli@5 ajv-formats@3" >&2
+validator="tests/validate-json-schema.cjs"
+if ! node -e "require('ajv'); require('ajv-formats')" >/dev/null 2>&1; then
+  echo "Ajv not found. Install dependencies with: npm install" >&2
   exit 2
 fi
 
@@ -100,11 +99,10 @@ validate_file() {
   local file="$2"
   checked=$((checked + 1))
   emit_group_start "$file"
-  if ajv validate \
-      --spec=draft2020 \
-      -s "$schema" \
-      -d "$file" \
-      --errors=line; then
+  if node "$validator" \
+      --schema "$schema" \
+      --data "$file" \
+      --quiet; then
     printf '  ✓ %s\n' "$file"
   else
     emit_error "$file" "Manifest failed schema validation against $schema"


### PR DESCRIPTION
## Summary

- remove `ajv-cli`, which pulls vulnerable `fast-json-patch` 2.x (GHSA-8gh8-hqwg-xf34)
- add a small tested Draft 2020-12 validator using the maintained `ajv` API directly
- rewire contract, manifest, package-script, pre-commit, and CI validation paths
- ensure validator changes and dependency changes trigger required CI checks

## Security impact

Before:

```text
2 high severity vulnerabilities
ajv-cli -> fast-json-patch@2.2.1
```

After:

```text
found 0 vulnerabilities
ajv-cli / fast-json-patch: absent from dependency tree
```

## Validation

- `npm audit --audit-level=low` — 0 vulnerabilities
- `npm run test:schema-validator` — 2/2 passed
- `npm run test:contract` — 49/49 fixtures valid
- `npm run test:contract:findings` — passed
- `npm run test:plugin-manifests` — 65/65 manifests valid
- `npm run test:grc-diagrams` — passed
- `npm run test:wiz-inspector` — 2/2 passed
- clean isolated pre-commit Node environment — passed without repository `node_modules`
- Node 20 validator, contract, and manifest validation — passed
- pre-commit large-file and secret scans — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared JSON Schema validation tool (Draft 2020-12 with format support).
  * Added automated tests for both valid and invalid JSON documents.

* **Bug Fixes**
  * Improved validation consistency across contract fixtures, findings, and plugin manifests.
  * Failures now provide clearer, file-specific results and validation error details.

* **Tests**
  * CI now runs schema-validation checks before fixture and manifest validation.
  * Pre-commit validation now uses the shared schema validator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->