### PR TITLE
fix(security): harden schema validator output

### DIFF
--- a/tests/schema-validator.test.mjs
+++ b/tests/schema-validator.test.mjs
@@ -27,7 +27,7 @@ function fixtureFiles() {
   writeFileSync(invalid, JSON.stringify({ name: '', unexpected: true }));
   writeFileSync(malformed, '{broken');
 
-  return { schema, valid, invalid, malformed };
+  return { directory, schema, valid, invalid, malformed };
 }
 
 function runValidator(...args) {
@@ -60,4 +60,31 @@ test('schema validator names malformed JSON files and exits with an operational 
   assert.equal(result.status, 2);
   assert.match(result.stderr, /malformed\.json/);
   assert.match(result.stderr, /invalid JSON/);
+});
+
+test('schema validator rejects unknown schema keywords in strict mode', () => {
+  const { directory, valid } = fixtureFiles();
+  const schema = join(directory, 'unknown-keyword.schema.json');
+  writeFileSync(schema, JSON.stringify({
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    propertiez: { name: { type: 'string' } },
+  }));
+
+  const result = runValidator('--schema', schema, '--data', valid);
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /strict mode: unknown keyword/);
+});
+
+test('schema validator cannot emit GitHub Actions commands from data filenames', () => {
+  const { directory, schema } = fixtureFiles();
+  const hostile = join(directory, 'line\n::warning::spoof.json');
+  writeFileSync(hostile, JSON.stringify({ unexpected: true }));
+
+  const result = runValidator('--schema', schema, '--data', hostile);
+
+  assert.equal(result.status, 1);
+  assert.doesNotMatch(result.stderr, /^::/m);
+  assert.match(result.stderr, /line%0A%3A%3Awarning%3A%3Aspoof\.json/);
 });

--- a/tests/validate-json-schema.cjs
+++ b/tests/validate-json-schema.cjs
@@ -38,6 +38,15 @@ function formatErrors(errors = []) {
     .join('; ');
 }
 
+function formatDataFile(file) {
+  return basename(file)
+    .replace(/%/g, '%25')
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A')
+    .replace(/:/g, '%3A')
+    .replace(/,/g, '%2C');
+}
+
 let options;
 try {
   options = parseArguments(process.argv.slice(2));
@@ -47,7 +56,13 @@ try {
 }
 
 try {
-  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  const ajv = new Ajv2020({
+    allErrors: true,
+    strict: true,
+    // Repository schemas intentionally place `required` in conditional/union
+    // branches while defining the corresponding properties in a parent schema.
+    strictRequired: false,
+  });
   addFormats(ajv);
   const validate = ajv.compile(readJson(options.schema));
   let failed = false;
@@ -57,15 +72,15 @@ try {
     try {
       data = readJson(file);
     } catch (error) {
-      throw new Error(`${basename(file)} invalid JSON: ${error.message}`);
+      throw new Error(`data file ${formatDataFile(file)} invalid JSON: ${error.message}`);
     }
 
     const valid = validate(data);
     if (valid) {
-      if (!options.quiet) console.log(`${basename(file)} valid`);
+      if (!options.quiet) console.log(`data file ${formatDataFile(file)} valid`);
     } else {
       failed = true;
-      console.error(`${basename(file)} invalid: ${formatErrors(validate.errors)}`);
+      console.error(`data file ${formatDataFile(file)} invalid: ${formatErrors(validate.errors)}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up hardening for #209 based on independent security review:

- prevent GitHub Actions workflow-command/log injection from PR-controlled fixture filenames
- enable Ajv strict schema checking so unknown or misspelled keywords fail closed
- retain `strictRequired: false` as a documented compatibility exception for repository schemas that intentionally define properties in parent scopes
- add regression tests for hostile filenames and unknown schema keywords

## Security validation

- hostile filename containing a newline and `::warning::` is percent-encoded before logging
- unknown schema keyword exits with operational error status 2
- `npm audit --audit-level=low` reports 0 vulnerabilities

## Tests

- schema validator: 5/5 passed on current Node and Node 20
- contract fixtures: 49/49 passed
- finding fixtures: passed
- plugin/marketplace manifests: 65/65 passed
- GRC diagram tests: passed
- Wiz inspector: 2/2 passed
- pre-commit large-file and secret scans: passed
