### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ Pre-1.0. The Finding schema is versioned, and breaking changes are documented in
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=GRCEngClub%2Fclaude-grc-engineering&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#GRCEngClub/claude-grc-engineering&type=date&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=GRCEngClub/claude-grc-engineering&type=date&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=GRCEngClub/claude-grc-engineering&type=date&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=GRCEngClub/claude-grc-engineering&type=date&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=GRCEngClub/claude-grc-engineering&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=GRCEngClub/claude-grc-engineering&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=GRCEngClub/claude-grc-engineering&type=date&legend=top-left" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README was broken: the upstream host stopped rendering it because of GitHub stargazer API restrictions. This switches the chart to a mirror that uses a different data source, requires no API token, and serves both the frontend and the image from the same domain. The chart renders again for every visitor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart links and image sources in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->