### PR TITLE
Add NIST AI RMF (AI 100-1) framework plugin at stub depth

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -402,6 +402,12 @@
       "source": "./plugins/trust-center",
       "description": "Build and deploy a serverless trust center — public compliance posture, gated document access with optional NDA e-signature, admin dashboard. Deploys to AWS.",
       "version": "0.1.0"
+    },
+    {
+      "name": "nist-ai-rmf",
+      "source": "./plugins/frameworks/nist-ai-rmf",
+      "description": "NIST AI 100-1 (AI RMF 1.0) \u2014 stub-depth plugin backed by the SCF crosswalk (158 SCF \u2192 91 framework controls).",
+      "version": "0.1.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes follow the format from [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Added
+
+- **NIST AI RMF framework plugin (stub).** Added `nist-ai-rmf`, the toolkit's first AI-governance framework plugin, scaffolded at Stub depth from the SCF crosswalk (`general-nist-100-1-ai-rmf`, 158 SCF controls → 91 AI RMF subcategories across GOVERN/MAP/MEASURE/MANAGE, counts verified against scf-api v2026.1), with marketplace registration. Reference-depth level-up (scope, evidence checklist, substantive SKILL) planned as a follow-up, along with a Generative AI Profile (AI 600-1) companion plugin. Closes [#195](https://github.com/GRCEngClub/claude-grc-engineering/issues/195).
+
 ### Removed
 
 - **`vanta-bridge` plugin removed.** Vanta now ships an official Claude Code plugin (`vanta-mcp-plugin` in `anthropics/claude-plugins-official`) and an official MCP server (`mcp.vanta.com/mcp` and regional variants). The community bridge predated both and added a manual-export step that's now obsolete. Users should install Vanta's official plugin instead — see [GHSA #150](https://github.com/GRCEngClub/claude-grc-engineering/issues/150). Drops the bridge plugin, marketplace registration, test fixtures, and documentation references.

--- a/plugins/frameworks/nist-ai-rmf/.claude-plugin/plugin.json
+++ b/plugins/frameworks/nist-ai-rmf/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "nist-ai-rmf",
+  "description": "NIST AI 100-1 (AI RMF 1.0) — stub plugin routing to /grc-engineer:gap-assessment via the SCF crosswalk. Level up by adding framework-specific commands, implementation guidance, and evidence patterns.",
+  "version": "0.1.0",
+  "author": {"name": "GRC Engineering Club Contributors"},
+  "repository": "https://github.com/GRCEngClub/claude-grc-engineering",
+  "license": "MIT",
+  "framework_metadata": {
+    "scf_framework_id": "general-nist-100-1-ai-rmf",
+    "display_name": "NIST AI 100-1 (AI RMF 1.0)",
+    "region": "Global",
+    "country": "US",
+    "depth": "stub",
+    "scf_controls_mapped": 158,
+    "framework_controls_mapped": 91,
+    "industry": ["cross-sector"],
+    "regulator": "NIST (voluntary framework; not enforced)"
+  }
+}

--- a/plugins/frameworks/nist-ai-rmf/README.md
+++ b/plugins/frameworks/nist-ai-rmf/README.md
@@ -1,0 +1,36 @@
+# nist-ai-rmf — NIST AI 100-1 (AI RMF 1.0)
+
+Stub-depth framework plugin scaffolded from the SCF crosswalk. Install and use it to run a gap assessment against **NIST AI 100-1 (AI RMF 1.0)**:
+
+```bash
+/plugin install nist-ai-rmf@grc-engineering-suite
+/nist-ai-rmf:assess --sources=aws-inspector,github-inspector
+```
+
+## Status: Stub
+
+This plugin is at **Stub depth** — it routes to `/grc-engineer:gap-assessment` via the SCF crosswalk (158 SCF controls → 91 NIST AI 100-1 (AI RMF 1.0) subcategories) without any framework-specific workflow commands yet. AI RMF 1.0 is NIST’s voluntary outcomes framework for AI risk management, organized across four functions: GOVERN, MAP, MEASURE, and MANAGE.
+
+### Level up to Reference
+
+Reference-depth adds an evidence checklist and framework-specific context. If you have domain expertise for NIST AI 100-1 (AI RMF 1.0), see the [Framework Plugin Guide](../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) and open a PR.
+
+### Level up to Full
+
+Full depth adds framework-native workflow commands tied to the audit ritual (e.g. `/fedramp-rev5:poam-review`, `/soc2:service-auditor-prep`). See the existing Full-depth plugins (`soc2`, `fedramp-rev5`, `pci-dss`, `nist-800-53`) for reference.
+
+## Metadata
+
+| | |
+|---|---|
+| SCF framework ID | `general-nist-100-1-ai-rmf` |
+| Region | Global |
+| Country | US |
+| SCF controls mapped | 158 |
+| Framework controls mapped | 91 |
+| Depth | Stub |
+
+## References
+
+- [Secure Controls Framework](https://securecontrolsframework.com) — crosswalk source (CC BY-ND 4.0)
+- [SCF API entry](https://hackidle.github.io/scf-api/api/crosswalks/general-nist-100-1-ai-rmf.json)

--- a/plugins/frameworks/nist-ai-rmf/README.md
+++ b/plugins/frameworks/nist-ai-rmf/README.md
@@ -33,4 +33,4 @@ Full depth adds framework-native workflow commands tied to the audit ritual (e.g
 ## References
 
 - [Secure Controls Framework](https://securecontrolsframework.com) — crosswalk source (CC BY-ND 4.0)
-- [SCF API entry](https://hackidle.github.io/scf-api/api/crosswalks/general-nist-100-1-ai-rmf.json)
+- [SCF API entry](https://grcengclub.github.io/scf-api/api/crosswalks/general-nist-100-1-ai-rmf.json)

--- a/plugins/frameworks/nist-ai-rmf/commands/assess.md
+++ b/plugins/frameworks/nist-ai-rmf/commands/assess.md
@@ -31,4 +31,4 @@ A prioritized gap report listing unmet NIST AI 100-1 (AI RMF 1.0) requirements, 
 ## Further reading
 
 - [Secure Controls Framework](https://securecontrolsframework.com)
-- [SCF API entry for this framework](https://hackidle.github.io/scf-api/api/crosswalks/general-nist-100-1-ai-rmf.json)
+- [SCF API entry for this framework](https://grcengclub.github.io/scf-api/api/crosswalks/general-nist-100-1-ai-rmf.json)

--- a/plugins/frameworks/nist-ai-rmf/commands/assess.md
+++ b/plugins/frameworks/nist-ai-rmf/commands/assess.md
@@ -1,0 +1,34 @@
+---
+description: NIST AI 100-1 (AI RMF 1.0) compliance gap assessment via the SCF crosswalk
+---
+
+# NIST AI 100-1 (AI RMF 1.0) Assessment
+
+Runs a compliance gap assessment against **NIST AI 100-1 (AI RMF 1.0)** by delegating to `/grc-engineer:gap-assessment` with the framework's SCF identifier.
+
+This is a **stub plugin** — the underlying gap assessment is powered by the SCF crosswalk (158 SCF controls mapped to 91 framework controls). To add framework-specific workflow commands, evidence checklists, or implementation guidance, see the [Framework Plugin Guide](../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the level-up path to Reference or Full depth.
+
+## Usage
+
+```
+/nist-ai-rmf:assess [--sources=<connector-list>]
+```
+
+Delegates to:
+
+```
+/grc-engineer:gap-assessment "general-nist-100-1-ai-rmf" [--sources=<connector-list>]
+```
+
+## Arguments
+
+- `--sources=<connector-list>` (optional) — comma-separated list of connector plugins to pull evidence from (e.g. `aws-inspector,github-inspector,okta-inspector`). Defaults to whichever connectors are configured and have recent runs.
+
+## Output
+
+A prioritized gap report listing unmet NIST AI 100-1 (AI RMF 1.0) requirements, severity-tagged and grouped by SCF family. The report maps back to the 91 framework-native controls via the SCF crosswalk.
+
+## Further reading
+
+- [Secure Controls Framework](https://securecontrolsframework.com)
+- [SCF API entry for this framework](https://hackidle.github.io/scf-api/api/crosswalks/general-nist-100-1-ai-rmf.json)

--- a/plugins/frameworks/nist-ai-rmf/skills/nist-ai-rmf-expert/SKILL.md
+++ b/plugins/frameworks/nist-ai-rmf/skills/nist-ai-rmf-expert/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: nist-ai-rmf-expert
+description: NIST AI 100-1 (AI RMF 1.0) expert. Stub-depth framework plugin that routes to the SCF crosswalk. Level up by adding framework-specific context, assessment workflow, and evidence patterns.
+allowed-tools: Read, Glob, Grep
+---
+
+# NIST AI 100-1 (AI RMF 1.0) Expert
+
+Stub-depth expertise for **NIST AI 100-1 (AI RMF 1.0)**. This plugin is scaffolded from the SCF crosswalk (158 SCF controls map to 91 framework controls) and defers to `/grc-engineer:gap-assessment` for the actual compliance check.
+
+## Framework identity
+
+- **SCF framework ID**: `general-nist-100-1-ai-rmf`
+- **Region**: Global
+- **Country**: US
+- **Issuing body**: NIST (U.S. National Institute of Standards and Technology); voluntary framework, not enforced
+- **Canonical source**: NIST AI 100-1, "Artificial Intelligence Risk Management Framework (AI RMF 1.0)", January 2023
+
+AI RMF is an **outcomes framework**, not a control catalog and not a certification. It organizes outcomes as Function → Category → Subcategory across four functions — **GOVERN**, **MAP**, **MEASURE**, **MANAGE** — applied across the AI system lifecycle. Subcategories describe desired risk-management outcomes; they do not prescribe specific controls. Concrete controls come from the SCF crosswalk: 158 SCF controls map to 91 AI RMF subcategories, referenced by subcategory ID (e.g. `GOVERN 1.1`, `MAP 2.3`), never by paraphrased prose.
+
+Common failure modes when working with this framework: treating AI RMF as a control catalog to "implement", confusing the four functions with maturity levels, and mapping to subcategory prose instead of subcategory IDs.
+
+## Scope and posture (placeholder — fill in when leveling up)
+
+TODO: replace with framework-specific overview. Minimum sections for Reference-depth upgrade:
+
+- Territorial scope (who and where the framework applies)
+- Controlled-entity obligations (controller, processor, covered entity, etc.)
+- Mandatory timelines (breach notification, assessment cadence)
+- Regulator and enforcement mechanism
+- Interaction with other frameworks (adequacy decisions, mutual recognition)
+
+## Command routing
+
+All commands in this plugin route through `/grc-engineer:gap-assessment` with framework ID `general-nist-100-1-ai-rmf`. Reference-depth plugins add:
+
+- `evidence-checklist` — framework-native evidence by control family
+- `scope` — applicability determination for the organization
+
+Full-depth plugins add framework-specific workflow commands (examples in sibling plugins like `soc2`, `fedramp-rev5`, `pci-dss`).
+
+## Levelling up
+
+See the [Framework Plugin Guide](../../../../../docs/FRAMEWORK-PLUGIN-GUIDE.md) for the Stub → Reference → Full progression checklist.

--- a/tests/validate-contract-fixtures.sh
+++ b/tests/validate-contract-fixtures.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Kept in contract-test path filters so required checks can be triggered.
 set -eo pipefail
 
 validator="tests/validate-json-schema.cjs"


### PR DESCRIPTION
Closes #195. First AI-governance framework plugin: scaffold-generated stub from the SCF crosswalk (general-nist-100-1-ai-rmf, 158 SCF → 91 subcategories, counts verified against scf-api v2026.1). Reference-depth level-up and the AI 600-1 GenAI Profile plugin planned as follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a NIST AI RMF 1.0 framework plugin in stub form, registered in the marketplace.
  * Added a `nist-ai-rmf:assess` command for compliance gap assessment with severity-tagged, prioritized reporting.

* **Documentation**
  * Documented the plugin in the changelog and added README/usage guidance, including planned upgrade paths (reference/full) and AI RMF concepts with SCF crosswalk mapping context.

* **Tests**
  * Updated a contract-fixture validation script comment to clarify why path filtering remains active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->