### PR TITLE
style(docs): clear all 31 pre-existing markdownlint warnings

### DIFF
--- a/plugins/frameworks/cmmc/skills/cmmc-assessment-objectives/SKILL.md
+++ b/plugins/frameworks/cmmc/skills/cmmc-assessment-objectives/SKILL.md
@@ -98,7 +98,7 @@ Each lettered sub-item (`[a]`, `[b]`, ...) is **one scoreable assessment objecti
 
 ---
 
-# 320 Assessment Objectives (NIST SP 800-171A Rev 2)
+## 320 Assessment Objectives (NIST SP 800-171A Rev 2)
 
 > Text below is verbatim from NIST SP 800-171A. Each lettered sub-item is one scoreable assessment objective.
 
@@ -698,7 +698,7 @@ Each lettered sub-item (`[a]`, `[b]`, ...) is **one scoreable assessment objecti
 
 ---
 
-# Rev 2 → Rev 3 Control Crosswalk
+## Rev 2 → Rev 3 Control Crosswalk
 
 > **CMMC 2.0 is Rev 2 only.** Rev 3 (Final, May 2024) is the forward horizon. DoD has not adopted Rev 3 for CMMC. Use this section for transition planning and to understand Rev 3 finding language — not as a substitute for Rev 2 assessment evidence.
 >
@@ -900,6 +900,7 @@ Each lettered sub-item (`[a]`, `[b]`, ...) is **one scoreable assessment objecti
 ---
 
 ### 3.12 → 03.12 SECURITY ASSESSMENT AND MONITORING 🔵
+
 *(Renamed from "Security Assessment" in Rev 2.)*
 
 | Rev 2 | Rev 2 title | Rev 3 | Status | Notes |

--- a/plugins/grc-portfolio/skills/website-build/SKILL.md
+++ b/plugins/grc-portfolio/skills/website-build/SKILL.md
@@ -58,7 +58,7 @@ Copy from `$TOOLKIT_DIR/examples/vite.config.js` as-is. It's already well-config
 
 ## Step 5: Generate Components by Site Type
 
-### All Types (shared components):
+### All Types (shared components)
 
 **Navbar.jsx** -- Navigation bar with:
 - Site name/logo on the left
@@ -83,26 +83,30 @@ Copy from `$TOOLKIT_DIR/examples/vite.config.js` as-is. It's already well-config
 - Loading state, success/error feedback
 - Basic client-side validation
 
-### Portfolio/Personal Components:
+### Portfolio/Personal Components
+
 - **About.jsx** -- Professional summary, photo placeholder
 - **Skills.jsx** -- Skills organized by category in a grid
 - **Projects.jsx** -- Project cards with descriptions, tech tags, links
 - **Certifications.jsx** -- Certification badges/list
 - **Speaking.jsx** -- Talks, podcasts, articles (if data provided)
 
-### Business Landing Page Components:
+### Business Landing Page Components
+
 - **Services.jsx** -- Service cards with descriptions
 - **Testimonials.jsx** -- Testimonial cards with quotes
 - **Team.jsx** -- Team member cards
 - **Pricing.jsx** -- Pricing tier cards (if data provided)
 
-### SaaS Marketing Components:
+### SaaS Marketing Components
+
 - **Features.jsx** -- Feature grid with icons and descriptions
 - **Pricing.jsx** -- Pricing comparison table/cards
 - **Integrations.jsx** -- Integration logos/grid
 - **CTA.jsx** -- Call-to-action section with demo/signup buttons
 
-### Brochure Components:
+### Brochure Components
+
 - **About.jsx** -- Business description
 - **Services.jsx** -- Service list
 - **Hours.jsx** -- Business hours and location/map placeholder
@@ -110,6 +114,7 @@ Copy from `$TOOLKIT_DIR/examples/vite.config.js` as-is. It's already well-config
 ## Step 6: Generate Styles
 
 ### index.css
+
 CSS reset and base styles. Set CSS custom properties based on `design.colorScheme`:
 
 **navy-slate (GRC default):**
@@ -151,6 +156,7 @@ CSS reset and base styles. Set CSS custom properties based on `design.colorSchem
 If `design.colorScheme` is "custom", use `design.primaryColor` and `design.accentColor` from config and derive the rest.
 
 ### App.css
+
 Component-level styles. Use the CSS custom properties from index.css. Style should match `design.style`:
 - **professional**: Conservative layout, clean typography, authoritative feel
 - **bold-modern**: Strong colors, larger typography, prominent shadows

--- a/plugins/grc-portfolio/skills/website-preflight/SKILL.md
+++ b/plugins/grc-portfolio/skills/website-preflight/SKILL.md
@@ -83,14 +83,17 @@ Run each check and record the result as PASS or FAIL:
 Output a formatted report with three sections:
 
 ### PASS
+
 List all checks that passed with a checkmark.
 
 ### ACTION REQUIRED (Automated)
+
 Things that can be fixed automatically -- offer to run the fix:
 - Missing tools (run bootstrap.sh)
 - Template validation (fix template issues)
 
 ### ACTION REQUIRED (Human)
+
 Things the user must do manually. For each, provide:
 - **What to do** (clear instructions)
 - **AWS Console URL** (direct link where possible)

--- a/plugins/trust-center/commands/add-document.md
+++ b/plugins/trust-center/commands/add-document.md
@@ -3,11 +3,13 @@
 Add a compliance document to the trust center.
 
 ## Steps
+
 1. Ask for document name, description, category, and access level (public/gated)
 2. Update `backend/seed_data.py`
 3. If deployed, write the record to DynamoDB directly
 
 ## Usage
+
 ```
 /trust-center:add-document --name "SOC 2 Type II" --access gated --category "Audit Reports"
 ```

--- a/plugins/trust-center/commands/deploy.md
+++ b/plugins/trust-center/commands/deploy.md
@@ -3,6 +3,7 @@
 Deploy the trust center to AWS.
 
 ## Steps
+
 1. Validate AWS credentials and region
 2. Deploy the CloudFormation stack from `infrastructure/template.yaml`
 3. Package and upload the Lambda function (`backend/functions/api_handler.py`)
@@ -11,6 +12,7 @@ Deploy the trust center to AWS.
 6. Output the live CloudFront URL
 
 ## Usage
+
 ```
 /trust-center:deploy --email admin@company.com
 /trust-center:deploy --email admin@company.com --domain trust.company.com

