### PR TITLE
feat(grc-auditor): add risk-report command taught in CGE-AUD Ch 5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes follow the format from [Keep a Changelog](https://keepachang
 
 ### Added
 
+- **`grc-auditor:risk-report` command.** Drafts a ranked, evidence-cited risk report from a folder of raw evidence: reads every file as-is, clusters findings into risks, rates likelihood × impact from the evidence, and writes the report in the audience's language with a per-risk citation to the exact evidence file plus a run_id traceability block. This is the workflow taught in CGE-AUD Chapter 5.4 (Drafting a Risk Report) — the course references `/grc-auditor:risk-report`, but the plugin shipped without it, leaving `review-evidence` as the closest match. Accepts positional (`<path> <audience>`) and flag-style (`--input=`, `--audience=`) arguments, matching both forms shown in the course. The `examples/sample-evidence/` README now points at it for the Ch 5.4 exercise.
 - **NIST AI RMF framework plugin (stub).** Added `nist-ai-rmf`, the toolkit's first AI-governance framework plugin, scaffolded at Stub depth from the SCF crosswalk (`general-nist-100-1-ai-rmf`, 158 SCF controls → 91 AI RMF subcategories across GOVERN/MAP/MEASURE/MANAGE, counts verified against scf-api v2026.1), with marketplace registration. Reference-depth level-up (scope, evidence checklist, substantive SKILL) planned as a follow-up, along with a Generative AI Profile (AI 600-1) companion plugin. Closes [#195](https://github.com/GRCEngClub/claude-grc-engineering/issues/195).
 
 ### Changed

--- a/examples/sample-evidence/README.md
+++ b/examples/sample-evidence/README.md
@@ -18,8 +18,11 @@ job, as taught in Chapter 5.4:
 
    ```bash
    /plugin install grc-auditor@grc-engineering-suite
-   /grc-auditor:review-evidence examples/sample-evidence/
+   /grc-auditor:risk-report examples/sample-evidence/ leadership
    ```
+
+   (`/grc-auditor:review-evidence examples/sample-evidence/` also works if you
+   want the control-by-control review instead of the ranked report.)
 
    or simply ask Claude Code to *"review the evidence in this folder and draft
    a ranked risk report, citing the specific file and line for every finding."*

--- a/plugins/grc-auditor/commands/risk-report.md
+++ b/plugins/grc-auditor/commands/risk-report.md
@@ -1,0 +1,49 @@
+---
+description: Draft a ranked, evidence-cited risk report from a folder of raw evidence
+---
+
+# Risk Report
+
+Reads every file in an evidence folder, clusters findings into risks, rates likelihood and impact from the evidence, and drafts a prioritized risk report in the audience's language. This is the workflow taught in CGE-AUD Chapter 5.4 (Drafting a Risk Report).
+
+## Arguments
+
+- `$1` - Evidence folder or file path (required)
+- `$2` - Audience (optional: `leadership`, `ciso`, `audit-committee`, `engagement-manager`; defaults to `leadership`)
+
+Flag-style arguments are also accepted: `--input=<path>` and `--audience=<audience>` map to `$1` and `$2`.
+
+## Instructions
+
+1. Read every file in the evidence folder as-is. Evidence arrives raw (JSON, CSV, Terraform, logs) exactly as the tools produced it — do not ask for reformatting. The point is that every claim in the report traces back to an original evidence file.
+
+2. Cross-reference between files. Resource IDs, account IDs, and usernames that appear in one artifact often reappear in others; a risk supported by multiple artifacts is stronger than one supported by a single line.
+
+3. Cluster related findings into risks. A risk is not a finding — several findings across files may describe one risk (e.g. a permissive IAM policy plus CloudTrail events exercising it).
+
+4. Rate each risk likelihood × impact, grounded only in what the evidence shows. Do not inflate ratings; be prepared to defend each one from a specific file and line.
+
+5. Draft the ranked risk report for the audience. For `leadership` and `audit-committee`, use plain business language, not auditor jargon. Every risk gets:
+   - A plain-language risk statement
+   - A likelihood × impact rating with one-line justification
+   - A citation to the exact evidence file (and line or record) it came from
+   - A recommended next step
+
+6. Do not invent findings. If a configuration in the evidence is fine, do not flag it. If the evidence does not support a risk, leave it out — an empty section is better than an unsupported claim.
+
+7. Append a traceability block: a `run_id` (date-based, e.g. `2026-08-11-r1`), the plugin name and version, the draft date, and an inventory of the evidence files read. Anyone questioning a risk should be able to walk from the risk statement to the evidence file to the original system.
+
+8. Close with the reviewer's split: this is a draft. The practitioner still owns challenging the ratings, deciding what is top-five versus noise, adding business context the evidence cannot show, and presenting the briefing.
+
+## Examples
+
+```bash
+# Draft a leadership risk report from an evidence folder
+/grc-auditor:risk-report ./evidence leadership
+
+# Run against the CGE-AUD Ch 5.4 practice pack
+/grc-auditor:risk-report examples/sample-evidence/
+
+# Flag-style form
+/grc-auditor:risk-report --input=./evidence --audience=leadership
+```


### PR DESCRIPTION
## Why

CGE-AUD Chapter 5.4 (Drafting a Risk Report) teaches `/grc-auditor:risk-report` — the lesson video walks through it and two exam questions reference it — but the plugin shipped without the command. Members following the lesson hit an unknown command (surfaced by a member in the study group Slack today).

## What

- Adds `plugins/grc-auditor/commands/risk-report.md` implementing the workflow as taught: read every evidence file as-is, cross-reference between files, cluster findings into risks, rate likelihood × impact from the evidence only, draft a ranked report in the audience's language with a per-risk citation to the exact evidence file, and append a run_id traceability block.
- Accepts positional (`<path> <audience>`) and flag-style (`--input=`, `--audience=`) arguments, matching both forms shown in the course.
- Points the `examples/sample-evidence/` README (the Ch 5.4 practice pack) at the new command, keeping `review-evidence` as the noted alternative.
- CHANGELOG entry under Unreleased.

## Verification

- `npm run test:plugin-manifests` — 67 manifests valid
- `npm run test:unit` — 55/55 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `grc-auditor:risk-report` command for creating ranked risk reports from evidence folders.
  * Reports include supporting evidence citations, risk ratings, audience-specific language, and run traceability.
  * Supports both positional and flag-based arguments.

* **Documentation**
  * Added command guidance covering evidence review, cross-referencing, risk clustering, reporting requirements, and draft review.
  * Updated sample evidence instructions with a leadership-focused example and an alternative control-by-control review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->