### PR TITLE
ci(link-check): exclude flaky aicpa-cima.com from lychee

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -26,6 +26,9 @@ exclude = [
   # Some regulator sites return 5xx to scrapers but render fine in browsers
   "^https://www\\.ecfr\\.gov",
   "^https://pcaobus\\.org/oversight/standards/auditing-standards$",
+  # aicpa-cima.com intermittently returns 502 to lychee's client (bot protection)
+  # while returning 200 to curl and browsers; was failing link-check on unrelated PRs
+  "^https://www\\.aicpa-cima\\.com",
   # canada.ca returns HTTP/2 protocol errors to lychee's client; renders fine in browsers
   "^https://www\\.canada\\.ca",
   # Upstream external repo was transferred to hackIDLE; both URLs should be updated in a docs pass

--- a/lychee.toml
+++ b/lychee.toml
@@ -28,7 +28,7 @@ exclude = [
   "^https://pcaobus\\.org/oversight/standards/auditing-standards$",
   # aicpa-cima.com intermittently returns 502 to lychee's client (bot protection)
   # while returning 200 to curl and browsers; was failing link-check on unrelated PRs
-  "^https://www\\.aicpa-cima\\.com",
+  "^https://www\\.aicpa-cima\\.com(?:[/?#]|$)",
   # canada.ca returns HTTP/2 protocol errors to lychee's client; renders fine in browsers
   "^https://www\\.canada\\.ca",
   # Upstream external repo was transferred to hackIDLE; both URLs should be updated in a docs pass


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The AICPA SOC overview link in `plugins/frameworks/us-sox/skills/us-sox-expert/SKILL.md` intermittently returns `502 Bad Gateway` to lychee's client (bot protection) while returning `200 OK` to curl and browsers. It was failing the `link-check` workflow on unrelated PRs, most recently the lychee failure on #218. Adds `aicpa-cima.com` to the `lychee.toml` exclusion list with the same rationale as the existing `ecfr.gov` and `canada.ca` entries.

Verified the link is alive, so this is a flake exclusion, not a dead link being hidden:

```text
$ curl -sI https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc
HTTP/1.1 200 OK
```

## Type of change

- [ ] Connector
- [ ] Framework plugin
- [ ] Persona plugin
- [ ] Documentation
- [ ] Community / governance
- [x] CI / automation
- [ ] Other

## Schema impact

- [x] No schema changes
- [ ] `schemas/finding.schema.json` changed
- [ ] Another schema or contract surface changed

## Test plan

Config-only change to `lychee.toml`; the `link-check` workflow on this PR exercises it directly (the workflow triggers on `lychee.toml` changes).

## CHANGELOG

- [x] No CHANGELOG entry needed
- [ ] I added a CHANGELOG entry
- [ ] A maintainer should add the CHANGELOG entry during merge

## Notes for reviewers

Domain-level exclusion rather than URL-level, so future AICPA references (likely for a SOC 2-focused repo) do not re-introduce the flake.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fa84600-a7ad-46c4-8f11-6a4a78a44980?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fa84600-a7ad-46c4-8f11-6a4a78a44980&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded `aicpa-cima.com` from automated link checking due to intermittent validation failures.
  * Added documentation explaining the exclusion and successful access through browsers and curl.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->