### PR TITLE
test(gcp-inspector): add v1 finding fixtures (#161)

### DIFF
--- a/tests/fixtures/findings/gcp-inspector/001-bucket-uniform-access-pass.json
+++ b/tests/fixtures/findings/gcp-inspector/001-bucket-uniform-access-pass.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0.0",
+  "source": "gcp-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-gcp-0001",
+  "collected_at": "2026-09-05T15:00:00Z",
+  "resource": {
+    "type": "gcp_storage_bucket",
+    "id": "acme-prod-audit-logs",
+    "uri": "gs://acme-prod-audit-logs",
+    "region": "us-central1",
+    "account_id": "acme-prod-123456"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "DCH-01.2",
+      "status": "pass",
+      "severity": "info"
+    },
+    {
+      "control_framework": "SCF",
+      "control_id": "IAC-10",
+      "status": "pass",
+      "severity": "info"
+    },
+    {
+      "control_framework": "SCF",
+      "control_id": "CRY-05",
+      "status": "pass",
+      "severity": "info",
+      "message": "Google-managed encryption (default). For regulated workloads, consider CMEK."
+    },
+    {
+      "control_framework": "SCF",
+      "control_id": "MON-01.2",
+      "status": "pass",
+      "severity": "info"
+    }
+  ]
+}

--- a/tests/fixtures/findings/gcp-inspector/002-project-iam-primitive-owner-fail.json
+++ b/tests/fixtures/findings/gcp-inspector/002-project-iam-primitive-owner-fail.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "source": "gcp-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-gcp-0002",
+  "collected_at": "2026-09-05T15:00:00Z",
+  "resource": {
+    "type": "gcp_project_iam",
+    "id": "acme-prod-123456",
+    "uri": "//cloudresourcemanager.googleapis.com/projects/acme-prod-123456",
+    "region": null,
+    "account_id": "acme-prod-123456"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "IAC-07.2",
+      "status": "fail",
+      "severity": "high",
+      "message": "2 user account(s) hold primitive role(s): user:alice@example.com (roles/owner); user:bob@example.com (roles/editor).",
+      "remediation": {
+        "summary": "Replace primitive roles with predefined or custom roles. roles/owner and roles/editor are over-broad.",
+        "ref": "grc-engineer://generate-implementation/least_privilege/gcp",
+        "effort_hours": 1,
+        "automation": "semi_automated"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/findings/gcp-inspector/003-log-sinks-quota-inconclusive.json
+++ b/tests/fixtures/findings/gcp-inspector/003-log-sinks-quota-inconclusive.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0.0",
+  "source": "gcp-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-gcp-0003",
+  "collected_at": "2026-09-05T15:00:00Z",
+  "resource": {
+    "type": "gcp_logging",
+    "id": "logging-acme-prod-123456",
+    "account_id": "acme-prod-123456"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "MON-02",
+      "status": "inconclusive",
+      "severity": "medium",
+      "message": "Log sinks fetch failed: ERROR: (gcloud.logging.sinks.list) RESOURCE_EXHAUSTED: Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'logging.googleapis.com'."
+    }
+  ]
+}

