### PR TITLE
Vouch @0xBahalaNa for contribution on #163

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -8,6 +8,7 @@
 # Maintainers (write/admin role) are auto-allowed and don't need to be listed.
 # Vouch a new contributor by commenting `!vouch` on their issue/PR.
 # Only @ajy0127 and @ethanolivertroy can vouch — see VOUCHED-MANAGERS.td.
+0xbahalana
 abdie-grcengineer
 ahmedhxssam
 ajy0127


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `0xbahalana` to `.github/VOUCHED.td` so they can open a PR for [#163](https://github.com/GRCEngClub/claude-grc-engineering/issues/163) (nist-800-53 `evidence-checklist`).
- Manual vouch: the Cursor cloud agent cannot post `!vouch` issue comments (GitHub App is comment-blocked), so this PR applies the same list change the vouch bot would have made.

## Context

@0xBahalaNa claimed #163 with a clear implementation plan. Ethan asked for a vouch from Slack; this is the durable equivalent of `!vouch @0xBahalaNa`.

## Test plan

- [ ] Confirm `0xbahalana` appears alphabetically in `.github/VOUCHED.td`
- [ ] After merge, a PR from @0xBahalaNa should pass the vouch check workflow

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://grc-engineering-club.slack.com/archives/C0ATC3NULTH/p1787109399210549?thread_ts=1787109399.210549&cid=C0ATC3NULTH)

<div><a href="https://cursor.com/agents/bc-aefba37e-f811-5711-b35e-b18574c69817?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aefba37e-f811-5711-b35e-b18574c69817&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a newly vouched contributor to the project’s trusted contributor list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->