--- a/plugins/trust-center/commands/init.md
+++ b/plugins/trust-center/commands/init.md
@@ -3,12 +3,14 @@
 Scaffold a trust center project in the current directory.
 
 ## Steps
+
 1. Ask for company name, certifications, and admin email
 2. Generate `infrastructure/template.yaml` customized to the answers
 3. Create `backend/functions/api_handler.py` and `backend/seed_data.py`
 4. Scaffold the React frontend under `frontend/`
 
 ## Usage
+
 ```
 /trust-center:init
 ```

--- a/plugins/trust-center/commands/status.md
+++ b/plugins/trust-center/commands/status.md
@@ -3,12 +3,14 @@
 Check the deployment status of the trust center.
 
 ## Steps
+
 1. Describe the CloudFormation stack and surface stack status
 2. Show the CloudFront domain and API URL from stack outputs
 3. Report Lambda function last-modified and memory config
 4. Check DynamoDB table item count
 
 ## Usage
+
 ```
 /trust-center:status
 ```

--- a/plugins/trust-center/skills/trust-center/SKILL.md
+++ b/plugins/trust-center/skills/trust-center/SKILL.md
@@ -181,6 +181,7 @@ callbacks.
 **The user must choose an e-signature provider.** Here are the tested options:
 
 ### Option 1: Documenso (Open Source — Recommended for Self-Hosting)
+
 - **Cloud**: Free tier (5 docs/month) or Individual plan ($25/month, unlimited)
 - **Self-hosted**: Free, unlimited, runs on Docker (EC2/ECS)
 - **API**: Full REST API on all plans including self-hosted
@@ -189,6 +190,7 @@ callbacks.
 - Website: https://documenso.com
 
 ### Option 2: OpenSign (Open Source — Recommended for Cloud)
+
 - **Cloud**: Professional plan ($9.99/month yearly, 240 API signatures/year)
 - **Self-hosted**: Free UI, but API requires paid Teams license ($720/year)
 - **Webhook event**: `completed`
@@ -196,6 +198,7 @@ callbacks.
 - Website: https://www.opensignlabs.com
 
 ### Option 3: DocuSeal (Open Source)
+
 - **Cloud**: Pro plan ($20/month + $0.20 per API-signed document)
 - **Self-hosted**: Free UI, but API requires Pro license ($20/month)
 - **Webhook event**: `form.completed`
@@ -203,12 +206,14 @@ callbacks.
 - Website: https://www.docuseal.com
 
 ### Option 4: DocuSign (Commercial)
+
 - **Cloud**: Developer API Starter plan ($50/month, 40 envelopes/month)
 - **Webhook event**: `envelope-completed`
 - **Setup**: Create Developer account → Get API key → Create NDA template
 - Website: https://developers.docusign.com
 
 ### Option 5: No NDA (Manual Review)
+
 - Access requests go directly to admin for review
 - Admin manually approves or denies from the dashboard
 - No e-signature integration needed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clears every pre-existing markdownlint warning so the pre-commit lint is fully green: `npx markdownlint-cli2@0.18.1` now reports **0 errors across 416 files** (previously 31 warnings across 8 files).

- **MD022** (23): blank lines added around headings in `grc-portfolio`, `trust-center`, and `cmmc` docs (auto-fix).
- **MD026** (5): trailing colons removed from the component-list headings in `grc-portfolio/skills/website-build/SKILL.md` (auto-fix).
- **MD025/MD001** (3): the two mid-document H1 "part divider" headings in `cmmc/skills/cmmc-assessment-objectives/SKILL.md` (`320 Assessment Objectives`, `Rev 2 → Rev 3 Control Crosswalk`) demoted to H2. The document's dominant section style is already H2, and this also fixes the illegal h1-to-h3 increment at the crosswalk's `Summary` subheading. No content changes.

## Type of change

- [ ] Connector
- [ ] Framework plugin
- [ ] Persona plugin
- [x] Documentation
- [ ] Community / governance
- [ ] CI / automation
- [ ] Other

## Schema impact

- [x] No schema changes
- [ ] `schemas/finding.schema.json` changed
- [ ] Another schema or contract surface changed

## Test plan

```text
$ npx markdownlint-cli2@0.18.1
Linting: 416 file(s)
Summary: 0 error(s)

$ npm run test:grc-diagrams
GRC diagram plugin skill/command surface is valid.

$ npm run test:plugin-manifests
Validated 66 manifest(s). All manifests valid.
```

## CHANGELOG

- [x] No CHANGELOG entry needed
- [ ] I added a CHANGELOG entry
- [ ] A maintainer should add the CHANGELOG entry during merge

## Notes for reviewers

Once this lands, the "note the repo currently has some pre-existing `MD022` warnings" caveat in `AGENTS.md` becomes stale. #216 already edits that same line, so the caveat removal is left to a one-word follow-up in whichever lands second, to avoid manufacturing a conflict between the two PRs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fa84600-a7ad-46c4-8f11-6a4a78a44980?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fa84600-a7ad-46c4-8f11-6a4a78a44980&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

