### PR TITLE
fix(security): sanitize validator diagnostics

### DIFF
--- a/tests/schema-validator.test.mjs
+++ b/tests/schema-validator.test.mjs
@@ -36,6 +36,10 @@ function runValidator(...args) {
   });
 }
 
+function assertNoWorkflowCommands(result) {
+  assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /^::/m);
+}
+
 test('schema validator accepts valid JSON against a Draft 2020-12 schema', () => {
   const { schema, valid } = fixtureFiles();
   const result = runValidator('--schema', schema, '--data', valid);
@@ -85,6 +89,53 @@ test('schema validator cannot emit GitHub Actions commands from data filenames',
   const result = runValidator('--schema', schema, '--data', hostile);
 
   assert.equal(result.status, 1);
-  assert.doesNotMatch(result.stderr, /^::/m);
+  assertNoWorkflowCommands(result);
   assert.match(result.stderr, /line%0A%3A%3Awarning%3A%3Aspoof\.json/);
+});
+
+test('schema validator sanitizes workflow commands in Ajv diagnostics', () => {
+  const { directory } = fixtureFiles();
+  const schema = join(directory, 'property-values.schema.json');
+  const data = join(directory, 'property-values.json');
+  writeFileSync(schema, JSON.stringify({
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    additionalProperties: { type: 'integer' },
+  }));
+  writeFileSync(data, JSON.stringify({
+    'bad\n::warning::DATA_INJECTION': 'not-an-integer',
+  }));
+
+  const result = runValidator('--schema', schema, '--data', data);
+
+  assert.equal(result.status, 1);
+  assertNoWorkflowCommands(result);
+  assert.match(result.stderr, /%0A::warning::DATA_INJECTION/);
+});
+
+test('schema validator sanitizes workflow commands in schema compilation errors', () => {
+  const { directory, valid } = fixtureFiles();
+  const schema = join(directory, 'hostile-keyword.schema.json');
+  writeFileSync(schema, JSON.stringify({
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    'bad\n::warning::SCHEMA_INJECTION': true,
+  }));
+
+  const result = runValidator('--schema', schema, '--data', valid);
+
+  assert.equal(result.status, 2);
+  assertNoWorkflowCommands(result);
+  assert.match(result.stderr, /%0A::warning::SCHEMA_INJECTION/);
+});
+
+test('schema validator sanitizes workflow commands in filesystem errors', () => {
+  const { directory, schema } = fixtureFiles();
+  const missing = join(directory, 'missing\n::error::FS_INJECTION.json');
+
+  const result = runValidator('--schema', schema, '--data', missing);
+
+  assert.equal(result.status, 2);
+  assertNoWorkflowCommands(result);
+  assert.match(result.stderr, /%0A::error::FS_INJECTION/);
 });

--- a/tests/validate-json-schema.cjs
+++ b/tests/validate-json-schema.cjs
@@ -47,11 +47,21 @@ function formatDataFile(file) {
     .replace(/,/g, '%2C');
 }
 
+function sanitizeDiagnostic(message) {
+  return String(message)
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A');
+}
+
+function writeOutput(stream, message) {
+  stream.write(`${sanitizeDiagnostic(message)}\n`);
+}
+
 let options;
 try {
   options = parseArguments(process.argv.slice(2));
 } catch (error) {
-  console.error(`schema-validator: ${error.message}`);
+  writeOutput(process.stderr, `schema-validator: ${error.message}`);
   process.exit(2);
 }
 
@@ -77,15 +87,18 @@ try {
 
     const valid = validate(data);
     if (valid) {
-      if (!options.quiet) console.log(`data file ${formatDataFile(file)} valid`);
+      if (!options.quiet) writeOutput(process.stdout, `data file ${formatDataFile(file)} valid`);
     } else {
       failed = true;
-      console.error(`data file ${formatDataFile(file)} invalid: ${formatErrors(validate.errors)}`);
+      writeOutput(
+        process.stderr,
+        `data file ${formatDataFile(file)} invalid: ${formatErrors(validate.errors)}`,
+      );
     }
   }
 
   process.exit(failed ? 1 : 0);
 } catch (error) {
-  console.error(`schema-validator: ${error.message}`);
+  writeOutput(process.stderr, `schema-validator: ${error.message}`);
   process.exit(2);
 }


### PR DESCRIPTION
## Summary

Comprehensive follow-up to #210 based on independent security review:

- route every schema-validator stdout/stderr path through centralized CR/LF sanitization
- prevent GitHub Actions workflow-command injection from Ajv validation diagnostics
- sanitize strict-schema compilation errors and Node filesystem error messages
- retain the prior hostile-filename protection
- add focused regressions for all identified injection paths

## Security tests

The test suite now verifies that no output line can begin with a GitHub Actions command when untrusted content appears in:

- data filenames
- Ajv `instancePath` diagnostics
- schema keywords/compilation errors
- missing data paths and filesystem errors

## Validation

- schema validator: 8/8 passed on current Node and Node 20
- contract fixtures: 49/49 passed
- finding fixtures: passed
- plugin/marketplace manifests: 65/65 passed
- GRC diagram tests: passed
- Wiz inspector: 2/2 passed
- pre-commit checks: passed
- `npm audit --audit-level=low`: 0 vulnerabilities