--- a/tests/fixtures/findings/gcp-inspector/004-kms-key-rotation-fail.json
+++ b/tests/fixtures/findings/gcp-inspector/004-kms-key-rotation-fail.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "source": "gcp-inspector",
+  "source_version": "0.1.0",
+  "run_id": "fixture-gcp-0004",
+  "collected_at": "2026-09-05T15:00:00Z",
+  "resource": {
+    "type": "gcp_kms_key",
+    "id": "projects/acme-prod-123456/locations/us-central1/keyRings/prod-ring/cryptoKeys/db-encryption",
+    "uri": "projects/acme-prod-123456/locations/us-central1/keyRings/prod-ring/cryptoKeys/db-encryption",
+    "region": "us-central1",
+    "account_id": "acme-prod-123456"
+  },
+  "evaluations": [
+    {
+      "control_framework": "SCF",
+      "control_id": "CRY-09",
+      "status": "fail",
+      "severity": "medium",
+      "message": "Key db-encryption rotation period is 365d — exceeds 90d baseline.",
+      "remediation": {
+        "summary": "Shorten rotationPeriod to 7776000s (90d).",
+        "ref": "grc-engineer://generate-implementation/key_rotation/gcp",
+        "effort_hours": 0.1,
+        "automation": "auto_fixable"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #161. Adds four v1 Finding fixtures for the `gcp-inspector` connector under `tests/fixtures/findings/gcp-inspector/`, covering the status mix the connector actually produces:

| File | Resource | Evaluations |
|---|---|---|
| `001-bucket-uniform-access-pass.json` | `gcp_storage_bucket` (`gs://` uri) | DCH-01.2, IAC-10, CRY-05, MON-01.2 — all pass |
| `002-project-iam-primitive-owner-fail.json` | `gcp_project_iam` (cloudresourcemanager self-link uri) | IAC-07.2 fail, high, with remediation |
| `003-log-sinks-quota-inconclusive.json` | `gcp_logging` | MON-02 inconclusive (quota exceeded) |
| `004-kms-key-rotation-fail.json` | `gcp_kms_key` | CRY-09 fail, medium, with remediation |

Every control ID, severity, message shape, remediation `ref`, and resource `type`/`uri` is taken verbatim from `plugins/connectors/gcp-inspector/scripts/collect.js` as of `main` (post-#216), so the fixtures match real connector output rather than the issue's illustrative examples.

## Type of change

- [ ] Connector
- [ ] Framework plugin
- [ ] Persona plugin
- [ ] Documentation
- [ ] Community / governance
- [ ] CI / automation
- [x] Other — test fixtures

## Schema impact

- [x] No schema changes

## Test plan

```text
$ bun install --no-save ajv-cli@5 ajv-formats@3
$ bash tests/validate-contract-fixtures.sh
  ✓ tests/fixtures/findings/gcp-inspector/001-bucket-uniform-access-pass.json
  ✓ tests/fixtures/findings/gcp-inspector/002-project-iam-primitive-owner-fail.json
  ✓ tests/fixtures/findings/gcp-inspector/003-log-sinks-quota-inconclusive.json
  ✓ tests/fixtures/findings/gcp-inspector/004-kms-key-rotation-fail.json
All 56 fixture(s) valid.
```

Baseline on untouched `main` was `All 52 fixture(s) valid.`; the four new fixtures bring it to 56.

## CHANGELOG

- [x] No CHANGELOG entry needed

## Notes for reviewers

Two places where the connector disagrees with the issue text, and the fixtures follow the connector:

- Uniform bucket-level access is evaluated under **IAC-10** in `collect.js`; **DCH-01.2** is public-access prevention. (PR #196 used DCH-01.2 for uniform access.) Worth correcting in the issue body so the next contributor doesn't trip on it.
- Buckets emit `uri: gs://<name>`, not a `//storage.googleapis.com/...` self-link. The self-link acceptance criterion is met by fixture 002, whose `gcp_project_iam` uri (`//cloudresourcemanager.googleapis.com/projects/...`) is the form the connector actually emits.
- CodeRabbit flagged fixtures 003 and 004 for lacking canonical self-link URIs. Those fixtures
  deliberately mirror what `collect.js` emits on `main` today for `gcp_logging` and `gcp_kms_key`,
  which is no self-link. The gap is in the connector, not the fixtures; I filed #234 for it and
  will update these two fixtures once that lands.

Four fixtures rather than three so each of the connector's resource families (storage, IAM, logging, KMS) has at least one document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ujsbt7nFmR4g84j9novBHw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded GCP Inspector test coverage with scenarios for:
    - Passing bucket security evaluations, including encryption guidance.
    - Project IAM findings involving primitive owner and editor roles.
    - Inconclusive log sink evaluations caused by quota exhaustion.
    - KMS key rotation periods exceeding the recommended baseline.
  - Added representative remediation guidance, severity levels, and evaluation outcomes for these findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
